### PR TITLE
Lua linker doesn't create a scope per module

### DIFF
--- a/lib/Language/PureScript/Backend.hs
+++ b/lib/Language/PureScript/Backend.hs
@@ -71,10 +71,9 @@ compileModules outputDir foreignDir appOrModule = do
                 IR.mkModuleName modul
             AsApplication (AppEntryPoint modul ident) ->
               Lua.functionCall
-                ( Lua.varQName $
-                    Lua.ImportedName
-                      (Lua.fromModuleName $ IR.mkModuleName modul)
-                      (Lua.fromName (IR.identToName ident))
+                ( Linker.linkedVar
+                    (Lua.fromModuleName $ IR.mkModuleName modul)
+                    (Lua.fromName (IR.identToName ident))
                 )
                 []
          ]

--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -160,7 +160,7 @@ adjacencyListFromDeclarations modname bindings =
 
 expDependencies :: ModuleName -> Exp -> [QName]
 expDependencies thisModule Exp {expInfo = Info {refsFree}} =
-  refsFree >>= \case
+  toList refsFree >>= \case
     Local name -> [(thisModule, name)]
     Imported fromModule name -> [(fromModule, name)]
 

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -10,9 +10,9 @@ import Language.PureScript.Backend.IR.Types
   , Literal (Boolean)
   , Module (moduleBindings, moduleImports)
   , ModuleName (..)
-  , Qualified (Imported)
   , everywhereTopDownExp
   , listGrouping
+  , qualified
   )
 
 optimizeAll :: DCE.Strategy -> [Module] -> [Module]
@@ -40,10 +40,7 @@ groupingsExprs groupings = [e | g <- groupings, (_name, e) <- listGrouping g]
 
 collectImportedModules :: Exp -> Set ModuleName
 collectImportedModules Exp {expInfo = Info {refsFree}} =
-  Set.fromList $
-    refsFree >>= \case
-      Imported modname _ -> [modname]
-      _ -> []
+  foldMap (qualified mempty \m _ -> Set.singleton m) refsFree
 
 optimizeDecls :: [Grouping (name, Exp)] -> [Grouping (name, Exp)]
 optimizeDecls = (fmap . fmap . fmap) optimizeExpression

--- a/lib/Language/PureScript/Backend/IR/Query.hs
+++ b/lib/Language/PureScript/Backend/IR/Query.hs
@@ -1,5 +1,6 @@
 module Language.PureScript.Backend.IR.Query where
 
+import Data.Set qualified as Set
 import Language.PureScript.Backend.IR.Types
   ( Exp (..)
   , Info (..)
@@ -16,7 +17,7 @@ usesRuntimeLazy Module {moduleBindings = bs} =
   getAny $ foldMap (foldMap (Any . findRuntimeLazyInExpr) . bindingExprs) bs
  where
   findRuntimeLazyInExpr Exp {expInfo = Info {refsFree}} =
-    Local (Name "$__runtime_lazy") `elem` refsFree
+    Local (Name "$__runtime_lazy") `Set.member` refsFree
 
 usesPrimModule :: Module -> Bool
 usesPrimModule Module {moduleBindings = bs} =

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -4,6 +4,7 @@ module Language.PureScript.Backend.IR.Types where
 
 import Data.Deriving (deriveEq1, deriveOrd1, deriveShow1)
 import Data.List (elemIndex)
+import Data.Set qualified as Set
 import Data.Tagged (Tagged (..), untag)
 import Data.Text qualified as Text
 import Data.Traversable (for)
@@ -39,7 +40,7 @@ bindingNames = fmap fst . listGrouping
 bindingExprs :: Grouping (name, Exp) -> [Exp]
 bindingExprs = fmap snd . listGrouping
 
-newtype Info = Info {refsFree :: [Qualified Name]}
+newtype Info = Info {refsFree :: Set (Qualified Name)}
   deriving stock (Generic)
   deriving (Semigroup, Monoid) via Generically Info
 
@@ -327,7 +328,7 @@ wrapExpF e = Exp e case e of
   ObjectProp a _prop -> expInfo a
   ObjectUpdate a patches -> expInfo a <> foldMap (expInfo . snd) patches
   App f x -> expInfo f <> expInfo x
-  RefFree ref -> mempty {refsFree = pure ref}
+  RefFree ref -> mempty {refsFree = Set.singleton ref}
   RefBound _index -> mempty
   Abs (AbsBinding _arg (LocallyNameless expr)) -> expInfo expr
   Let (LetBinding binds (LocallyNameless body)) ->

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -12,6 +12,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as Text
 import Data.Traversable (for)
 import Language.PureScript.Backend.IR.Types qualified as IR
+import Language.PureScript.Backend.Lua.Linker qualified as Linker
 import Language.PureScript.Backend.Lua.Name (Name)
 import Language.PureScript.Backend.Lua.Name qualified as Name
 import Language.PureScript.Backend.Lua.Optimizer (optimizeChunk)
@@ -110,9 +111,7 @@ fromExp modname origExp = go origExp
         pure case qualifiedName of
           IR.Local name -> varName (fromName name)
           IR.Imported modname' name ->
-            varField
-              (varName (unModuleName (fromModuleName modname')))
-              (fromName name)
+            Linker.linkedVar (fromModuleName modname') (fromName name)
       IR.RefBound index -> throwError $ UnexpectedRefBound origExp index
       IR.Let binding -> do
         (bindings, bodyExp) <- IR.unbindLet binding

--- a/lib/Language/PureScript/Backend/Lua/Linker.hs
+++ b/lib/Language/PureScript/Backend/Lua/Linker.hs
@@ -2,20 +2,19 @@
 
 module Language.PureScript.Backend.Lua.Linker where
 
-import Control.Monad.Oops
-  ( CouldBe
-  , Variant
-  )
-
+import Control.Monad.Oops (CouldBe, Variant)
 import Control.Monad.Oops qualified as Oops
 import Data.Graph (graphFromEdges', reverseTopSort)
+import Data.Set qualified as Set
 import Data.Tagged (Tagged (..))
 import Data.Traversable (for)
 import Language.PureScript.Backend.Lua.Linker.Foreign qualified as Foreign
 import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Name qualified as LuaName
+import Language.PureScript.Backend.Lua.Name qualified as Name
+import Language.PureScript.Backend.Lua.Traversal (everywhereStat)
 import Language.PureScript.Backend.Lua.Types qualified as Lua
 import Path (Abs, Dir, Path, toFilePath)
-import Prelude hiding (show)
 
 newtype Error = LinkerErrorForeign Foreign.Error
   deriving newtype (Show)
@@ -26,7 +25,7 @@ linkModules
   -> [Lua.Module]
   -> ExceptT (Variant e) IO Lua.Chunk
 linkModules (Tagged foreigns) luaModules =
-  for (topoSorted luaModules) \Lua.Module {..} -> do
+  join <$> for (topoSorted luaModules) \Lua.Module {..} -> do
     foreignCode <-
       case moduleForeigns of
         [] -> pure []
@@ -39,15 +38,51 @@ linkModules (Tagged foreigns) luaModules =
 
     let fname = [Lua.name|foreign|]
 
-    pure . Lua.local1 (Lua.unModuleName moduleName) . Lua.thunks . mconcat $
-      [ [ Lua.local1 fname (Lua.thunks foreignCode)
-        | not (null foreignCode)
-        ]
+    pure . mconcat $
+      [ [Lua.local1 fname (Lua.thunks foreignCode) | not (null foreignCode)]
       , moduleForeigns <&> \name ->
           Lua.local1 name (Lua.varField (Lua.varName fname) name)
-      , moduleChunk
-      , [Lua.Return $ Lua.table $ Lua.pun <$> moduleExports]
+      , qualifyLocalNames moduleName moduleChunk
       ]
+
+qualifyLocalNames :: Lua.ModuleName -> Lua.Chunk -> Lua.Chunk
+qualifyLocalNames thisModule statements =
+  everywhereStat updateStat updateExpr <$> statements
+ where
+  topLocalNames :: Set Lua.Name = Set.fromList do
+    toList statements & foldMap \case
+      Lua.Local names _es -> toList names
+      Lua.Assign vars _es -> [n | Lua.VarName (Lua.LocalName n) <- toList vars]
+      _ -> []
+
+  qualifyIfTopName name =
+    if Set.member name topLocalNames
+      then LuaName.join2 (Lua.unModuleName thisModule) name
+      else name
+
+  qualifyVar = \case
+    Lua.VarName qname -> Lua.VarName case qname of
+      Lua.ImportedName moduleName name ->
+        Lua.LocalName (LuaName.join2 (Lua.unModuleName moduleName) name)
+      Lua.LocalName name -> Lua.LocalName (qualifyIfTopName name)
+    Lua.VarIndex e1 e2 -> Lua.VarIndex e1 e2
+    Lua.VarField expr name -> Lua.VarField expr (qualifyIfTopName name)
+
+  updateStat :: Lua.Statement -> Lua.Statement
+  updateStat = \case
+    Lua.Assign vars exprs -> Lua.Assign (qualifyVar <$> vars) exprs
+    Lua.Local names exprs -> Lua.Local (qualifyIfTopName <$> names) exprs
+    stat -> stat
+
+  updateExpr :: Lua.Exp -> Lua.Exp
+  updateExpr = \case
+    Lua.Var var -> Lua.Var (qualifyVar var)
+    Lua.Function args body -> Lua.Function (qualifyIfTopName <$> args) body
+    expr -> expr
+
+linkedVar :: Lua.ModuleName -> Lua.Name -> Lua.Exp
+linkedVar modname name =
+  Lua.varName (Name.join2 (Lua.unModuleName modname) name)
 
 topoSorted :: [Lua.Module] -> [Lua.Module]
 topoSorted modules =

--- a/lib/Language/PureScript/Backend/Lua/Traversal.hs
+++ b/lib/Language/PureScript/Backend/Lua/Traversal.hs
@@ -34,7 +34,7 @@ everywhereExpM f g = goe
       f $ TableCtor tableRows
     UnOp op e -> f . UnOp op =<< goe e
     BinOp op e1 e2 -> f =<< BinOp op <$> goe e1 <*> goe e2
-    FunctionCall name args -> f . FunctionCall name =<< traverse goe args
+    FunctionCall fn args -> f =<< FunctionCall <$> goe fn <*> traverse goe args
     other -> f other
 
 everywhereStatM

--- a/nix/hix.nix
+++ b/nix/hix.nix
@@ -25,7 +25,11 @@
         version = "latest";
       };
     };
-    buildInputs =
-      [ pkgs.purescript pkgs.lua53Packages.lua pkgs.lua53Packages.luacheck ];
+    buildInputs = with pkgs; [
+      lua53Packages.lua
+      lua53Packages.luacheck
+      purescript
+      spago
+    ];
   };
 }

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -163,6 +163,7 @@ test-suite spec
   ghc-options:    -threaded -rtsopts -fprof-auto -with-rtsopts=-N
   build-depends:
     , call-stack                      ^>=0.4.0
+    , exceptions                      ^>=0.10.7
     , hedgehog                        ^>=1.2
     , hedgehog-corpus                 ^>=0.2
     , hspec                           ^>=2.10.10

--- a/test/ps/.gitignore
+++ b/test/ps/.gitignore
@@ -3,7 +3,7 @@
 /.pulp-cache/
 /output/*/*.cbor
 /output/*/*.json
-!/output/*/corefn.json
+!/output/Golden*/corefn.json
 /output/*/*.js
 /output/*/actual.*
 /output/*.json

--- a/test/ps/golden/Golden/TestHelloPrelude.purs
+++ b/test/ps/golden/Golden/TestHelloPrelude.purs
@@ -1,0 +1,7 @@
+module Golden.TestHelloPrelude where
+
+import Prelude
+import Effect (Effect)
+
+main :: Effect Unit
+main = pass

--- a/test/ps/output/Golden.Reexport.Exports/golden.ir
+++ b/test/ps/output/Golden.Reexport.Exports/golden.ir
@@ -5,7 +5,7 @@
          (Name "binding1",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}})],
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "binding1"],
     moduleReExports = fromList [],

--- a/test/ps/output/Golden.Reexport.Exports/golden.lua
+++ b/test/ps/output/Golden.Reexport.Exports/golden.lua
@@ -1,4 +1,1 @@
-local Golden_Reexport_Exports = (function()
-  local binding1 = 1
-  return { binding1 = binding1 }
-end)()
+local Golden_Reexport_Exports_I_binding1 = 1

--- a/test/ps/output/Golden.Reexport.ReExports/golden.ir
+++ b/test/ps/output/Golden.Reexport.ReExports/golden.ir
@@ -5,7 +5,7 @@
          (Name "binding2",
           Exp
             {unExp = Lit (Integer 2),
-             expInfo = Info {refsFree = []}})],
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "binding2"],
     moduleReExports =

--- a/test/ps/output/Golden.Reexport.ReExports/golden.lua
+++ b/test/ps/output/Golden.Reexport.ReExports/golden.lua
@@ -1,4 +1,1 @@
-local Golden_Reexport_ReExports = (function()
-  local binding2 = 2
-  return { binding2 = binding2 }
-end)()
+local Golden_Reexport_ReExports_I_binding2 = 2

--- a/test/ps/output/Golden.TestCaseStatements/golden.ir
+++ b/test/ps/output/Golden.TestCaseStatements/golden.ir
@@ -10,17 +10,17 @@
                  (TyName "M")
                  (CtorName "J")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "N",
           Exp
             {unExp = Ctor SumType (TyName "M") (CtorName "N") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "multipleGuards",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "d",
           Exp
@@ -64,7 +64,8 @@
                                                                                           expInfo =
                                                                                             Info
                                                                                               {refsFree =
-                                                                                                 []}})
+                                                                                                 fromList
+                                                                                                   []}})
                                                                                       (Exp
                                                                                          {unExp =
                                                                                             RefBound
@@ -76,11 +77,13 @@
                                                                                           expInfo =
                                                                                             Info
                                                                                               {refsFree =
-                                                                                                 []}})),
+                                                                                                 fromList
+                                                                                                   []}})),
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      []}})
+                                                                                      fromList
+                                                                                        []}})
                                                                            (Exp
                                                                               {unExp =
                                                                                  Lit
@@ -89,7 +92,8 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      []}})
+                                                                                      fromList
+                                                                                        []}})
                                                                            (Exp
                                                                               {unExp =
                                                                                  Lit
@@ -98,15 +102,18 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      []}}),
+                                                                                      fromList
+                                                                                        []}}),
                                                                        expInfo =
                                                                          Info
                                                                            {refsFree =
-                                                                              []}})),
+                                                                              fromList
+                                                                                []}})),
                                                             expInfo =
                                                               Info
                                                                 {refsFree =
-                                                                   []}})
+                                                                   fromList
+                                                                     []}})
                                                         :|
                                                         [])
                                                      (Exp
@@ -124,7 +131,8 @@
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   []}})
+                                                                                   fromList
+                                                                                     []}})
                                                                         (Exp
                                                                            {unExp =
                                                                               RefBound
@@ -136,11 +144,13 @@
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   []}})),
+                                                                                   fromList
+                                                                                     []}})),
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        []}})
+                                                                        fromList
+                                                                          []}})
                                                              (Exp
                                                                 {unExp =
                                                                    IfThenElse
@@ -156,7 +166,8 @@
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           []}})
+                                                                                           fromList
+                                                                                             []}})
                                                                                 (Exp
                                                                                    {unExp =
                                                                                       Prim
@@ -172,15 +183,18 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      []}})),
+                                                                                                      fromList
+                                                                                                        []}})),
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           []}})),
+                                                                                           fromList
+                                                                                             []}})),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            Let
@@ -202,12 +216,14 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      []}})
+                                                                                                      fromList
+                                                                                                        []}})
                                                                                            0,
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              []}})
+                                                                                              fromList
+                                                                                                []}})
                                                                                    :|
                                                                                    [])
                                                                                 (Exp
@@ -225,7 +241,8 @@
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              []}})
+                                                                                                              fromList
+                                                                                                                []}})
                                                                                                    (Exp
                                                                                                       {unExp =
                                                                                                          Prim
@@ -241,15 +258,18 @@
                                                                                                                   expInfo =
                                                                                                                     Info
                                                                                                                       {refsFree =
-                                                                                                                         []}})),
+                                                                                                                         fromList
+                                                                                                                           []}})),
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              []}})),
+                                                                                                              fromList
+                                                                                                                []}})),
                                                                                             expInfo =
                                                                                               Info
                                                                                                 {refsFree =
-                                                                                                   []}})
+                                                                                                   fromList
+                                                                                                     []}})
                                                                                         (Exp
                                                                                            {unExp =
                                                                                               RefBound
@@ -261,7 +281,8 @@
                                                                                             expInfo =
                                                                                               Info
                                                                                                 {refsFree =
-                                                                                                   []}})
+                                                                                                   fromList
+                                                                                                     []}})
                                                                                         (Exp
                                                                                            {unExp =
                                                                                               App
@@ -276,7 +297,8 @@
                                                                                                     expInfo =
                                                                                                       Info
                                                                                                         {refsFree =
-                                                                                                           []}})
+                                                                                                           fromList
+                                                                                                             []}})
                                                                                                 (Exp
                                                                                                    {unExp =
                                                                                                       Lit
@@ -285,19 +307,23 @@
                                                                                                     expInfo =
                                                                                                       Info
                                                                                                         {refsFree =
-                                                                                                           []}}),
+                                                                                                           fromList
+                                                                                                             []}}),
                                                                                             expInfo =
                                                                                               Info
                                                                                                 {refsFree =
-                                                                                                   []}}),
+                                                                                                   fromList
+                                                                                                     []}}),
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           []}})),
+                                                                                           fromList
+                                                                                             []}})),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            App
@@ -312,7 +338,8 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}})
+                                                                                        fromList
+                                                                                          []}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    Lit
@@ -321,15 +348,18 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}}),
+                                                                                        fromList
+                                                                                          []}}),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}}),
+                                                                                fromList
+                                                                                  []}}),
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        []}})
+                                                                        fromList
+                                                                          []}})
                                                              (Exp
                                                                 {unExp =
                                                                    App
@@ -344,7 +374,8 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            Lit
@@ -353,28 +384,33 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}}),
+                                                                                fromList
+                                                                                  []}}),
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        []}}),
+                                                                        fromList
+                                                                          []}}),
                                                          expInfo =
                                                            Info
-                                                             {refsFree = []}})),
-                                              expInfo = Info {refsFree = []}})),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                                             {refsFree =
+                                                                fromList []}})),
+                                              expInfo =
+                                                Info
+                                                  {refsFree = fromList []}})),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "b",
           Exp
             {unExp = Lit (Char 'b'),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "a",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "c",
           Exp
@@ -400,7 +436,8 @@
                                                            Lit (Integer 2),
                                                          expInfo =
                                                            Info
-                                                             {refsFree = []}})
+                                                             {refsFree =
+                                                                fromList []}})
                                                      (Exp
                                                         {unExp =
                                                            RefFree
@@ -408,13 +445,15 @@
                                                          expInfo =
                                                            Info
                                                              {refsFree =
-                                                                [Local
-                                                                   (Name
-                                                                      "a")]}})),
+                                                                fromList
+                                                                  [Local
+                                                                     (Name
+                                                                        "a")]}})),
                                               expInfo =
                                                 Info
                                                   {refsFree =
-                                                     [Local (Name "a")]}})
+                                                     fromList
+                                                       [Local (Name "a")]}})
                                           (Exp
                                              {unExp =
                                                 IfThenElse
@@ -432,29 +471,34 @@
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f")]}})
+                                                                     fromList
+                                                                       [Imported
+                                                                          (ModuleName
+                                                                             "Golden.TestValues")
+                                                                          (Name
+                                                                             "f")]}})
                                                           (Exp
                                                              {unExp =
                                                                 Lit (Integer 0),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}}),
+                                                                     fromList
+                                                                       []}}),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f")]}})
+                                                             fromList
+                                                               [Imported
+                                                                  (ModuleName
+                                                                     "Golden.TestValues")
+                                                                  (Name "f")]}})
                                                   (Exp
                                                      {unExp = Lit (Integer 10),
                                                       expInfo =
-                                                        Info {refsFree = []}})
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})
                                                   (Exp
                                                      {unExp =
                                                         IfThenElse
@@ -470,7 +514,8 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            RefFree
@@ -480,15 +525,17 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Local
-                                                                                   (Name
-                                                                                      "a")]}})),
+                                                                                fromList
+                                                                                  [Local
+                                                                                     (Name
+                                                                                        "a")]}})),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Local
-                                                                        (Name
-                                                                           "a")]}})
+                                                                     fromList
+                                                                       [Local
+                                                                          (Name
+                                                                             "a")]}})
                                                           (Exp
                                                              {unExp =
                                                                 Let
@@ -511,7 +558,8 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      []}})
+                                                                                                      fromList
+                                                                                                        []}})
                                                                                            (Exp
                                                                                               {unExp =
                                                                                                  RefFree
@@ -521,15 +569,17 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      [Local
-                                                                                                         (Name
-                                                                                                            "a")]}})),
+                                                                                                      fromList
+                                                                                                        [Local
+                                                                                                           (Name
+                                                                                                              "a")]}})),
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           [Local
-                                                                                              (Name
-                                                                                                 "a")]}})
+                                                                                           fromList
+                                                                                             [Local
+                                                                                                (Name
+                                                                                                   "a")]}})
                                                                                 (Exp
                                                                                    {unExp =
                                                                                       Let
@@ -545,7 +595,8 @@
                                                                                                   expInfo =
                                                                                                     Info
                                                                                                       {refsFree =
-                                                                                                         []}})
+                                                                                                         fromList
+                                                                                                           []}})
                                                                                               :|
                                                                                               [Standalone
                                                                                                  (Name
@@ -559,9 +610,10 @@
                                                                                                      expInfo =
                                                                                                        Info
                                                                                                          {refsFree =
-                                                                                                            [Local
-                                                                                                               (Name
-                                                                                                                  "a")]}}),
+                                                                                                            fromList
+                                                                                                              [Local
+                                                                                                                 (Name
+                                                                                                                    "a")]}}),
                                                                                                Standalone
                                                                                                  (Name
                                                                                                     "z",
@@ -574,9 +626,10 @@
                                                                                                      expInfo =
                                                                                                        Info
                                                                                                          {refsFree =
-                                                                                                            [Local
-                                                                                                               (Name
-                                                                                                                  "a")]}})])
+                                                                                                            fromList
+                                                                                                              [Local
+                                                                                                                 (Name
+                                                                                                                    "a")]}})])
                                                                                            (Exp
                                                                                               {unExp =
                                                                                                  IfThenElse
@@ -594,11 +647,12 @@
                                                                                                                expInfo =
                                                                                                                  Info
                                                                                                                    {refsFree =
-                                                                                                                      [Imported
-                                                                                                                         (ModuleName
-                                                                                                                            "Golden.TestValues")
-                                                                                                                         (Name
-                                                                                                                            "f")]}})
+                                                                                                                      fromList
+                                                                                                                        [Imported
+                                                                                                                           (ModuleName
+                                                                                                                              "Golden.TestValues")
+                                                                                                                           (Name
+                                                                                                                              "f")]}})
                                                                                                            (Exp
                                                                                                               {unExp =
                                                                                                                  RefBound
@@ -610,15 +664,17 @@
                                                                                                                expInfo =
                                                                                                                  Info
                                                                                                                    {refsFree =
-                                                                                                                      []}}),
+                                                                                                                      fromList
+                                                                                                                        []}}),
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              [Imported
-                                                                                                                 (ModuleName
-                                                                                                                    "Golden.TestValues")
-                                                                                                                 (Name
-                                                                                                                    "f")]}})
+                                                                                                              fromList
+                                                                                                                [Imported
+                                                                                                                   (ModuleName
+                                                                                                                      "Golden.TestValues")
+                                                                                                                   (Name
+                                                                                                                      "f")]}})
                                                                                                    (Exp
                                                                                                       {unExp =
                                                                                                          RefBound
@@ -630,7 +686,8 @@
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              []}})
+                                                                                                              fromList
+                                                                                                                []}})
                                                                                                    (Exp
                                                                                                       {unExp =
                                                                                                          RefBound
@@ -642,29 +699,29 @@
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              []}}),
+                                                                                                              fromList
+                                                                                                                []}}),
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      [Imported
-                                                                                                         (ModuleName
-                                                                                                            "Golden.TestValues")
-                                                                                                         (Name
-                                                                                                            "f")]}})),
+                                                                                                      fromList
+                                                                                                        [Imported
+                                                                                                           (ModuleName
+                                                                                                              "Golden.TestValues")
+                                                                                                           (Name
+                                                                                                              "f")]}})),
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           [Local
-                                                                                              (Name
-                                                                                                 "a"),
-                                                                                            Local
-                                                                                              (Name
-                                                                                                 "a"),
-                                                                                            Imported
-                                                                                              (ModuleName
-                                                                                                 "Golden.TestValues")
-                                                                                              (Name
-                                                                                                 "f")]}})
+                                                                                           fromList
+                                                                                             [Local
+                                                                                                (Name
+                                                                                                   "a"),
+                                                                                              Imported
+                                                                                                (ModuleName
+                                                                                                   "Golden.TestValues")
+                                                                                                (Name
+                                                                                                   "f")]}})
                                                                                 (Exp
                                                                                    {unExp =
                                                                                       Lit
@@ -673,24 +730,20 @@
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           []}}),
+                                                                                           fromList
+                                                                                             []}}),
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   [Local
-                                                                                      (Name
-                                                                                         "a"),
-                                                                                    Local
-                                                                                      (Name
-                                                                                         "a"),
-                                                                                    Local
-                                                                                      (Name
-                                                                                         "a"),
-                                                                                    Imported
-                                                                                      (ModuleName
-                                                                                         "Golden.TestValues")
-                                                                                      (Name
-                                                                                         "f")]}})
+                                                                                   fromList
+                                                                                     [Local
+                                                                                        (Name
+                                                                                           "a"),
+                                                                                      Imported
+                                                                                        (ModuleName
+                                                                                           "Golden.TestValues")
+                                                                                        (Name
+                                                                                           "f")]}})
                                                                         :|
                                                                         [Standalone
                                                                            (Name
@@ -704,9 +757,10 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      [Local
-                                                                                         (Name
-                                                                                            "a")]}}),
+                                                                                      fromList
+                                                                                        [Local
+                                                                                           (Name
+                                                                                              "a")]}}),
                                                                          Standalone
                                                                            (Name
                                                                               "z",
@@ -719,9 +773,10 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      [Local
-                                                                                         (Name
-                                                                                            "a")]}})])
+                                                                                      fromList
+                                                                                        [Local
+                                                                                           (Name
+                                                                                              "a")]}})])
                                                                      (Exp
                                                                         {unExp =
                                                                            IfThenElse
@@ -739,11 +794,12 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                [Imported
-                                                                                                   (ModuleName
-                                                                                                      "Golden.TestValues")
-                                                                                                   (Name
-                                                                                                      "f")]}})
+                                                                                                fromList
+                                                                                                  [Imported
+                                                                                                     (ModuleName
+                                                                                                        "Golden.TestValues")
+                                                                                                     (Name
+                                                                                                        "f")]}})
                                                                                      (Exp
                                                                                         {unExp =
                                                                                            RefBound
@@ -755,15 +811,17 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}}),
+                                                                                                fromList
+                                                                                                  []}}),
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Imported
-                                                                                           (ModuleName
-                                                                                              "Golden.TestValues")
-                                                                                           (Name
-                                                                                              "f")]}})
+                                                                                        fromList
+                                                                                          [Imported
+                                                                                             (ModuleName
+                                                                                                "Golden.TestValues")
+                                                                                             (Name
+                                                                                                "f")]}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefBound
@@ -775,7 +833,8 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}})
+                                                                                        fromList
+                                                                                          []}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefBound
@@ -787,43 +846,29 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}}),
+                                                                                        fromList
+                                                                                          []}}),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Imported
-                                                                                   (ModuleName
-                                                                                      "Golden.TestValues")
-                                                                                   (Name
-                                                                                      "f")]}})),
+                                                                                fromList
+                                                                                  [Imported
+                                                                                     (ModuleName
+                                                                                        "Golden.TestValues")
+                                                                                     (Name
+                                                                                        "f")]}})),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f")]}})
+                                                                     fromList
+                                                                       [Local
+                                                                          (Name
+                                                                             "a"),
+                                                                        Imported
+                                                                          (ModuleName
+                                                                             "Golden.TestValues")
+                                                                          (Name
+                                                                             "f")]}})
                                                           (Exp
                                                              {unExp =
                                                                 IfThenElse
@@ -839,7 +884,8 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}})
+                                                                                        fromList
+                                                                                          []}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefFree
@@ -849,15 +895,17 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Local
-                                                                                           (Name
-                                                                                              "a")]}})),
+                                                                                        fromList
+                                                                                          [Local
+                                                                                             (Name
+                                                                                                "a")]}})),
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             [Local
-                                                                                (Name
-                                                                                   "a")]}})
+                                                                             fromList
+                                                                               [Local
+                                                                                  (Name
+                                                                                     "a")]}})
                                                                   (Exp
                                                                      {unExp =
                                                                         Let
@@ -873,7 +921,8 @@
                                                                                     expInfo =
                                                                                       Info
                                                                                         {refsFree =
-                                                                                           []}})
+                                                                                           fromList
+                                                                                             []}})
                                                                                 :|
                                                                                 [Standalone
                                                                                    (Name
@@ -887,9 +936,10 @@
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              [Local
-                                                                                                 (Name
-                                                                                                    "a")]}}),
+                                                                                              fromList
+                                                                                                [Local
+                                                                                                   (Name
+                                                                                                      "a")]}}),
                                                                                  Standalone
                                                                                    (Name
                                                                                       "z",
@@ -902,9 +952,10 @@
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              [Local
-                                                                                                 (Name
-                                                                                                    "a")]}})])
+                                                                                              fromList
+                                                                                                [Local
+                                                                                                   (Name
+                                                                                                      "a")]}})])
                                                                              (Exp
                                                                                 {unExp =
                                                                                    IfThenElse
@@ -922,11 +973,12 @@
                                                                                                  expInfo =
                                                                                                    Info
                                                                                                      {refsFree =
-                                                                                                        [Imported
-                                                                                                           (ModuleName
-                                                                                                              "Golden.TestValues")
-                                                                                                           (Name
-                                                                                                              "f")]}})
+                                                                                                        fromList
+                                                                                                          [Imported
+                                                                                                             (ModuleName
+                                                                                                                "Golden.TestValues")
+                                                                                                             (Name
+                                                                                                                "f")]}})
                                                                                              (Exp
                                                                                                 {unExp =
                                                                                                    RefBound
@@ -938,15 +990,17 @@
                                                                                                  expInfo =
                                                                                                    Info
                                                                                                      {refsFree =
-                                                                                                        []}}),
+                                                                                                        fromList
+                                                                                                          []}}),
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                [Imported
-                                                                                                   (ModuleName
-                                                                                                      "Golden.TestValues")
-                                                                                                   (Name
-                                                                                                      "f")]}})
+                                                                                                fromList
+                                                                                                  [Imported
+                                                                                                     (ModuleName
+                                                                                                        "Golden.TestValues")
+                                                                                                     (Name
+                                                                                                        "f")]}})
                                                                                      (Exp
                                                                                         {unExp =
                                                                                            RefBound
@@ -958,7 +1012,8 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}})
+                                                                                                fromList
+                                                                                                  []}})
                                                                                      (Exp
                                                                                         {unExp =
                                                                                            RefBound
@@ -970,29 +1025,29 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}}),
+                                                                                                fromList
+                                                                                                  []}}),
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Imported
-                                                                                           (ModuleName
-                                                                                              "Golden.TestValues")
-                                                                                           (Name
-                                                                                              "f")]}})),
+                                                                                        fromList
+                                                                                          [Imported
+                                                                                             (ModuleName
+                                                                                                "Golden.TestValues")
+                                                                                             (Name
+                                                                                                "f")]}})),
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             [Local
-                                                                                (Name
-                                                                                   "a"),
-                                                                              Local
-                                                                                (Name
-                                                                                   "a"),
-                                                                              Imported
-                                                                                (ModuleName
-                                                                                   "Golden.TestValues")
-                                                                                (Name
-                                                                                   "f")]}})
+                                                                             fromList
+                                                                               [Local
+                                                                                  (Name
+                                                                                     "a"),
+                                                                                Imported
+                                                                                  (ModuleName
+                                                                                     "Golden.TestValues")
+                                                                                  (Name
+                                                                                     "f")]}})
                                                                   (Exp
                                                                      {unExp =
                                                                         Lit
@@ -1001,76 +1056,40 @@
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}}),
+                                                                             fromList
+                                                                               []}}),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f")]}}),
+                                                                     fromList
+                                                                       [Local
+                                                                          (Name
+                                                                             "a"),
+                                                                        Imported
+                                                                          (ModuleName
+                                                                             "Golden.TestValues")
+                                                                          (Name
+                                                                             "f")]}}),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f")]}}),
+                                                             fromList
+                                                               [Local
+                                                                  (Name "a"),
+                                                                Imported
+                                                                  (ModuleName
+                                                                     "Golden.TestValues")
+                                                                  (Name
+                                                                     "f")]}}),
                                               expInfo =
                                                 Info
                                                   {refsFree =
-                                                     [Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f")]}})
+                                                     fromList
+                                                       [Local (Name "a"),
+                                                        Imported
+                                                          (ModuleName
+                                                             "Golden.TestValues")
+                                                          (Name "f")]}})
                                           (Exp
                                              {unExp =
                                                 IfThenElse
@@ -1086,7 +1105,8 @@
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        []}})
+                                                                        fromList
+                                                                          []}})
                                                              (Exp
                                                                 {unExp =
                                                                    RefFree
@@ -1096,14 +1116,16 @@
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        [Local
-                                                                           (Name
-                                                                              "a")]}})),
+                                                                        fromList
+                                                                          [Local
+                                                                             (Name
+                                                                                "a")]}})),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Local
-                                                                (Name "a")]}})
+                                                             fromList
+                                                               [Local
+                                                                  (Name "a")]}})
                                                   (Exp
                                                      {unExp =
                                                         Let
@@ -1125,7 +1147,8 @@
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              []}})
+                                                                                              fromList
+                                                                                                []}})
                                                                                    (Exp
                                                                                       {unExp =
                                                                                          RefFree
@@ -1135,15 +1158,17 @@
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              [Local
-                                                                                                 (Name
-                                                                                                    "a")]}})),
+                                                                                              fromList
+                                                                                                [Local
+                                                                                                   (Name
+                                                                                                      "a")]}})),
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   [Local
-                                                                                      (Name
-                                                                                         "a")]}})
+                                                                                   fromList
+                                                                                     [Local
+                                                                                        (Name
+                                                                                           "a")]}})
                                                                         (Exp
                                                                            {unExp =
                                                                               Let
@@ -1159,7 +1184,8 @@
                                                                                           expInfo =
                                                                                             Info
                                                                                               {refsFree =
-                                                                                                 []}})
+                                                                                                 fromList
+                                                                                                   []}})
                                                                                       :|
                                                                                       [Standalone
                                                                                          (Name
@@ -1173,9 +1199,10 @@
                                                                                              expInfo =
                                                                                                Info
                                                                                                  {refsFree =
-                                                                                                    [Local
-                                                                                                       (Name
-                                                                                                          "a")]}}),
+                                                                                                    fromList
+                                                                                                      [Local
+                                                                                                         (Name
+                                                                                                            "a")]}}),
                                                                                        Standalone
                                                                                          (Name
                                                                                             "z",
@@ -1188,9 +1215,10 @@
                                                                                              expInfo =
                                                                                                Info
                                                                                                  {refsFree =
-                                                                                                    [Local
-                                                                                                       (Name
-                                                                                                          "a")]}})])
+                                                                                                    fromList
+                                                                                                      [Local
+                                                                                                         (Name
+                                                                                                            "a")]}})])
                                                                                    (Exp
                                                                                       {unExp =
                                                                                          IfThenElse
@@ -1208,11 +1236,12 @@
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              [Imported
-                                                                                                                 (ModuleName
-                                                                                                                    "Golden.TestValues")
-                                                                                                                 (Name
-                                                                                                                    "f")]}})
+                                                                                                              fromList
+                                                                                                                [Imported
+                                                                                                                   (ModuleName
+                                                                                                                      "Golden.TestValues")
+                                                                                                                   (Name
+                                                                                                                      "f")]}})
                                                                                                    (Exp
                                                                                                       {unExp =
                                                                                                          RefBound
@@ -1224,15 +1253,17 @@
                                                                                                        expInfo =
                                                                                                          Info
                                                                                                            {refsFree =
-                                                                                                              []}}),
+                                                                                                              fromList
+                                                                                                                []}}),
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      [Imported
-                                                                                                         (ModuleName
-                                                                                                            "Golden.TestValues")
-                                                                                                         (Name
-                                                                                                            "f")]}})
+                                                                                                      fromList
+                                                                                                        [Imported
+                                                                                                           (ModuleName
+                                                                                                              "Golden.TestValues")
+                                                                                                           (Name
+                                                                                                              "f")]}})
                                                                                            (Exp
                                                                                               {unExp =
                                                                                                  RefBound
@@ -1244,7 +1275,8 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      []}})
+                                                                                                      fromList
+                                                                                                        []}})
                                                                                            (Exp
                                                                                               {unExp =
                                                                                                  RefBound
@@ -1256,29 +1288,29 @@
                                                                                                expInfo =
                                                                                                  Info
                                                                                                    {refsFree =
-                                                                                                      []}}),
+                                                                                                      fromList
+                                                                                                        []}}),
                                                                                        expInfo =
                                                                                          Info
                                                                                            {refsFree =
-                                                                                              [Imported
-                                                                                                 (ModuleName
-                                                                                                    "Golden.TestValues")
-                                                                                                 (Name
-                                                                                                    "f")]}})),
+                                                                                              fromList
+                                                                                                [Imported
+                                                                                                   (ModuleName
+                                                                                                      "Golden.TestValues")
+                                                                                                   (Name
+                                                                                                      "f")]}})),
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   [Local
-                                                                                      (Name
-                                                                                         "a"),
-                                                                                    Local
-                                                                                      (Name
-                                                                                         "a"),
-                                                                                    Imported
-                                                                                      (ModuleName
-                                                                                         "Golden.TestValues")
-                                                                                      (Name
-                                                                                         "f")]}})
+                                                                                   fromList
+                                                                                     [Local
+                                                                                        (Name
+                                                                                           "a"),
+                                                                                      Imported
+                                                                                        (ModuleName
+                                                                                           "Golden.TestValues")
+                                                                                        (Name
+                                                                                           "f")]}})
                                                                         (Exp
                                                                            {unExp =
                                                                               Lit
@@ -1287,24 +1319,20 @@
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   []}}),
+                                                                                   fromList
+                                                                                     []}}),
                                                                     expInfo =
                                                                       Info
                                                                         {refsFree =
-                                                                           [Local
-                                                                              (Name
-                                                                                 "a"),
-                                                                            Local
-                                                                              (Name
-                                                                                 "a"),
-                                                                            Local
-                                                                              (Name
-                                                                                 "a"),
-                                                                            Imported
-                                                                              (ModuleName
-                                                                                 "Golden.TestValues")
-                                                                              (Name
-                                                                                 "f")]}})
+                                                                           fromList
+                                                                             [Local
+                                                                                (Name
+                                                                                   "a"),
+                                                                              Imported
+                                                                                (ModuleName
+                                                                                   "Golden.TestValues")
+                                                                                (Name
+                                                                                   "f")]}})
                                                                 :|
                                                                 [Standalone
                                                                    (Name "y",
@@ -1317,9 +1345,10 @@
                                                                        expInfo =
                                                                          Info
                                                                            {refsFree =
-                                                                              [Local
-                                                                                 (Name
-                                                                                    "a")]}}),
+                                                                              fromList
+                                                                                [Local
+                                                                                   (Name
+                                                                                      "a")]}}),
                                                                  Standalone
                                                                    (Name "z",
                                                                     Exp
@@ -1331,9 +1360,10 @@
                                                                        expInfo =
                                                                          Info
                                                                            {refsFree =
-                                                                              [Local
-                                                                                 (Name
-                                                                                    "a")]}})])
+                                                                              fromList
+                                                                                [Local
+                                                                                   (Name
+                                                                                      "a")]}})])
                                                              (Exp
                                                                 {unExp =
                                                                    IfThenElse
@@ -1351,11 +1381,12 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Imported
-                                                                                           (ModuleName
-                                                                                              "Golden.TestValues")
-                                                                                           (Name
-                                                                                              "f")]}})
+                                                                                        fromList
+                                                                                          [Imported
+                                                                                             (ModuleName
+                                                                                                "Golden.TestValues")
+                                                                                             (Name
+                                                                                                "f")]}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefBound
@@ -1367,15 +1398,17 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}}),
+                                                                                        fromList
+                                                                                          []}}),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Imported
-                                                                                   (ModuleName
-                                                                                      "Golden.TestValues")
-                                                                                   (Name
-                                                                                      "f")]}})
+                                                                                fromList
+                                                                                  [Imported
+                                                                                     (ModuleName
+                                                                                        "Golden.TestValues")
+                                                                                     (Name
+                                                                                        "f")]}})
                                                                      (Exp
                                                                         {unExp =
                                                                            RefBound
@@ -1387,7 +1420,8 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            RefBound
@@ -1399,31 +1433,27 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}}),
+                                                                                fromList
+                                                                                  []}}),
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        [Imported
-                                                                           (ModuleName
-                                                                              "Golden.TestValues")
-                                                                           (Name
-                                                                              "f")]}})),
+                                                                        fromList
+                                                                          [Imported
+                                                                             (ModuleName
+                                                                                "Golden.TestValues")
+                                                                             (Name
+                                                                                "f")]}})),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f")]}})
+                                                             fromList
+                                                               [Local
+                                                                  (Name "a"),
+                                                                Imported
+                                                                  (ModuleName
+                                                                     "Golden.TestValues")
+                                                                  (Name "f")]}})
                                                   (Exp
                                                      {unExp =
                                                         IfThenElse
@@ -1439,7 +1469,8 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})
+                                                                                fromList
+                                                                                  []}})
                                                                      (Exp
                                                                         {unExp =
                                                                            RefFree
@@ -1449,15 +1480,17 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Local
-                                                                                   (Name
-                                                                                      "a")]}})),
+                                                                                fromList
+                                                                                  [Local
+                                                                                     (Name
+                                                                                        "a")]}})),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Local
-                                                                        (Name
-                                                                           "a")]}})
+                                                                     fromList
+                                                                       [Local
+                                                                          (Name
+                                                                             "a")]}})
                                                           (Exp
                                                              {unExp =
                                                                 Let
@@ -1473,7 +1506,8 @@
                                                                             expInfo =
                                                                               Info
                                                                                 {refsFree =
-                                                                                   []}})
+                                                                                   fromList
+                                                                                     []}})
                                                                         :|
                                                                         [Standalone
                                                                            (Name
@@ -1487,9 +1521,10 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      [Local
-                                                                                         (Name
-                                                                                            "a")]}}),
+                                                                                      fromList
+                                                                                        [Local
+                                                                                           (Name
+                                                                                              "a")]}}),
                                                                          Standalone
                                                                            (Name
                                                                               "z",
@@ -1502,9 +1537,10 @@
                                                                                expInfo =
                                                                                  Info
                                                                                    {refsFree =
-                                                                                      [Local
-                                                                                         (Name
-                                                                                            "a")]}})])
+                                                                                      fromList
+                                                                                        [Local
+                                                                                           (Name
+                                                                                              "a")]}})])
                                                                      (Exp
                                                                         {unExp =
                                                                            IfThenElse
@@ -1522,11 +1558,12 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                [Imported
-                                                                                                   (ModuleName
-                                                                                                      "Golden.TestValues")
-                                                                                                   (Name
-                                                                                                      "f")]}})
+                                                                                                fromList
+                                                                                                  [Imported
+                                                                                                     (ModuleName
+                                                                                                        "Golden.TestValues")
+                                                                                                     (Name
+                                                                                                        "f")]}})
                                                                                      (Exp
                                                                                         {unExp =
                                                                                            RefBound
@@ -1538,15 +1575,17 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}}),
+                                                                                                fromList
+                                                                                                  []}}),
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Imported
-                                                                                           (ModuleName
-                                                                                              "Golden.TestValues")
-                                                                                           (Name
-                                                                                              "f")]}})
+                                                                                        fromList
+                                                                                          [Imported
+                                                                                             (ModuleName
+                                                                                                "Golden.TestValues")
+                                                                                             (Name
+                                                                                                "f")]}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefBound
@@ -1558,7 +1597,8 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}})
+                                                                                        fromList
+                                                                                          []}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    RefBound
@@ -1570,156 +1610,74 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}}),
+                                                                                        fromList
+                                                                                          []}}),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Imported
-                                                                                   (ModuleName
-                                                                                      "Golden.TestValues")
-                                                                                   (Name
-                                                                                      "f")]}})),
+                                                                                fromList
+                                                                                  [Imported
+                                                                                     (ModuleName
+                                                                                        "Golden.TestValues")
+                                                                                     (Name
+                                                                                        "f")]}})),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Local
-                                                                        (Name
-                                                                           "a"),
-                                                                      Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f")]}})
+                                                                     fromList
+                                                                       [Local
+                                                                          (Name
+                                                                             "a"),
+                                                                        Imported
+                                                                          (ModuleName
+                                                                             "Golden.TestValues")
+                                                                          (Name
+                                                                             "f")]}})
                                                           (Exp
                                                              {unExp =
                                                                 Lit (Integer 0),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}}),
+                                                                     fromList
+                                                                       []}}),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Local (Name "a"),
-                                                              Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f")]}}),
+                                                             fromList
+                                                               [Local
+                                                                  (Name "a"),
+                                                                Imported
+                                                                  (ModuleName
+                                                                     "Golden.TestValues")
+                                                                  (Name
+                                                                     "f")]}}),
                                               expInfo =
                                                 Info
                                                   {refsFree =
-                                                     [Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Local (Name "a"),
-                                                      Imported
-                                                        (ModuleName
-                                                           "Golden.TestValues")
-                                                        (Name "f")]}}),
+                                                     fromList
+                                                       [Local (Name "a"),
+                                                        Imported
+                                                          (ModuleName
+                                                             "Golden.TestValues")
+                                                          (Name "f")]}}),
                                       expInfo =
                                         Info
                                           {refsFree =
-                                             [Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Local (Name "a"),
-                                              Imported
-                                                (ModuleName "Golden.TestValues")
-                                                (Name "f")]}})),
+                                             fromList
+                                               [Local (Name "a"),
+                                                Imported
+                                                  (ModuleName
+                                                     "Golden.TestValues")
+                                                  (Name "f")]}})),
                            expInfo =
                              Info
                                {refsFree =
-                                  [Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Local (Name "a"),
-                                   Imported
-                                     (ModuleName "Golden.TestValues")
-                                     (Name "f")]}})
+                                  fromList
+                                    [Local (Name "a"),
+                                     Imported
+                                       (ModuleName "Golden.TestValues")
+                                       (Name "f")]}})
                        :|
                        [])
                     (Exp
@@ -1731,14 +1689,18 @@
                                     (Eq
                                        (Exp
                                           {unExp = Lit (Integer 1),
-                                           expInfo = Info {refsFree = []}})
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp = RefFree (Local (Name "a")),
                                            expInfo =
                                              Info
                                                {refsFree =
-                                                  [Local (Name "a")]}})),
-                                expInfo = Info {refsFree = [Local (Name "a")]}})
+                                                  fromList
+                                                    [Local (Name "a")]}})),
+                                expInfo =
+                                  Info
+                                    {refsFree = fromList [Local (Name "a")]}})
                             (Exp
                                {unExp =
                                   IfThenElse
@@ -1749,17 +1711,22 @@
                                                (Exp
                                                   {unExp = Lit (Char 'b'),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp =
                                                      RefFree (Local (Name "b")),
                                                    expInfo =
                                                      Info
                                                        {refsFree =
-                                                          [Local
-                                                             (Name "b")]}})),
+                                                          fromList
+                                                            [Local
+                                                               (Name "b")]}})),
                                         expInfo =
-                                          Info {refsFree = [Local (Name "b")]}})
+                                          Info
+                                            {refsFree =
+                                               fromList [Local (Name "b")]}})
                                     (Exp
                                        {unExp =
                                           Let
@@ -1780,25 +1747,28 @@
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     [Imported
-                                                                        (ModuleName
-                                                                           "Golden.TestValues")
-                                                                        (Name
-                                                                           "f")]}})
+                                                                     fromList
+                                                                       [Imported
+                                                                          (ModuleName
+                                                                             "Golden.TestValues")
+                                                                          (Name
+                                                                             "f")]}})
                                                           (Exp
                                                              {unExp =
                                                                 Lit (Integer 2),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}}),
+                                                                     fromList
+                                                                       []}}),
                                                       expInfo =
                                                         Info
                                                           {refsFree =
-                                                             [Imported
-                                                                (ModuleName
-                                                                   "Golden.TestValues")
-                                                                (Name "f")]}})
+                                                             fromList
+                                                               [Imported
+                                                                  (ModuleName
+                                                                     "Golden.TestValues")
+                                                                  (Name "f")]}})
                                                   :|
                                                   [])
                                                (Exp
@@ -1816,7 +1786,8 @@
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})
+                                                                             fromList
+                                                                               []}})
                                                                   (Exp
                                                                      {unExp =
                                                                         RefBound
@@ -1828,10 +1799,12 @@
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Let
@@ -1852,11 +1825,12 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        [Imported
-                                                                                           (ModuleName
-                                                                                              "Golden.TestValues")
-                                                                                           (Name
-                                                                                              "f")]}})
+                                                                                        fromList
+                                                                                          [Imported
+                                                                                             (ModuleName
+                                                                                                "Golden.TestValues")
+                                                                                             (Name
+                                                                                                "f")]}})
                                                                              (Exp
                                                                                 {unExp =
                                                                                    Lit
@@ -1865,15 +1839,17 @@
                                                                                  expInfo =
                                                                                    Info
                                                                                      {refsFree =
-                                                                                        []}}),
+                                                                                        fromList
+                                                                                          []}}),
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                [Imported
-                                                                                   (ModuleName
-                                                                                      "Golden.TestValues")
-                                                                                   (Name
-                                                                                      "f")]}})
+                                                                                fromList
+                                                                                  [Imported
+                                                                                     (ModuleName
+                                                                                        "Golden.TestValues")
+                                                                                     (Name
+                                                                                        "f")]}})
                                                                      :|
                                                                      [])
                                                                   (Exp
@@ -1891,7 +1867,8 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}})
+                                                                                                fromList
+                                                                                                  []}})
                                                                                      (Exp
                                                                                         {unExp =
                                                                                            RefBound
@@ -1903,11 +1880,13 @@
                                                                                          expInfo =
                                                                                            Info
                                                                                              {refsFree =
-                                                                                                []}})),
+                                                                                                fromList
+                                                                                                  []}})),
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           (Exp
                                                                              {unExp =
                                                                                 Lit
@@ -1916,7 +1895,8 @@
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           (Exp
                                                                              {unExp =
                                                                                 App
@@ -1931,7 +1911,8 @@
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   (Exp
                                                                                      {unExp =
                                                                                         Lit
@@ -1940,23 +1921,27 @@
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}}),
+                                                                                             fromList
+                                                                                               []}}),
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}}),
+                                                                                     fromList
+                                                                                       []}}),
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  [Imported
-                                                                     (ModuleName
-                                                                        "Golden.TestValues")
-                                                                     (Name
-                                                                        "f")]}})
+                                                                  fromList
+                                                                    [Imported
+                                                                       (ModuleName
+                                                                          "Golden.TestValues")
+                                                                       (Name
+                                                                          "f")]}})
                                                        (Exp
                                                           {unExp =
                                                              App
@@ -1971,7 +1956,8 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})
+                                                                          fromList
+                                                                            []}})
                                                                (Exp
                                                                   {unExp =
                                                                      Lit
@@ -1980,29 +1966,29 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}}),
+                                                                          fromList
+                                                                            []}}),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}}),
+                                                                  fromList
+                                                                    []}}),
                                                    expInfo =
                                                      Info
                                                        {refsFree =
-                                                          [Imported
-                                                             (ModuleName
-                                                                "Golden.TestValues")
-                                                             (Name "f")]}})),
+                                                          fromList
+                                                            [Imported
+                                                               (ModuleName
+                                                                  "Golden.TestValues")
+                                                               (Name "f")]}})),
                                         expInfo =
                                           Info
                                             {refsFree =
-                                               [Imported
-                                                  (ModuleName
-                                                     "Golden.TestValues")
-                                                  (Name "f"),
-                                                Imported
-                                                  (ModuleName
-                                                     "Golden.TestValues")
-                                                  (Name "f")]}})
+                                               fromList
+                                                 [Imported
+                                                    (ModuleName
+                                                       "Golden.TestValues")
+                                                    (Name "f")]}})
                                     (Exp
                                        {unExp =
                                           App
@@ -2011,22 +1997,24 @@
                                                   RefBound
                                                     (Index
                                                        {level = 2, offset = 0}),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Boolean True),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}}),
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
                                 expInfo =
                                   Info
                                     {refsFree =
-                                       [Local (Name "b"),
-                                        Imported
-                                          (ModuleName "Golden.TestValues")
-                                          (Name "f"),
-                                        Imported
-                                          (ModuleName "Golden.TestValues")
-                                          (Name "f")]}})
+                                       fromList
+                                         [Local (Name "b"),
+                                          Imported
+                                            (ModuleName "Golden.TestValues")
+                                            (Name "f")]}})
                             (Exp
                                {unExp =
                                   App
@@ -2034,55 +2022,30 @@
                                        {unExp =
                                           RefBound
                                             (Index {level = 2, offset = 0}),
-                                        expInfo = Info {refsFree = []}})
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp = Lit (Boolean True),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}}),
                         expInfo =
                           Info
                             {refsFree =
-                               [Local (Name "a"),
-                                Local (Name "b"),
-                                Imported
-                                  (ModuleName "Golden.TestValues") (Name "f"),
-                                Imported
-                                  (ModuleName "Golden.TestValues")
-                                  (Name "f")]}})),
+                               fromList
+                                 [Local (Name "a"),
+                                  Local (Name "b"),
+                                  Imported
+                                    (ModuleName "Golden.TestValues")
+                                    (Name "f")]}})),
              expInfo =
                Info
                  {refsFree =
-                    [Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Local (Name "a"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "b"),
-                     Imported (ModuleName "Golden.TestValues") (Name "f"),
-                     Imported
-                       (ModuleName "Golden.TestValues") (Name "f")]}})],
+                    fromList
+                      [Local (Name "a"),
+                       Local (Name "b"),
+                       Imported
+                         (ModuleName "Golden.TestValues") (Name "f")]}})],
     moduleImports = [ModuleName "Golden.TestValues"],
     moduleExports =
       [Name "a",
@@ -2114,8 +2077,8 @@
                     ArgUnused
                     (Exp
                        {unExp = Lit (Boolean True),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "f"],
     moduleReExports = fromList [],

--- a/test/ps/output/Golden.TestCaseStatements/golden.lua
+++ b/test/ps/output/Golden.TestCaseStatements/golden.lua
@@ -1,123 +1,63 @@
-local Golden_TestValues = (function()
-  local f = function() return true end
-  return { f = f }
-end)()
-local Golden_TestCaseStatements = (function()
-  local J = function(value0)
-    return { ["$ctor"] = "Golden_TestCaseStatements.J", value0 = value0 }
-  end
-  local N = function() return { ["$ctor"] = "Golden_TestCaseStatements.N" } end
-  local multipleGuards = 1
-  local d = function(m0)
-    return function(n1)
-      return function(x2)
-        local v3 = function()
-          return (function() if "y" == x2 then return 0 else return 1 end end)()
-        end
-        return (function()
-          if "x" == x2 then
-            return (function()
-              if "Golden.TestCaseStatements.J" == m0["$ctor"] then
-                return (function()
-                  local y4 = m0[0]
-                  return (function()
-                    if "Golden.TestCaseStatements.N" == n1["$ctor"] then
-                      return y4
-                    else
-                      return v3(true)
-                    end
-                  end)()
-                end)()
-              else
-                return v3(true)
-              end
-            end)()
-          else
-            return v3(true)
-          end
-        end)()
-      end
-    end
-  end
-  local b = "b"
-  local a = 1
-  local c = (function()
-    local v5 = function()
+local Golden_TestValues_I_f = function() return true end
+local Golden_TestCaseStatements_I_J = function(value0)
+  return { ["$ctor"] = "Golden_TestCaseStatements.J", value0 = value0 }
+end
+local Golden_TestCaseStatements_I_N = function()
+  return { ["$ctor"] = "Golden_TestCaseStatements.N" }
+end
+local Golden_TestCaseStatements_I_multipleGuards = 1
+local Golden_TestCaseStatements_I_d = function(m0)
+  return function(n1)
+    return function(x2)
+      local v3 = function() if "y" == x2 then return 0 else return 1 end end
       return (function()
-        if 2 == a then
+        if "x" == x2 then
           return (function()
-            if Golden_TestValues.f(0) then
-              return 10
-            else
+            if "Golden.TestCaseStatements.J" == m0["$ctor"] then
               return (function()
-                if 3 == a then
-                  return (function()
-                    local n18 = (function()
-                      if 4 == a then
-                        return (function()
-                          local n211 = 0
-                          local y12 = a
-                          local z13 = a
-                          return (function()
-                            if Golden_TestValues.f(y12) then
-                              return z13
-                            else
-                              return n211
-                            end
-                          end)()
-                        end)()
-                      else
-                        return 0
-                      end
-                    end)()
-                    local y9 = a
-                    local z10 = a
-                    return (function()
-                      if Golden_TestValues.f(z10) then
-                        return y9
-                      else
-                        return n18
-                      end
-                    end)()
-                  end)()
-                else
-                  return (function()
-                    if 4 == a then
-                      return (function()
-                        local n314 = 0
-                        local y15 = a
-                        local z16 = a
-                        return (function()
-                          if Golden_TestValues.f(y15) then
-                            return z16
-                          else
-                            return n314
-                          end
-                        end)()
-                      end)()
-                    else
-                      return 0
-                    end
-                  end)()
-                end
+                local y4 = m0[0]
+                return (function()
+                  if "Golden.TestCaseStatements.N" == n1["$ctor"] then
+                    return y4
+                  else
+                    return v3(true)
+                  end
+                end)()
               end)()
+            else
+              return v3(true)
             end
           end)()
         else
+          return v3(true)
+        end
+      end)()
+    end
+  end
+end
+local Golden_TestCaseStatements_I_b = "b"
+local Golden_TestCaseStatements_I_a = 1
+local Golden_TestCaseStatements_I_c = (function()
+  local v5 = function()
+    if 2 == Golden_TestCaseStatements_I_a then
+      return (function()
+        if Golden_TestValues_I_f(0) then
+          return 10
+        else
           return (function()
-            if 3 == a then
+            if 3 == Golden_TestCaseStatements_I_a then
               return (function()
-                local n417 = (function()
-                  if 4 == a then
+                local n18 = (function()
+                  if 4 == Golden_TestCaseStatements_I_a then
                     return (function()
-                      local n520 = 0
-                      local y21 = a
-                      local z22 = a
+                      local n211 = 0
+                      local y12 = Golden_TestCaseStatements_I_a
+                      local z13 = Golden_TestCaseStatements_I_a
                       return (function()
-                        if Golden_TestValues.f(y21) then
-                          return z22
+                        if Golden_TestValues_I_f(y12) then
+                          return z13
                         else
-                          return n520
+                          return n211
                         end
                       end)()
                     end)()
@@ -125,28 +65,28 @@ local Golden_TestCaseStatements = (function()
                     return 0
                   end
                 end)()
-                local y18 = a
-                local z19 = a
+                local y9 = Golden_TestCaseStatements_I_a
+                local z10 = Golden_TestCaseStatements_I_a
                 return (function()
-                  if Golden_TestValues.f(z19) then
-                    return y18
+                  if Golden_TestValues_I_f(z10) then
+                    return y9
                   else
-                    return n417
+                    return n18
                   end
                 end)()
               end)()
             else
               return (function()
-                if 4 == a then
+                if 4 == Golden_TestCaseStatements_I_a then
                   return (function()
-                    local n623 = 0
-                    local y24 = a
-                    local z25 = a
+                    local n314 = 0
+                    local y15 = Golden_TestCaseStatements_I_a
+                    local z16 = Golden_TestCaseStatements_I_a
                     return (function()
-                      if Golden_TestValues.f(y24) then
-                        return z25
+                      if Golden_TestValues_I_f(y15) then
+                        return z16
                       else
-                        return n623
+                        return n314
                       end
                     end)()
                   end)()
@@ -158,42 +98,82 @@ local Golden_TestCaseStatements = (function()
           end)()
         end
       end)()
-    end
-    return (function()
-      if 1 == a then
-        return (function()
-          if "b" == b then
-            return (function()
-              local e76 = Golden_TestValues.f(2)
-              return (function()
-                if true == e76 then
+    else
+      return (function()
+        if 3 == Golden_TestCaseStatements_I_a then
+          return (function()
+            local n417 = (function()
+              if 4 == Golden_TestCaseStatements_I_a then
+                return (function()
+                  local n520 = 0
+                  local y21 = Golden_TestCaseStatements_I_a
+                  local z22 = Golden_TestCaseStatements_I_a
                   return (function()
-                    local e87 = Golden_TestValues.f(1)
-                    return (function()
-                      if true == e87 then return 42 else return v5(true) end
-                    end)()
+                    if Golden_TestValues_I_f(y21) then
+                      return z22
+                    else
+                      return n520
+                    end
                   end)()
-                else
-                  return v5(true)
-                end
-              end)()
+                end)()
+              else
+                return 0
+              end
             end)()
-          else
-            return v5(true)
-          end
-        end)()
-      else
-        return v5(true)
-      end
-    end)()
+            local y18 = Golden_TestCaseStatements_I_a
+            local z19 = Golden_TestCaseStatements_I_a
+            return (function()
+              if Golden_TestValues_I_f(z19) then return y18 else return n417 end
+            end)()
+          end)()
+        else
+          return (function()
+            if 4 == Golden_TestCaseStatements_I_a then
+              return (function()
+                local n623 = 0
+                local y24 = Golden_TestCaseStatements_I_a
+                local z25 = Golden_TestCaseStatements_I_a
+                return (function()
+                  if Golden_TestValues_I_f(y24) then
+                    return z25
+                  else
+                    return n623
+                  end
+                end)()
+              end)()
+            else
+              return 0
+            end
+          end)()
+        end
+      end)()
+    end
+  end
+  return (function()
+    if 1 == Golden_TestCaseStatements_I_a then
+      return (function()
+        if "b" == Golden_TestCaseStatements_I_b then
+          return (function()
+            local e76 = Golden_TestValues_I_f(2)
+            return (function()
+              if true == e76 then
+                return (function()
+                  local e87 = Golden_TestValues_I_f(1)
+                  return (function()
+                    if true == e87 then return 42 else return v5(true) end
+                  end)()
+                end)()
+              else
+                return v5(true)
+              end
+            end)()
+          end)()
+        else
+          return v5(true)
+        end
+      end)()
+    else
+      return v5(true)
+    end
   end)()
-  return {
-    a = a,
-    b = b,
-    c = c,
-    J = J,
-    N = N,
-    d = d,
-    multipleGuards = multipleGuards
-  }
 end)()

--- a/test/ps/output/Golden.TestCurrying/golden.ir
+++ b/test/ps/output/Golden.TestCurrying/golden.ir
@@ -28,11 +28,14 @@
                                                            Lit (String "ok"),
                                                          expInfo =
                                                            Info
-                                                             {refsFree = []}})),
-                                              expInfo = Info {refsFree = []}})),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                                             {refsFree =
+                                                                fromList []}})),
+                                              expInfo =
+                                                Info
+                                                  {refsFree = fromList []}})),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "apply",
           Exp
@@ -52,15 +55,17 @@
                                           {unExp =
                                              RefBound
                                                (Index {level = 1, offset = 0}),
-                                           expInfo = Info {refsFree = []}})
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp =
                                              RefBound
                                                (Index {level = 0, offset = 0}),
-                                           expInfo = Info {refsFree = []}}),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                           expInfo =
+                                             Info {refsFree = fromList []}}),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "apply", Name "f"],
     moduleReExports = fromList [],

--- a/test/ps/output/Golden.TestCurrying/golden.lua
+++ b/test/ps/output/Golden.TestCurrying/golden.lua
@@ -1,9 +1,6 @@
-local Golden_TestCurrying = (function()
-  local f = function()
-    return function()
-      return function() return function() return "ok" end end
-    end
-  end
-  local apply = function(f10) return function(x1) return f10(x1) end end
-  return { apply = apply, f = f }
-end)()
+local Golden_TestCurrying_I_f = function()
+  return function() return function() return function() return "ok" end end end
+end
+local Golden_TestCurrying_I_apply = function(f10)
+  return function(x1) return f10(x1) end
+end

--- a/test/ps/output/Golden.TestDataDeclarations1/golden.ir
+++ b/test/ps/output/Golden.TestDataDeclarations1/golden.ir
@@ -7,7 +7,7 @@
           Exp
             {unExp =
                Ctor ProductType (TyName "Unit") (CtorName "U") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "CtorSameName",
           Exp
@@ -17,13 +17,13 @@
                  (TyName "TySameName")
                  (CtorName "CtorSameName")
                  [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "S0",
           Exp
             {unExp =
                Ctor SumType (TyName "TSum") (CtorName "S0") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "S1",
           Exp
@@ -33,7 +33,7 @@
                  (TyName "TSum")
                  (CtorName "S1")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "S2",
           Exp
@@ -43,7 +43,7 @@
                  (TyName "TSum")
                  (CtorName "S2")
                  [FieldName "value0", FieldName "value1"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "PF",
           Exp
@@ -53,7 +53,7 @@
                  (TyName "TProductWithFields")
                  (CtorName "PF")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "P3",
           Exp
@@ -65,13 +65,13 @@
                  [FieldName "value0",
                   FieldName "value1",
                   FieldName "value2"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Nop",
           Exp
             {unExp =
                Ctor SumType (TyName "Rec") (CtorName "Nop") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "More",
           Exp
@@ -81,7 +81,7 @@
                  (TyName "Rec")
                  (CtorName "More")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}})],
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports =
       [Name "U",

--- a/test/ps/output/Golden.TestDataDeclarations1/golden.lua
+++ b/test/ps/output/Golden.TestDataDeclarations1/golden.lua
@@ -1,49 +1,36 @@
-local Golden_TestDataDeclarations1 = (function()
-  local U = function()
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.U" }
-  end
-  local CtorSameName = function()
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.CtorSameName" }
-  end
-  local S0 = function()
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.S0" }
-  end
-  local S1 = function(value0)
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.S1", value0 = value0 }
-  end
-  local S2 = function(value0, value1)
-    return {
-      ["$ctor"] = "Golden_TestDataDeclarations1.S2",
-      value0 = value0,
-      value1 = value1
-    }
-  end
-  local PF = function(value0)
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.PF", value0 = value0 }
-  end
-  local P3 = function(value0, value1, value2)
-    return {
-      ["$ctor"] = "Golden_TestDataDeclarations1.P3",
-      value0 = value0,
-      value1 = value1,
-      value2 = value2
-    }
-  end
-  local Nop = function()
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.Nop" }
-  end
-  local More = function(value0)
-    return { ["$ctor"] = "Golden_TestDataDeclarations1.More", value0 = value0 }
-  end
+local Golden_TestDataDeclarations1_I_U = function()
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.U" }
+end
+local Golden_TestDataDeclarations1_I_CtorSameName = function()
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.CtorSameName" }
+end
+local Golden_TestDataDeclarations1_I_S0 = function()
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.S0" }
+end
+local Golden_TestDataDeclarations1_I_S1 = function(value0)
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.S1", value0 = value0 }
+end
+local Golden_TestDataDeclarations1_I_S2 = function(value0, value1)
   return {
-    U = U,
-    P3 = P3,
-    PF = PF,
-    S0 = S0,
-    S1 = S1,
-    S2 = S2,
-    Nop = Nop,
-    More = More,
-    CtorSameName = CtorSameName
+    ["$ctor"] = "Golden_TestDataDeclarations1.S2",
+    value0 = value0,
+    value1 = value1
   }
-end)()
+end
+local Golden_TestDataDeclarations1_I_PF = function(value0)
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.PF", value0 = value0 }
+end
+local Golden_TestDataDeclarations1_I_P3 = function(value0, value1, value2)
+  return {
+    ["$ctor"] = "Golden_TestDataDeclarations1.P3",
+    value0 = value0,
+    value1 = value1,
+    value2 = value2
+  }
+end
+local Golden_TestDataDeclarations1_I_Nop = function()
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.Nop" }
+end
+local Golden_TestDataDeclarations1_I_More = function(value0)
+  return { ["$ctor"] = "Golden_TestDataDeclarations1.More", value0 = value0 }
+end

--- a/test/ps/output/Golden.TestDataDeclarations2/golden.ir
+++ b/test/ps/output/Golden.TestDataDeclarations2/golden.ir
@@ -11,7 +11,7 @@
                  (TyName "TySameName")
                  (CtorName "CtorSameName")
                  [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "test",
           Exp
@@ -37,7 +37,9 @@
                                                           (String
                                                              "Golden.TestDataDeclarations1.CtorSameName"),
                                                       expInfo =
-                                                        Info {refsFree = []}})
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})
                                                   (Exp
                                                      {unExp =
                                                         Prim
@@ -53,10 +55,14 @@
                                                                  expInfo =
                                                                    Info
                                                                      {refsFree =
-                                                                        []}})),
+                                                                        fromList
+                                                                          []}})),
                                                       expInfo =
-                                                        Info {refsFree = []}})),
-                                           expInfo = Info {refsFree = []}})
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp =
                                              IfThenElse
@@ -72,7 +78,8 @@
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}})
+                                                                     fromList
+                                                                       []}})
                                                           (Exp
                                                              {unExp =
                                                                 Prim
@@ -88,31 +95,41 @@
                                                                          expInfo =
                                                                            Info
                                                                              {refsFree =
-                                                                                []}})),
+                                                                                fromList
+                                                                                  []}})),
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}})),
+                                                                     fromList
+                                                                       []}})),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp = Lit (Boolean True),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp =
                                                      Exception
                                                        "No patterns matched",
                                                    expInfo =
-                                                     Info {refsFree = []}}),
-                                           expInfo = Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}}),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp =
                                              Exception "No patterns matched",
-                                           expInfo = Info {refsFree = []}}),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                           expInfo =
+                                             Info {refsFree = fromList []}}),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "CtorSameName", Name "test"],
     moduleReExports = fromList [],

--- a/test/ps/output/Golden.TestDataDeclarations2/golden.lua
+++ b/test/ps/output/Golden.TestDataDeclarations2/golden.lua
@@ -1,21 +1,18 @@
-local Golden_TestDataDeclarations2 = (function()
-  local CtorSameName = function()
-    return { ["$ctor"] = "Golden_TestDataDeclarations2.CtorSameName" }
-  end
-  local test = function(v0)
-    return function(v11)
-      if "Golden.TestDataDeclarations1.CtorSameName" == v0["$ctor"] then
-        return (function()
-          if "Golden.TestDataDeclarations2.CtorSameName" == v11["$ctor"] then
-            return true
-          else
-            return error("No patterns matched")
-          end
-        end)()
-      else
-        return error("No patterns matched")
-      end
+local Golden_TestDataDeclarations2_I_CtorSameName = function()
+  return { ["$ctor"] = "Golden_TestDataDeclarations2.CtorSameName" }
+end
+local Golden_TestDataDeclarations2_I_test = function(v0)
+  return function(v11)
+    if "Golden.TestDataDeclarations1.CtorSameName" == v0["$ctor"] then
+      return (function()
+        if "Golden.TestDataDeclarations2.CtorSameName" == v11["$ctor"] then
+          return true
+        else
+          return error("No patterns matched")
+        end
+      end)()
+    else
+      return error("No patterns matched")
     end
   end
-  return { CtorSameName = CtorSameName, test = test }
-end)()
+end

--- a/test/ps/output/Golden.TestForeign/golden.lua
+++ b/test/ps/output/Golden.TestForeign/golden.lua
@@ -1,2 +1,6 @@
-local foreign = (function() local fooBar = 42 return { foo = fooBar }  end)()
-local foo = foreign.foo
+local Golden_TestForeign_I_foreign = (function()
+  local fooBar = 42
+  return { foo = fooBar }
+
+end)()
+local Golden_TestForeign_I_foo = Golden_TestForeign_I_foreign.foo

--- a/test/ps/output/Golden.TestForeign/golden.lua
+++ b/test/ps/output/Golden.TestForeign/golden.lua
@@ -1,5 +1,2 @@
-local Golden_TestForeign = (function()
-  local foreign = (function() local fooBar = 42 return { foo = fooBar }  end)()
-  local foo = foreign.foo
-  return { foo = foo }
-end)()
+local foreign = (function() local fooBar = 42 return { foo = fooBar }  end)()
+local foo = foreign.foo

--- a/test/ps/output/Golden.TestHelloPrelude/corefn.json
+++ b/test/ps/output/Golden.TestHelloPrelude/corefn.json
@@ -1,0 +1,163 @@
+{
+  "builtWith": "0.15.7",
+  "comments": [],
+  "decls": [
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "end": [
+            6,
+            20
+          ],
+          "start": [
+            6,
+            1
+          ]
+        }
+      },
+      "bindType": "NonRec",
+      "expression": {
+        "abstraction": {
+          "annotation": {
+            "meta": {
+              "metaType": "IsForeign"
+            },
+            "sourceSpan": {
+              "end": [
+                7,
+                12
+              ],
+              "start": [
+                7,
+                8
+              ]
+            }
+          },
+          "type": "Var",
+          "value": {
+            "identifier": "pass",
+            "moduleName": [
+              "Prelude"
+            ]
+          }
+        },
+        "annotation": {
+          "meta": {
+            "metaType": "IsSyntheticApp"
+          },
+          "sourceSpan": {
+            "end": [
+              7,
+              12
+            ],
+            "start": [
+              7,
+              8
+            ]
+          }
+        },
+        "argument": {
+          "annotation": {
+            "meta": null,
+            "sourceSpan": {
+              "end": [
+                0,
+                0
+              ],
+              "start": [
+                0,
+                0
+              ]
+            }
+          },
+          "type": "Var",
+          "value": {
+            "identifier": "applicativeEffect",
+            "moduleName": [
+              "Effect"
+            ]
+          }
+        },
+        "type": "App"
+      },
+      "identifier": "main"
+    }
+  ],
+  "exports": [
+    "main"
+  ],
+  "foreign": [],
+  "imports": [
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "end": [
+            7,
+            12
+          ],
+          "start": [
+            1,
+            1
+          ]
+        }
+      },
+      "moduleName": [
+        "Effect"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "end": [
+            7,
+            12
+          ],
+          "start": [
+            1,
+            1
+          ]
+        }
+      },
+      "moduleName": [
+        "Prelude"
+      ]
+    },
+    {
+      "annotation": {
+        "meta": null,
+        "sourceSpan": {
+          "end": [
+            7,
+            12
+          ],
+          "start": [
+            1,
+            1
+          ]
+        }
+      },
+      "moduleName": [
+        "Prim"
+      ]
+    }
+  ],
+  "moduleName": [
+    "Golden",
+    "TestHelloPrelude"
+  ],
+  "modulePath": "golden/Golden/TestHelloPrelude.purs",
+  "reExports": {},
+  "sourceSpan": {
+    "end": [
+      7,
+      12
+    ],
+    "start": [
+      1,
+      1
+    ]
+  }
+}

--- a/test/ps/output/Golden.TestHelloPrelude/golden.ir
+++ b/test/ps/output/Golden.TestHelloPrelude/golden.ir
@@ -1,0 +1,1374 @@
+[Module
+   {moduleName = ModuleName "Control.Applicative",
+    moduleBindings =
+      [Standalone
+         (Name "pure",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dict"))
+                    (Exp
+                       {unExp =
+                          Let
+                            (LetBinding
+                               (Standalone
+                                  (Name "v",
+                                   Exp
+                                     {unExp =
+                                        RefBound
+                                          (Index {level = 1, offset = 0}),
+                                      expInfo = Info {refsFree = fromList []}})
+                                  :|
+                                  [])
+                               (Exp
+                                  {unExp =
+                                     ObjectProp
+                                       (Exp
+                                          {unExp =
+                                             RefBound
+                                               (Index {level = 0, offset = 0}),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
+                                       (PropName "pure"),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
+       Standalone
+         (Name "liftA1",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dictApplicative"))
+                    (Exp
+                       {unExp =
+                          Let
+                            (LetBinding
+                               (Standalone
+                                  (Name "apply",
+                                   Exp
+                                     {unExp =
+                                        App
+                                          (Exp
+                                             {unExp =
+                                                RefFree
+                                                  (Imported
+                                                     (ModuleName
+                                                        "Control.Apply")
+                                                     (Name "apply")),
+                                              expInfo =
+                                                Info
+                                                  {refsFree =
+                                                     fromList
+                                                       [Imported
+                                                          (ModuleName
+                                                             "Control.Apply")
+                                                          (Name "apply")]}})
+                                          (Exp
+                                             {unExp =
+                                                App
+                                                  (Exp
+                                                     {unExp =
+                                                        ObjectProp
+                                                          (Exp
+                                                             {unExp =
+                                                                RefBound
+                                                                  (Index
+                                                                     {level = 1,
+                                                                      offset =
+                                                                        0}),
+                                                              expInfo =
+                                                                Info
+                                                                  {refsFree =
+                                                                     fromList
+                                                                       []}})
+                                                          (PropName "Apply0"),
+                                                      expInfo =
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})
+                                                  (Exp
+                                                     {unExp =
+                                                        RefFree
+                                                          (Imported
+                                                             (ModuleName "Prim")
+                                                             (Name
+                                                                "undefined")),
+                                                      expInfo =
+                                                        Info
+                                                          {refsFree =
+                                                             fromList
+                                                               [Imported
+                                                                  (ModuleName
+                                                                     "Prim")
+                                                                  (Name
+                                                                     "undefined")]}}),
+                                              expInfo =
+                                                Info
+                                                  {refsFree =
+                                                     fromList
+                                                       [Imported
+                                                          (ModuleName "Prim")
+                                                          (Name
+                                                             "undefined")]}}),
+                                      expInfo =
+                                        Info
+                                          {refsFree =
+                                             fromList
+                                               [Imported
+                                                  (ModuleName "Control.Apply")
+                                                  (Name "apply"),
+                                                Imported
+                                                  (ModuleName "Prim")
+                                                  (Name "undefined")]}})
+                                  :|
+                                  [Standalone
+                                     (Name "pure1",
+                                      Exp
+                                        {unExp =
+                                           App
+                                             (Exp
+                                                {unExp =
+                                                   RefFree
+                                                     (Local (Name "pure")),
+                                                 expInfo =
+                                                   Info
+                                                     {refsFree =
+                                                        fromList
+                                                          [Local
+                                                             (Name "pure")]}})
+                                             (Exp
+                                                {unExp =
+                                                   RefBound
+                                                     (Index
+                                                        {level = 1,
+                                                         offset = 0}),
+                                                 expInfo =
+                                                   Info
+                                                     {refsFree = fromList []}}),
+                                         expInfo =
+                                           Info
+                                             {refsFree =
+                                                fromList
+                                                  [Local (Name "pure")]}})])
+                               (Exp
+                                  {unExp =
+                                     Abs
+                                       (AbsBinding
+                                          (ArgNamed (Name "f"))
+                                          (Exp
+                                             {unExp =
+                                                Abs
+                                                  (AbsBinding
+                                                     (ArgNamed (Name "a"))
+                                                     (Exp
+                                                        {unExp =
+                                                           App
+                                                             (Exp
+                                                                {unExp =
+                                                                   App
+                                                                     (Exp
+                                                                        {unExp =
+                                                                           RefBound
+                                                                             (Index
+                                                                                {level =
+                                                                                   2,
+                                                                                 offset =
+                                                                                   0}),
+                                                                         expInfo =
+                                                                           Info
+                                                                             {refsFree =
+                                                                                fromList
+                                                                                  []}})
+                                                                     (Exp
+                                                                        {unExp =
+                                                                           App
+                                                                             (Exp
+                                                                                {unExp =
+                                                                                   RefBound
+                                                                                     (Index
+                                                                                        {level =
+                                                                                           2,
+                                                                                         offset =
+                                                                                           1}),
+                                                                                 expInfo =
+                                                                                   Info
+                                                                                     {refsFree =
+                                                                                        fromList
+                                                                                          []}})
+                                                                             (Exp
+                                                                                {unExp =
+                                                                                   RefBound
+                                                                                     (Index
+                                                                                        {level =
+                                                                                           1,
+                                                                                         offset =
+                                                                                           0}),
+                                                                                 expInfo =
+                                                                                   Info
+                                                                                     {refsFree =
+                                                                                        fromList
+                                                                                          []}}),
+                                                                         expInfo =
+                                                                           Info
+                                                                             {refsFree =
+                                                                                fromList
+                                                                                  []}}),
+                                                                 expInfo =
+                                                                   Info
+                                                                     {refsFree =
+                                                                        fromList
+                                                                          []}})
+                                                             (Exp
+                                                                {unExp =
+                                                                   RefBound
+                                                                     (Index
+                                                                        {level =
+                                                                           0,
+                                                                         offset =
+                                                                           0}),
+                                                                 expInfo =
+                                                                   Info
+                                                                     {refsFree =
+                                                                        fromList
+                                                                          []}}),
+                                                         expInfo =
+                                                           Info
+                                                             {refsFree =
+                                                                fromList []}})),
+                                              expInfo =
+                                                Info
+                                                  {refsFree = fromList []}})),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo =
+                          Info
+                            {refsFree =
+                               fromList
+                                 [Local (Name "pure"),
+                                  Imported
+                                    (ModuleName "Control.Apply") (Name "apply"),
+                                  Imported
+                                    (ModuleName "Prim") (Name "undefined")]}})),
+             expInfo =
+               Info
+                 {refsFree =
+                    fromList
+                      [Local (Name "pure"),
+                       Imported (ModuleName "Control.Apply") (Name "apply"),
+                       Imported (ModuleName "Prim") (Name "undefined")]}})],
+    moduleImports =
+      [ModuleName "Control.Apply", ModuleName "Prim"],
+    moduleExports = [Name "pure", Name "liftA1"],
+    moduleReExports =
+      fromList
+        [(ModuleName "Control.Apply", []),
+         (ModuleName "Data.Functor", [])],
+    moduleForeigns = [],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Control/Applicative.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Control.Apply",
+    moduleBindings =
+      [Standalone
+         (Name "apply",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dict"))
+                    (Exp
+                       {unExp =
+                          Let
+                            (LetBinding
+                               (Standalone
+                                  (Name "v",
+                                   Exp
+                                     {unExp =
+                                        RefBound
+                                          (Index {level = 1, offset = 0}),
+                                      expInfo = Info {refsFree = fromList []}})
+                                  :|
+                                  [])
+                               (Exp
+                                  {unExp =
+                                     ObjectProp
+                                       (Exp
+                                          {unExp =
+                                             RefBound
+                                               (Index {level = 0, offset = 0}),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
+                                       (PropName "apply"),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
+    moduleImports = [],
+    moduleExports = [Name "apply"],
+    moduleReExports =
+      fromList [(ModuleName "Data.Functor", [])],
+    moduleForeigns = [],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Control/Apply.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Control.Bind",
+    moduleBindings =
+      [Standalone
+         (Name "bind",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dict"))
+                    (Exp
+                       {unExp =
+                          Let
+                            (LetBinding
+                               (Standalone
+                                  (Name "v",
+                                   Exp
+                                     {unExp =
+                                        RefBound
+                                          (Index {level = 1, offset = 0}),
+                                      expInfo = Info {refsFree = fromList []}})
+                                  :|
+                                  [])
+                               (Exp
+                                  {unExp =
+                                     ObjectProp
+                                       (Exp
+                                          {unExp =
+                                             RefBound
+                                               (Index {level = 0, offset = 0}),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
+                                       (PropName "bind"),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
+    moduleImports = [],
+    moduleExports = [Name "bind"],
+    moduleReExports =
+      fromList
+        [(ModuleName "Control.Applicative", []),
+         (ModuleName "Control.Apply", []),
+         (ModuleName "Data.Functor", [])],
+    moduleForeigns = [],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Control/Bind.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Control.Monad",
+    moduleBindings =
+      [Standalone
+         (Name "ap",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dictMonad"))
+                    (Exp
+                       {unExp =
+                          Let
+                            (LetBinding
+                               (Standalone
+                                  (Name "bind",
+                                   Exp
+                                     {unExp =
+                                        App
+                                          (Exp
+                                             {unExp =
+                                                RefFree
+                                                  (Imported
+                                                     (ModuleName "Control.Bind")
+                                                     (Name "bind")),
+                                              expInfo =
+                                                Info
+                                                  {refsFree =
+                                                     fromList
+                                                       [Imported
+                                                          (ModuleName
+                                                             "Control.Bind")
+                                                          (Name "bind")]}})
+                                          (Exp
+                                             {unExp =
+                                                App
+                                                  (Exp
+                                                     {unExp =
+                                                        ObjectProp
+                                                          (Exp
+                                                             {unExp =
+                                                                RefBound
+                                                                  (Index
+                                                                     {level = 1,
+                                                                      offset =
+                                                                        0}),
+                                                              expInfo =
+                                                                Info
+                                                                  {refsFree =
+                                                                     fromList
+                                                                       []}})
+                                                          (PropName "Bind1"),
+                                                      expInfo =
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})
+                                                  (Exp
+                                                     {unExp =
+                                                        RefFree
+                                                          (Imported
+                                                             (ModuleName "Prim")
+                                                             (Name
+                                                                "undefined")),
+                                                      expInfo =
+                                                        Info
+                                                          {refsFree =
+                                                             fromList
+                                                               [Imported
+                                                                  (ModuleName
+                                                                     "Prim")
+                                                                  (Name
+                                                                     "undefined")]}}),
+                                              expInfo =
+                                                Info
+                                                  {refsFree =
+                                                     fromList
+                                                       [Imported
+                                                          (ModuleName "Prim")
+                                                          (Name
+                                                             "undefined")]}}),
+                                      expInfo =
+                                        Info
+                                          {refsFree =
+                                             fromList
+                                               [Imported
+                                                  (ModuleName "Control.Bind")
+                                                  (Name "bind"),
+                                                Imported
+                                                  (ModuleName "Prim")
+                                                  (Name "undefined")]}})
+                                  :|
+                                  [Standalone
+                                     (Name "pure",
+                                      Exp
+                                        {unExp =
+                                           App
+                                             (Exp
+                                                {unExp =
+                                                   RefFree
+                                                     (Imported
+                                                        (ModuleName
+                                                           "Control.Applicative")
+                                                        (Name "pure")),
+                                                 expInfo =
+                                                   Info
+                                                     {refsFree =
+                                                        fromList
+                                                          [Imported
+                                                             (ModuleName
+                                                                "Control.Applicative")
+                                                             (Name "pure")]}})
+                                             (Exp
+                                                {unExp =
+                                                   App
+                                                     (Exp
+                                                        {unExp =
+                                                           ObjectProp
+                                                             (Exp
+                                                                {unExp =
+                                                                   RefBound
+                                                                     (Index
+                                                                        {level =
+                                                                           1,
+                                                                         offset =
+                                                                           0}),
+                                                                 expInfo =
+                                                                   Info
+                                                                     {refsFree =
+                                                                        fromList
+                                                                          []}})
+                                                             (PropName
+                                                                "Applicative0"),
+                                                         expInfo =
+                                                           Info
+                                                             {refsFree =
+                                                                fromList []}})
+                                                     (Exp
+                                                        {unExp =
+                                                           RefFree
+                                                             (Imported
+                                                                (ModuleName
+                                                                   "Prim")
+                                                                (Name
+                                                                   "undefined")),
+                                                         expInfo =
+                                                           Info
+                                                             {refsFree =
+                                                                fromList
+                                                                  [Imported
+                                                                     (ModuleName
+                                                                        "Prim")
+                                                                     (Name
+                                                                        "undefined")]}}),
+                                                 expInfo =
+                                                   Info
+                                                     {refsFree =
+                                                        fromList
+                                                          [Imported
+                                                             (ModuleName "Prim")
+                                                             (Name
+                                                                "undefined")]}}),
+                                         expInfo =
+                                           Info
+                                             {refsFree =
+                                                fromList
+                                                  [Imported
+                                                     (ModuleName
+                                                        "Control.Applicative")
+                                                     (Name "pure"),
+                                                   Imported
+                                                     (ModuleName "Prim")
+                                                     (Name "undefined")]}})])
+                               (Exp
+                                  {unExp =
+                                     Abs
+                                       (AbsBinding
+                                          (ArgNamed (Name "f"))
+                                          (Exp
+                                             {unExp =
+                                                Abs
+                                                  (AbsBinding
+                                                     (ArgNamed (Name "a"))
+                                                     (Exp
+                                                        {unExp =
+                                                           App
+                                                             (Exp
+                                                                {unExp =
+                                                                   App
+                                                                     (Exp
+                                                                        {unExp =
+                                                                           RefBound
+                                                                             (Index
+                                                                                {level =
+                                                                                   2,
+                                                                                 offset =
+                                                                                   0}),
+                                                                         expInfo =
+                                                                           Info
+                                                                             {refsFree =
+                                                                                fromList
+                                                                                  []}})
+                                                                     (Exp
+                                                                        {unExp =
+                                                                           RefBound
+                                                                             (Index
+                                                                                {level =
+                                                                                   1,
+                                                                                 offset =
+                                                                                   0}),
+                                                                         expInfo =
+                                                                           Info
+                                                                             {refsFree =
+                                                                                fromList
+                                                                                  []}}),
+                                                                 expInfo =
+                                                                   Info
+                                                                     {refsFree =
+                                                                        fromList
+                                                                          []}})
+                                                             (Exp
+                                                                {unExp =
+                                                                   Abs
+                                                                     (AbsBinding
+                                                                        (ArgNamed
+                                                                           (Name
+                                                                              "f'"))
+                                                                        (Exp
+                                                                           {unExp =
+                                                                              App
+                                                                                (Exp
+                                                                                   {unExp =
+                                                                                      App
+                                                                                        (Exp
+                                                                                           {unExp =
+                                                                                              RefBound
+                                                                                                (Index
+                                                                                                   {level =
+                                                                                                      3,
+                                                                                                    offset =
+                                                                                                      0}),
+                                                                                            expInfo =
+                                                                                              Info
+                                                                                                {refsFree =
+                                                                                                   fromList
+                                                                                                     []}})
+                                                                                        (Exp
+                                                                                           {unExp =
+                                                                                              RefBound
+                                                                                                (Index
+                                                                                                   {level =
+                                                                                                      1,
+                                                                                                    offset =
+                                                                                                      0}),
+                                                                                            expInfo =
+                                                                                              Info
+                                                                                                {refsFree =
+                                                                                                   fromList
+                                                                                                     []}}),
+                                                                                    expInfo =
+                                                                                      Info
+                                                                                        {refsFree =
+                                                                                           fromList
+                                                                                             []}})
+                                                                                (Exp
+                                                                                   {unExp =
+                                                                                      Abs
+                                                                                        (AbsBinding
+                                                                                           (ArgNamed
+                                                                                              (Name
+                                                                                                 "a'"))
+                                                                                           (Exp
+                                                                                              {unExp =
+                                                                                                 App
+                                                                                                   (Exp
+                                                                                                      {unExp =
+                                                                                                         RefBound
+                                                                                                           (Index
+                                                                                                              {level =
+                                                                                                                 4,
+                                                                                                               offset =
+                                                                                                                 1}),
+                                                                                                       expInfo =
+                                                                                                         Info
+                                                                                                           {refsFree =
+                                                                                                              fromList
+                                                                                                                []}})
+                                                                                                   (Exp
+                                                                                                      {unExp =
+                                                                                                         App
+                                                                                                           (Exp
+                                                                                                              {unExp =
+                                                                                                                 RefBound
+                                                                                                                   (Index
+                                                                                                                      {level =
+                                                                                                                         1,
+                                                                                                                       offset =
+                                                                                                                         0}),
+                                                                                                               expInfo =
+                                                                                                                 Info
+                                                                                                                   {refsFree =
+                                                                                                                      fromList
+                                                                                                                        []}})
+                                                                                                           (Exp
+                                                                                                              {unExp =
+                                                                                                                 RefBound
+                                                                                                                   (Index
+                                                                                                                      {level =
+                                                                                                                         0,
+                                                                                                                       offset =
+                                                                                                                         0}),
+                                                                                                               expInfo =
+                                                                                                                 Info
+                                                                                                                   {refsFree =
+                                                                                                                      fromList
+                                                                                                                        []}}),
+                                                                                                       expInfo =
+                                                                                                         Info
+                                                                                                           {refsFree =
+                                                                                                              fromList
+                                                                                                                []}}),
+                                                                                               expInfo =
+                                                                                                 Info
+                                                                                                   {refsFree =
+                                                                                                      fromList
+                                                                                                        []}})),
+                                                                                    expInfo =
+                                                                                      Info
+                                                                                        {refsFree =
+                                                                                           fromList
+                                                                                             []}}),
+                                                                            expInfo =
+                                                                              Info
+                                                                                {refsFree =
+                                                                                   fromList
+                                                                                     []}})),
+                                                                 expInfo =
+                                                                   Info
+                                                                     {refsFree =
+                                                                        fromList
+                                                                          []}}),
+                                                         expInfo =
+                                                           Info
+                                                             {refsFree =
+                                                                fromList []}})),
+                                              expInfo =
+                                                Info
+                                                  {refsFree = fromList []}})),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo =
+                          Info
+                            {refsFree =
+                               fromList
+                                 [Imported
+                                    (ModuleName "Control.Applicative")
+                                    (Name "pure"),
+                                  Imported
+                                    (ModuleName "Control.Bind") (Name "bind"),
+                                  Imported
+                                    (ModuleName "Prim") (Name "undefined")]}})),
+             expInfo =
+               Info
+                 {refsFree =
+                    fromList
+                      [Imported
+                         (ModuleName "Control.Applicative") (Name "pure"),
+                       Imported (ModuleName "Control.Bind") (Name "bind"),
+                       Imported (ModuleName "Prim") (Name "undefined")]}})],
+    moduleImports =
+      [ModuleName "Control.Applicative",
+       ModuleName "Control.Bind",
+       ModuleName "Prim"],
+    moduleExports = [Name "ap"],
+    moduleReExports =
+      fromList
+        [(ModuleName "Control.Applicative", []),
+         (ModuleName "Control.Apply", []),
+         (ModuleName "Control.Bind", []),
+         (ModuleName "Data.Functor", [])],
+    moduleForeigns = [],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Control/Monad.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Data.Unit",
+    moduleBindings = [],
+    moduleImports = [],
+    moduleExports = [Name "unit"],
+    moduleReExports = fromList [],
+    moduleForeigns = [Name "unit"],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Data/Unit.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Effect",
+    moduleBindings =
+      [RecursiveGroup
+         ((Name "monadEffect",
+           Exp
+             {unExp =
+                Lit
+                  (Object
+                     [(PropName "Applicative0",
+                       Exp
+                         {unExp =
+                            Abs
+                              (AbsBinding
+                                 ArgUnused
+                                 (Exp
+                                    {unExp =
+                                       RefFree
+                                         (Local (Name "applicativeEffect")),
+                                     expInfo =
+                                       Info
+                                         {refsFree =
+                                            fromList
+                                              [Local
+                                                 (Name
+                                                    "applicativeEffect")]}})),
+                          expInfo =
+                            Info
+                              {refsFree =
+                                 fromList [Local (Name "applicativeEffect")]}}),
+                      (PropName "Bind1",
+                       Exp
+                         {unExp =
+                            Abs
+                              (AbsBinding
+                                 ArgUnused
+                                 (Exp
+                                    {unExp =
+                                       RefFree (Local (Name "bindEffect")),
+                                     expInfo =
+                                       Info
+                                         {refsFree =
+                                            fromList
+                                              [Local (Name "bindEffect")]}})),
+                          expInfo =
+                            Info
+                              {refsFree =
+                                 fromList [Local (Name "bindEffect")]}})]),
+              expInfo =
+                Info
+                  {refsFree =
+                     fromList
+                       [Local (Name "applicativeEffect"),
+                        Local (Name "bindEffect")]}})
+            :|
+            [(Name "bindEffect",
+              Exp
+                {unExp =
+                   Lit
+                     (Object
+                        [(PropName "bind",
+                          Exp
+                            {unExp = RefFree (Local (Name "bindE")),
+                             expInfo =
+                               Info
+                                 {refsFree = fromList [Local (Name "bindE")]}}),
+                         (PropName "Apply0",
+                          Exp
+                            {unExp =
+                               Abs
+                                 (AbsBinding
+                                    ArgUnused
+                                    (Exp
+                                       {unExp =
+                                          App
+                                            (Exp
+                                               {unExp =
+                                                  RefFree
+                                                    (Local
+                                                       (Name
+                                                          "$__lazy_applyEffect")),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree =
+                                                       fromList
+                                                         [Local
+                                                            (Name
+                                                               "$__lazy_applyEffect")]}})
+                                            (Exp
+                                               {unExp = Lit (Integer 0),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info
+                                            {refsFree =
+                                               fromList
+                                                 [Local
+                                                    (Name
+                                                       "$__lazy_applyEffect")]}})),
+                             expInfo =
+                               Info
+                                 {refsFree =
+                                    fromList
+                                      [Local (Name "$__lazy_applyEffect")]}})]),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList
+                          [Local (Name "$__lazy_applyEffect"),
+                           Local (Name "bindE")]}}),
+             (Name "applicativeEffect",
+              Exp
+                {unExp =
+                   Lit
+                     (Object
+                        [(PropName "pure",
+                          Exp
+                            {unExp = RefFree (Local (Name "pureE")),
+                             expInfo =
+                               Info
+                                 {refsFree = fromList [Local (Name "pureE")]}}),
+                         (PropName "Apply0",
+                          Exp
+                            {unExp =
+                               Abs
+                                 (AbsBinding
+                                    ArgUnused
+                                    (Exp
+                                       {unExp =
+                                          App
+                                            (Exp
+                                               {unExp =
+                                                  RefFree
+                                                    (Local
+                                                       (Name
+                                                          "$__lazy_applyEffect")),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree =
+                                                       fromList
+                                                         [Local
+                                                            (Name
+                                                               "$__lazy_applyEffect")]}})
+                                            (Exp
+                                               {unExp = Lit (Integer 0),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info
+                                            {refsFree =
+                                               fromList
+                                                 [Local
+                                                    (Name
+                                                       "$__lazy_applyEffect")]}})),
+                             expInfo =
+                               Info
+                                 {refsFree =
+                                    fromList
+                                      [Local (Name "$__lazy_applyEffect")]}})]),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList
+                          [Local (Name "$__lazy_applyEffect"),
+                           Local (Name "pureE")]}}),
+             (Name "$__lazy_functorEffect",
+              Exp
+                {unExp =
+                   App
+                     (Exp
+                        {unExp =
+                           App
+                             (Exp
+                                {unExp =
+                                   RefFree (Local (Name "$__runtime_lazy")),
+                                 expInfo =
+                                   Info
+                                     {refsFree =
+                                        fromList
+                                          [Local (Name "$__runtime_lazy")]}})
+                             (Exp
+                                {unExp = Lit (String "functorEffect"),
+                                 expInfo = Info {refsFree = fromList []}}),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList [Local (Name "$__runtime_lazy")]}})
+                     (Exp
+                        {unExp =
+                           Abs
+                             (AbsBinding
+                                ArgUnused
+                                (Exp
+                                   {unExp =
+                                      Lit
+                                        (Object
+                                           [(PropName "map",
+                                             Exp
+                                               {unExp =
+                                                  App
+                                                    (Exp
+                                                       {unExp =
+                                                          RefFree
+                                                            (Imported
+                                                               (ModuleName
+                                                                  "Control.Applicative")
+                                                               (Name "liftA1")),
+                                                        expInfo =
+                                                          Info
+                                                            {refsFree =
+                                                               fromList
+                                                                 [Imported
+                                                                    (ModuleName
+                                                                       "Control.Applicative")
+                                                                    (Name
+                                                                       "liftA1")]}})
+                                                    (Exp
+                                                       {unExp =
+                                                          RefFree
+                                                            (Local
+                                                               (Name
+                                                                  "applicativeEffect")),
+                                                        expInfo =
+                                                          Info
+                                                            {refsFree =
+                                                               fromList
+                                                                 [Local
+                                                                    (Name
+                                                                       "applicativeEffect")]}}),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree =
+                                                       fromList
+                                                         [Local
+                                                            (Name
+                                                               "applicativeEffect"),
+                                                          Imported
+                                                            (ModuleName
+                                                               "Control.Applicative")
+                                                            (Name
+                                                               "liftA1")]}})]),
+                                    expInfo =
+                                      Info
+                                        {refsFree =
+                                           fromList
+                                             [Local (Name "applicativeEffect"),
+                                              Imported
+                                                (ModuleName
+                                                   "Control.Applicative")
+                                                (Name "liftA1")]}})),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList
+                                  [Local (Name "applicativeEffect"),
+                                   Imported
+                                     (ModuleName "Control.Applicative")
+                                     (Name "liftA1")]}}),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList
+                          [Local (Name "$__runtime_lazy"),
+                           Local (Name "applicativeEffect"),
+                           Imported
+                             (ModuleName "Control.Applicative")
+                             (Name "liftA1")]}}),
+             (Name "$__lazy_applyEffect",
+              Exp
+                {unExp =
+                   App
+                     (Exp
+                        {unExp =
+                           App
+                             (Exp
+                                {unExp =
+                                   RefFree (Local (Name "$__runtime_lazy")),
+                                 expInfo =
+                                   Info
+                                     {refsFree =
+                                        fromList
+                                          [Local (Name "$__runtime_lazy")]}})
+                             (Exp
+                                {unExp = Lit (String "applyEffect"),
+                                 expInfo = Info {refsFree = fromList []}}),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList [Local (Name "$__runtime_lazy")]}})
+                     (Exp
+                        {unExp =
+                           Abs
+                             (AbsBinding
+                                ArgUnused
+                                (Exp
+                                   {unExp =
+                                      Lit
+                                        (Object
+                                           [(PropName "apply",
+                                             Exp
+                                               {unExp =
+                                                  App
+                                                    (Exp
+                                                       {unExp =
+                                                          RefFree
+                                                            (Imported
+                                                               (ModuleName
+                                                                  "Control.Monad")
+                                                               (Name "ap")),
+                                                        expInfo =
+                                                          Info
+                                                            {refsFree =
+                                                               fromList
+                                                                 [Imported
+                                                                    (ModuleName
+                                                                       "Control.Monad")
+                                                                    (Name
+                                                                       "ap")]}})
+                                                    (Exp
+                                                       {unExp =
+                                                          RefFree
+                                                            (Local
+                                                               (Name
+                                                                  "monadEffect")),
+                                                        expInfo =
+                                                          Info
+                                                            {refsFree =
+                                                               fromList
+                                                                 [Local
+                                                                    (Name
+                                                                       "monadEffect")]}}),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree =
+                                                       fromList
+                                                         [Local
+                                                            (Name
+                                                               "monadEffect"),
+                                                          Imported
+                                                            (ModuleName
+                                                               "Control.Monad")
+                                                            (Name "ap")]}}),
+                                            (PropName "Functor0",
+                                             Exp
+                                               {unExp =
+                                                  Abs
+                                                    (AbsBinding
+                                                       ArgUnused
+                                                       (Exp
+                                                          {unExp =
+                                                             App
+                                                               (Exp
+                                                                  {unExp =
+                                                                     RefFree
+                                                                       (Local
+                                                                          (Name
+                                                                             "$__lazy_functorEffect")),
+                                                                   expInfo =
+                                                                     Info
+                                                                       {refsFree =
+                                                                          fromList
+                                                                            [Local
+                                                                               (Name
+                                                                                  "$__lazy_functorEffect")]}})
+                                                               (Exp
+                                                                  {unExp =
+                                                                     Lit
+                                                                       (Integer
+                                                                          0),
+                                                                   expInfo =
+                                                                     Info
+                                                                       {refsFree =
+                                                                          fromList
+                                                                            []}}),
+                                                           expInfo =
+                                                             Info
+                                                               {refsFree =
+                                                                  fromList
+                                                                    [Local
+                                                                       (Name
+                                                                          "$__lazy_functorEffect")]}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree =
+                                                       fromList
+                                                         [Local
+                                                            (Name
+                                                               "$__lazy_functorEffect")]}})]),
+                                    expInfo =
+                                      Info
+                                        {refsFree =
+                                           fromList
+                                             [Local
+                                                (Name "$__lazy_functorEffect"),
+                                              Local (Name "monadEffect"),
+                                              Imported
+                                                (ModuleName "Control.Monad")
+                                                (Name "ap")]}})),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList
+                                  [Local (Name "$__lazy_functorEffect"),
+                                   Local (Name "monadEffect"),
+                                   Imported
+                                     (ModuleName "Control.Monad")
+                                     (Name "ap")]}}),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList
+                          [Local (Name "$__lazy_functorEffect"),
+                           Local (Name "$__runtime_lazy"),
+                           Local (Name "monadEffect"),
+                           Imported
+                             (ModuleName "Control.Monad") (Name "ap")]}}),
+             (Name "functorEffect",
+              Exp
+                {unExp =
+                   App
+                     (Exp
+                        {unExp =
+                           RefFree (Local (Name "$__lazy_functorEffect")),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList
+                                  [Local (Name "$__lazy_functorEffect")]}})
+                     (Exp
+                        {unExp = Lit (Integer 0),
+                         expInfo = Info {refsFree = fromList []}}),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList [Local (Name "$__lazy_functorEffect")]}}),
+             (Name "applyEffect",
+              Exp
+                {unExp =
+                   App
+                     (Exp
+                        {unExp =
+                           RefFree (Local (Name "$__lazy_applyEffect")),
+                         expInfo =
+                           Info
+                             {refsFree =
+                                fromList [Local (Name "$__lazy_applyEffect")]}})
+                     (Exp
+                        {unExp = Lit (Integer 0),
+                         expInfo = Info {refsFree = fromList []}}),
+                 expInfo =
+                   Info
+                     {refsFree =
+                        fromList [Local (Name "$__lazy_applyEffect")]}})])],
+    moduleImports =
+      [ModuleName "Control.Applicative",
+       ModuleName "Control.Monad"],
+    moduleExports =
+      [Name "functorEffect",
+       Name "applyEffect",
+       Name "applicativeEffect",
+       Name "bindEffect",
+       Name "monadEffect"],
+    moduleReExports = fromList [],
+    moduleForeigns = [Name "pureE", Name "bindE"],
+    modulePath =
+      ".spago/lua-effect/v4.0.0/src/Effect.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Golden.TestHelloPrelude",
+    moduleBindings =
+      [Standalone
+         (Name "main",
+          Exp
+            {unExp =
+               App
+                 (Exp
+                    {unExp =
+                       RefFree
+                         (Imported (ModuleName "Prelude") (Name "pass")),
+                     expInfo =
+                       Info
+                         {refsFree =
+                            fromList
+                              [Imported (ModuleName "Prelude") (Name "pass")]}})
+                 (Exp
+                    {unExp =
+                       RefFree
+                         (Imported
+                            (ModuleName "Effect") (Name "applicativeEffect")),
+                     expInfo =
+                       Info
+                         {refsFree =
+                            fromList
+                              [Imported
+                                 (ModuleName "Effect")
+                                 (Name "applicativeEffect")]}}),
+             expInfo =
+               Info
+                 {refsFree =
+                    fromList
+                      [Imported
+                         (ModuleName "Effect") (Name "applicativeEffect"),
+                       Imported (ModuleName "Prelude") (Name "pass")]}})],
+    moduleImports =
+      [ModuleName "Effect", ModuleName "Prelude"],
+    moduleExports = [Name "main"],
+    moduleReExports = fromList [],
+    moduleForeigns = [],
+    modulePath = "golden/Golden/TestHelloPrelude.purs",
+    dataTypes = fromList []},
+ Module
+   {moduleName = ModuleName "Prelude",
+    moduleBindings =
+      [Standalone
+         (Name "pass",
+          Exp
+            {unExp =
+               Abs
+                 (AbsBinding
+                    (ArgNamed (Name "dictApplicative"))
+                    (Exp
+                       {unExp =
+                          App
+                            (Exp
+                               {unExp =
+                                  App
+                                    (Exp
+                                       {unExp =
+                                          RefFree
+                                            (Imported
+                                               (ModuleName
+                                                  "Control.Applicative")
+                                               (Name "pure")),
+                                        expInfo =
+                                          Info
+                                            {refsFree =
+                                               fromList
+                                                 [Imported
+                                                    (ModuleName
+                                                       "Control.Applicative")
+                                                    (Name "pure")]}})
+                                    (Exp
+                                       {unExp =
+                                          RefBound
+                                            (Index {level = 0, offset = 0}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo =
+                                  Info
+                                    {refsFree =
+                                       fromList
+                                         [Imported
+                                            (ModuleName "Control.Applicative")
+                                            (Name "pure")]}})
+                            (Exp
+                               {unExp =
+                                  RefFree
+                                    (Imported
+                                       (ModuleName "Data.Unit") (Name "unit")),
+                                expInfo =
+                                  Info
+                                    {refsFree =
+                                       fromList
+                                         [Imported
+                                            (ModuleName "Data.Unit")
+                                            (Name "unit")]}}),
+                        expInfo =
+                          Info
+                            {refsFree =
+                               fromList
+                                 [Imported
+                                    (ModuleName "Control.Applicative")
+                                    (Name "pure"),
+                                  Imported
+                                    (ModuleName "Data.Unit") (Name "unit")]}})),
+             expInfo =
+               Info
+                 {refsFree =
+                    fromList
+                      [Imported
+                         (ModuleName "Control.Applicative") (Name "pure"),
+                       Imported (ModuleName "Data.Unit") (Name "unit")]}})],
+    moduleImports =
+      [ModuleName "Control.Applicative",
+       ModuleName "Data.Unit"],
+    moduleExports = [Name "pass"],
+    moduleReExports =
+      fromList
+        [(ModuleName "Control.Applicative", []),
+         (ModuleName "Control.Apply", []),
+         (ModuleName "Control.Bind", []),
+         (ModuleName "Control.Category", []),
+         (ModuleName "Control.Monad", []),
+         (ModuleName "Control.Semigroupoid", []),
+         (ModuleName "Data.Boolean", []),
+         (ModuleName "Data.BooleanAlgebra", []),
+         (ModuleName "Data.Bounded", []),
+         (ModuleName "Data.CommutativeRing", []),
+         (ModuleName "Data.DivisionRing", []),
+         (ModuleName "Data.Eq", []),
+         (ModuleName "Data.EuclideanRing", []),
+         (ModuleName "Data.Field", []),
+         (ModuleName "Data.Function", []),
+         (ModuleName "Data.Functor", []),
+         (ModuleName "Data.HeytingAlgebra", []),
+         (ModuleName "Data.Monoid", []),
+         (ModuleName "Data.NaturalTransformation", []),
+         (ModuleName "Data.Ord", []),
+         (ModuleName "Data.Ordering", []),
+         (ModuleName "Data.Ring", []),
+         (ModuleName "Data.Semigroup", []),
+         (ModuleName "Data.Semiring", []),
+         (ModuleName "Data.Show", []),
+         (ModuleName "Data.Unit", []),
+         (ModuleName "Data.Void", [])],
+    moduleForeigns = [],
+    modulePath =
+      ".spago/lua-prelude/v6.0.2/src/Prelude.purs",
+    dataTypes = fromList []}]

--- a/test/ps/output/Golden.TestHelloPrelude/golden.lua
+++ b/test/ps/output/Golden.TestHelloPrelude/golden.lua
@@ -1,0 +1,136 @@
+local _S___runtime_lazy = function(name)
+  return function(init)
+    local state = 0
+    local val = nil
+    return function(lineNumber)
+      if state == 2 then
+        return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
+      else
+        state = 1
+        val = init()
+        state = 2
+        return val
+      end
+    end
+  end
+end
+local Control_Apply_I_apply = function(dict0)
+  local v1 = dict0
+  return v1.apply
+end
+local Prim_I_undefined = nil
+local Control_Applicative_I_pure = function(dict0)
+  local v1 = dict0
+  return v1.pure
+end
+local Control_Applicative_I_liftA1 = function(dictApplicative2)
+  return function(f5)
+    local apply3 = Control_Apply_I_apply(dictApplicative2.Apply0(Prim_I_undefined))
+    local pure14 = Control_Applicative_I_pure(dictApplicative2)
+    return function(a6) return apply3(pure14(f5))(a6) end
+  end
+end
+local Control_Bind_I_bind = function(dict0) local v1 = dict0 return v1.bind end
+local Control_Monad_I_ap = function(dictMonad0)
+  return function(f3)
+    local bind1 = Control_Bind_I_bind(dictMonad0.Bind1(Prim_I_undefined))
+    local pure2 = Control_Applicative_I_pure(dictMonad0.Applicative0(Prim_I_undefined))
+    return function(a4)
+      return bind1(f3)(function(fPrime5)
+        return bind1(a4)(function(aPrime6) return pure2(fPrime5(aPrime6)) end)
+      end)
+    end
+  end
+end
+local Data_Unit_I_foreign = (function() return { unit = nil }  end)()
+local Data_Unit_I_unit = Data_Unit_I_foreign.unit
+local Effect_I_foreign = (function()
+  return {
+
+    pureE = function(a)
+      return function()
+        return a
+      end
+    end
+
+    , bindE = function(a)
+      return function(f)
+        return function()
+          return f(a())()
+        end
+      end
+    end
+
+    , untilE = function(f)
+      return function()
+        while not f() do end
+      end
+    end
+
+    , whileE = function(f)
+      return function(a)
+        return function()
+          while f() do
+            a()
+          end
+        end
+      end
+    end
+
+    , forE = function(lo)
+      return function(hi)
+        return function(f)
+          return function()
+            for i = lo, hi do
+              f(i)()
+            end
+          end
+        end
+      end
+    end
+
+    , foreachE = function(as)
+      return function(f)
+        return function()
+          for i, v in ipairs(as) do
+            f(v)()
+          end
+        end
+      end
+    end
+
+  }
+
+end)()
+local Effect_I_pureE = Effect_I_foreign.pureE
+local Effect_I_bindE = Effect_I_foreign.bindE
+local Effect_I_monadEffect, Effect_I_bindEffect, Effect_I_applicativeEffect, Effect_I__S___lazy_functorEffect, Effect_I__S___lazy_applyEffect, Effect_I_functorEffect, Effect_I_applyEffect
+Effect_I_monadEffect = {
+  Applicative0 = function() return Effect_I_applicativeEffect end,
+  Bind1 = function() return Effect_I_bindEffect end
+}
+Effect_I_bindEffect = {
+  bind = Effect_I_bindE,
+  Apply0 = function() return Effect_I__S___lazy_applyEffect(0) end
+}
+Effect_I_applicativeEffect = {
+  pure = Effect_I_pureE,
+  Apply0 = function() return Effect_I__S___lazy_applyEffect(0) end
+}
+Effect_I__S___lazy_functorEffect = _S___runtime_lazy("functorEffect")(function()
+  return { map = Control_Applicative_I_liftA1(Effect_I_applicativeEffect) }
+end)
+Effect_I__S___lazy_applyEffect = _S___runtime_lazy("applyEffect")(function()
+  return {
+    apply = Control_Monad_I_ap(Effect_I_monadEffect),
+    Functor0 = function() return Effect_I__S___lazy_functorEffect(0) end
+  }
+end)
+Effect_I_functorEffect = Effect_I__S___lazy_functorEffect(0)
+Effect_I_applyEffect = Effect_I__S___lazy_applyEffect(0)
+local Prelude_I_pass = function(dictApplicative0)
+  return Control_Applicative_I_pure(dictApplicative0)(Data_Unit_I_unit)
+end
+local Golden_TestHelloPrelude_I_main = Prelude_I_pass(Effect_I_applicativeEffect)

--- a/test/ps/output/Golden.TestNewtype/golden.ir
+++ b/test/ps/output/Golden.TestNewtype/golden.ir
@@ -10,13 +10,14 @@
                     (ArgNamed (Name "x"))
                     (Exp
                        {unExp = RefBound (Index {level = 0, offset = 0}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "g",
           Exp
             {unExp = RefFree (Local (Name "NT")),
-             expInfo = Info {refsFree = [Local (Name "NT")]}}),
+             expInfo =
+               Info {refsFree = fromList [Local (Name "NT")]}}),
        Standalone
          (Name "f",
           Exp
@@ -34,7 +35,7 @@
                                      {unExp =
                                         RefBound
                                           (Index {level = 1, offset = 0}),
-                                      expInfo = Info {refsFree = []}})
+                                      expInfo = Info {refsFree = fromList []}})
                                   :|
                                   [])
                                (Exp
@@ -44,11 +45,12 @@
                                           {unExp =
                                              RefBound
                                                (Index {level = 0, offset = 0}),
-                                           expInfo = Info {refsFree = []}})
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (PropName "foo"),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "NT", Name "f", Name "g"],
     moduleReExports = fromList [],

--- a/test/ps/output/Golden.TestNewtype/golden.lua
+++ b/test/ps/output/Golden.TestNewtype/golden.lua
@@ -1,6 +1,3 @@
-local Golden_TestNewtype = (function()
-  local NT = function(x0) return x0 end
-  local g = NT
-  local f = function(v1) local n2 = v1 return n2.foo end
-  return { NT = NT, f = f, g = g }
-end)()
+local Golden_TestNewtype_I_NT = function(x0) return x0 end
+local Golden_TestNewtype_I_g = Golden_TestNewtype_I_NT
+local Golden_TestNewtype_I_f = function(v1) local n2 = v1 return n2.foo end

--- a/test/ps/output/Golden.TestPatternMatching1/golden.ir
+++ b/test/ps/output/Golden.TestPatternMatching1/golden.ir
@@ -7,7 +7,7 @@
           Exp
             {unExp =
                Ctor SumType (TyName "N") (CtorName "Zero") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Succ",
           Exp
@@ -17,7 +17,7 @@
                  (TyName "N")
                  (CtorName "Succ")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Num",
           Exp
@@ -27,7 +27,7 @@
                  (TyName "E")
                  (CtorName "Num")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Not",
           Exp
@@ -37,7 +37,7 @@
                  (TyName "E")
                  (CtorName "Not")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "pat",
           Exp
@@ -57,7 +57,8 @@
                                              Lit
                                                (String
                                                   "Golden.TestPatternMatching1.Not"),
-                                           expInfo = Info {refsFree = []}})
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp =
                                              Prim
@@ -69,9 +70,12 @@
                                                              {level = 0,
                                                               offset = 0}),
                                                       expInfo =
-                                                        Info {refsFree = []}})),
-                                           expInfo = Info {refsFree = []}})),
-                                expInfo = Info {refsFree = []}})
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})),
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp =
                                   IfThenElse
@@ -85,7 +89,9 @@
                                                        (String
                                                           "Golden.TestPatternMatching1.Num"),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp =
                                                      Prim
@@ -104,15 +110,20 @@
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})
+                                                                             fromList
+                                                                               []}})
                                                                   0,
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}})),
+                                                                     fromList
+                                                                       []}})),
                                                    expInfo =
-                                                     Info {refsFree = []}})),
-                                        expInfo = Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           IfThenElse
@@ -127,7 +138,8 @@
                                                                   "Golden.TestPatternMatching1.Succ"),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Prim
@@ -149,25 +161,33 @@
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   0,
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           0,
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}})),
-                                                expInfo = Info {refsFree = []}})
+                                                                  fromList
+                                                                    []}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 1),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp =
                                                   IfThenElse
@@ -183,7 +203,8 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})
+                                                                          fromList
+                                                                            []}})
                                                                (Exp
                                                                   {unExp =
                                                                      Prim
@@ -205,35 +226,46 @@
                                                                                               expInfo =
                                                                                                 Info
                                                                                                   {refsFree =
-                                                                                                     []}})
+                                                                                                     fromList
+                                                                                                       []}})
                                                                                           0,
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   0,
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})),
+                                                                                     fromList
+                                                                                       []}})),
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})),
+                                                                          fromList
+                                                                            []}})),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 2),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 6),
                                                         expInfo =
                                                           Info
-                                                            {refsFree = []}}),
+                                                            {refsFree =
+                                                               fromList []}}),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           IfThenElse
@@ -248,7 +280,8 @@
                                                                   "Golden.TestPatternMatching1.Not"),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Prim
@@ -267,17 +300,22 @@
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           0,
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}})),
-                                                expInfo = Info {refsFree = []}})
+                                                                  fromList
+                                                                    []}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp =
                                                   IfThenElse
@@ -293,7 +331,8 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})
+                                                                          fromList
+                                                                            []}})
                                                                (Exp
                                                                   {unExp =
                                                                      Prim
@@ -315,23 +354,29 @@
                                                                                               expInfo =
                                                                                                 Info
                                                                                                   {refsFree =
-                                                                                                     []}})
+                                                                                                     fromList
+                                                                                                       []}})
                                                                                           0,
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   0,
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})),
+                                                                                     fromList
+                                                                                       []}})),
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})),
+                                                                          fromList
+                                                                            []}})),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp =
                                                           IfThenElse
@@ -347,7 +392,8 @@
                                                                            expInfo =
                                                                              Info
                                                                                {refsFree =
-                                                                                  []}})
+                                                                                  fromList
+                                                                                    []}})
                                                                        (Exp
                                                                           {unExp =
                                                                              Prim
@@ -372,30 +418,36 @@
                                                                                                               expInfo =
                                                                                                                 Info
                                                                                                                   {refsFree =
-                                                                                                                     []}})
+                                                                                                                     fromList
+                                                                                                                       []}})
                                                                                                           0,
                                                                                                       expInfo =
                                                                                                         Info
                                                                                                           {refsFree =
-                                                                                                             []}})
+                                                                                                             fromList
+                                                                                                               []}})
                                                                                                   0,
                                                                                               expInfo =
                                                                                                 Info
                                                                                                   {refsFree =
-                                                                                                     []}})
+                                                                                                     fromList
+                                                                                                       []}})
                                                                                           0,
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})),
+                                                                                             fromList
+                                                                                               []}})),
                                                                            expInfo =
                                                                              Info
                                                                                {refsFree =
-                                                                                  []}})),
+                                                                                  fromList
+                                                                                    []}})),
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}})
+                                                                       fromList
+                                                                         []}})
                                                             (Exp
                                                                {unExp =
                                                                   Lit
@@ -403,7 +455,8 @@
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}})
+                                                                       fromList
+                                                                         []}})
                                                             (Exp
                                                                {unExp =
                                                                   Lit
@@ -411,21 +464,29 @@
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}}),
+                                                                       fromList
+                                                                         []}}),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 6),
                                                         expInfo =
                                                           Info
-                                                            {refsFree = []}}),
-                                                expInfo = Info {refsFree = []}})
+                                                            {refsFree =
+                                                               fromList []}}),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 6),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp =
                                   IfThenElse
@@ -439,7 +500,9 @@
                                                        (String
                                                           "Golden.TestPatternMatching1.Num"),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp =
                                                      Prim
@@ -454,10 +517,14 @@
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}})),
+                                                                     fromList
+                                                                       []}})),
                                                    expInfo =
-                                                     Info {refsFree = []}})),
-                                        expInfo = Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           IfThenElse
@@ -472,7 +539,8 @@
                                                                   "Golden.TestPatternMatching1.Succ"),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Prim
@@ -491,31 +559,41 @@
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           0,
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}})),
-                                                expInfo = Info {refsFree = []}})
+                                                                  fromList
+                                                                    []}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 4),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 5),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp = Lit (Integer 6),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports =
       [Name "Zero",

--- a/test/ps/output/Golden.TestPatternMatching1/golden.lua
+++ b/test/ps/output/Golden.TestPatternMatching1/golden.lua
@@ -1,70 +1,67 @@
-local Golden_TestPatternMatching1 = (function()
-  local Zero = function()
-    return { ["$ctor"] = "Golden_TestPatternMatching1.Zero" }
+local Golden_TestPatternMatching1_I_Zero = function()
+  return { ["$ctor"] = "Golden_TestPatternMatching1.Zero" }
+end
+local Golden_TestPatternMatching1_I_Succ = function(value0)
+  return { ["$ctor"] = "Golden_TestPatternMatching1.Succ", value0 = value0 }
+end
+local Golden_TestPatternMatching1_I_Num = function(value0)
+  return { ["$ctor"] = "Golden_TestPatternMatching1.Num", value0 = value0 }
+end
+local Golden_TestPatternMatching1_I_Not = function(value0)
+  return { ["$ctor"] = "Golden_TestPatternMatching1.Not", value0 = value0 }
+end
+local Golden_TestPatternMatching1_I_pat = function(e0)
+  if "Golden.TestPatternMatching1.Not" == e0["$ctor"] then
+    return (function()
+      if "Golden.TestPatternMatching1.Num" == e0[0]["$ctor"] then
+        return (function()
+          if "Golden.TestPatternMatching1.Succ" == e0[0][0]["$ctor"] then
+            return 1
+          else
+            return (function()
+              if "Golden.TestPatternMatching1.Zero" == e0[0][0]["$ctor"] then
+                return 2
+              else
+                return 6
+              end
+            end)()
+          end
+        end)()
+      else
+        return (function()
+          if "Golden.TestPatternMatching1.Not" == e0[0]["$ctor"] then
+            return (function()
+              if "Golden.TestPatternMatching1.Num" == e0[0][0]["$ctor"] then
+                return (function()
+                  if "Golden.TestPatternMatching1.Succ" == e0[0][0][0]["$ctor"] then
+                    return 3
+                  else
+                    return 6
+                  end
+                end)()
+              else
+                return 6
+              end
+            end)()
+          else
+            return 6
+          end
+        end)()
+      end
+    end)()
+  else
+    return (function()
+      if "Golden.TestPatternMatching1.Num" == e0["$ctor"] then
+        return (function()
+          if "Golden.TestPatternMatching1.Succ" == e0[0]["$ctor"] then
+            return 4
+          else
+            return 5
+          end
+        end)()
+      else
+        return 6
+      end
+    end)()
   end
-  local Succ = function(value0)
-    return { ["$ctor"] = "Golden_TestPatternMatching1.Succ", value0 = value0 }
-  end
-  local Num = function(value0)
-    return { ["$ctor"] = "Golden_TestPatternMatching1.Num", value0 = value0 }
-  end
-  local Not = function(value0)
-    return { ["$ctor"] = "Golden_TestPatternMatching1.Not", value0 = value0 }
-  end
-  local pat = function(e0)
-    if "Golden.TestPatternMatching1.Not" == e0["$ctor"] then
-      return (function()
-        if "Golden.TestPatternMatching1.Num" == e0[0]["$ctor"] then
-          return (function()
-            if "Golden.TestPatternMatching1.Succ" == e0[0][0]["$ctor"] then
-              return 1
-            else
-              return (function()
-                if "Golden.TestPatternMatching1.Zero" == e0[0][0]["$ctor"] then
-                  return 2
-                else
-                  return 6
-                end
-              end)()
-            end
-          end)()
-        else
-          return (function()
-            if "Golden.TestPatternMatching1.Not" == e0[0]["$ctor"] then
-              return (function()
-                if "Golden.TestPatternMatching1.Num" == e0[0][0]["$ctor"] then
-                  return (function()
-                    if "Golden.TestPatternMatching1.Succ" == e0[0][0][0]["$ctor"] then
-                      return 3
-                    else
-                      return 6
-                    end
-                  end)()
-                else
-                  return 6
-                end
-              end)()
-            else
-              return 6
-            end
-          end)()
-        end
-      end)()
-    else
-      return (function()
-        if "Golden.TestPatternMatching1.Num" == e0["$ctor"] then
-          return (function()
-            if "Golden.TestPatternMatching1.Succ" == e0[0]["$ctor"] then
-              return 4
-            else
-              return 5
-            end
-          end)()
-        else
-          return 6
-        end
-      end)()
-    end
-  end
-  return { Zero = Zero, Succ = Succ, Num = Num, Not = Not, pat = pat }
-end)()
+end

--- a/test/ps/output/Golden.TestPatternMatching2/golden.ir
+++ b/test/ps/output/Golden.TestPatternMatching2/golden.ir
@@ -7,7 +7,7 @@
           Exp
             {unExp =
                Ctor SumType (TyName "N") (CtorName "Zero") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Succ",
           Exp
@@ -17,7 +17,7 @@
                  (TyName "N")
                  (CtorName "Succ")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Add",
           Exp
@@ -27,7 +27,7 @@
                  (TyName "N")
                  (CtorName "Add")
                  [FieldName "value0", FieldName "value1"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "Mul",
           Exp
@@ -37,7 +37,7 @@
                  (TyName "N")
                  (CtorName "Mul")
                  [FieldName "value0", FieldName "value1"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "pat",
           Exp
@@ -57,7 +57,8 @@
                                              Lit
                                                (String
                                                   "Golden.TestPatternMatching2.Add"),
-                                           expInfo = Info {refsFree = []}})
+                                           expInfo =
+                                             Info {refsFree = fromList []}})
                                        (Exp
                                           {unExp =
                                              Prim
@@ -69,9 +70,12 @@
                                                              {level = 0,
                                                               offset = 0}),
                                                       expInfo =
-                                                        Info {refsFree = []}})),
-                                           expInfo = Info {refsFree = []}})),
-                                expInfo = Info {refsFree = []}})
+                                                        Info
+                                                          {refsFree =
+                                                             fromList []}})),
+                                           expInfo =
+                                             Info {refsFree = fromList []}})),
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp =
                                   IfThenElse
@@ -85,7 +89,9 @@
                                                        (String
                                                           "Golden.TestPatternMatching2.Zero"),
                                                    expInfo =
-                                                     Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})
                                                (Exp
                                                   {unExp =
                                                      Prim
@@ -104,15 +110,20 @@
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})
+                                                                             fromList
+                                                                               []}})
                                                                   1,
                                                               expInfo =
                                                                 Info
                                                                   {refsFree =
-                                                                     []}})),
+                                                                     fromList
+                                                                       []}})),
                                                    expInfo =
-                                                     Info {refsFree = []}})),
-                                        expInfo = Info {refsFree = []}})
+                                                     Info
+                                                       {refsFree =
+                                                          fromList []}})),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           IfThenElse
@@ -127,7 +138,8 @@
                                                                   "Golden.TestPatternMatching2.Add"),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Prim
@@ -146,20 +158,27 @@
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           0,
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}})),
-                                                expInfo = Info {refsFree = []}})
+                                                                  fromList
+                                                                    []}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 1),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp =
                                                   IfThenElse
@@ -175,7 +194,8 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})
+                                                                          fromList
+                                                                            []}})
                                                                (Exp
                                                                   {unExp =
                                                                      Prim
@@ -194,30 +214,40 @@
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   0,
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})),
+                                                                                     fromList
+                                                                                       []}})),
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})),
+                                                                          fromList
+                                                                            []}})),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 2),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 5),
                                                         expInfo =
                                                           Info
-                                                            {refsFree = []}}),
+                                                            {refsFree =
+                                                               fromList []}}),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           IfThenElse
@@ -232,7 +262,8 @@
                                                                   "Golden.TestPatternMatching2.Mul"),
                                                            expInfo =
                                                              Info
-                                                               {refsFree = []}})
+                                                               {refsFree =
+                                                                  fromList []}})
                                                        (Exp
                                                           {unExp =
                                                              Prim
@@ -251,20 +282,27 @@
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})
+                                                                                     fromList
+                                                                                       []}})
                                                                           1,
                                                                       expInfo =
                                                                         Info
                                                                           {refsFree =
-                                                                             []}})),
+                                                                             fromList
+                                                                               []}})),
                                                            expInfo =
                                                              Info
                                                                {refsFree =
-                                                                  []}})),
-                                                expInfo = Info {refsFree = []}})
+                                                                  fromList
+                                                                    []}})),
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp = Lit (Integer 3),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp =
                                                   IfThenElse
@@ -280,7 +318,8 @@
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})
+                                                                          fromList
+                                                                            []}})
                                                                (Exp
                                                                   {unExp =
                                                                      Prim
@@ -299,22 +338,29 @@
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})
+                                                                                             fromList
+                                                                                               []}})
                                                                                   1,
                                                                               expInfo =
                                                                                 Info
                                                                                   {refsFree =
-                                                                                     []}})),
+                                                                                     fromList
+                                                                                       []}})),
                                                                    expInfo =
                                                                      Info
                                                                        {refsFree =
-                                                                          []}})),
+                                                                          fromList
+                                                                            []}})),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp = Lit (Integer 4),
                                                         expInfo =
-                                                          Info {refsFree = []}})
+                                                          Info
+                                                            {refsFree =
+                                                               fromList []}})
                                                     (Exp
                                                        {unExp =
                                                           IfThenElse
@@ -330,7 +376,8 @@
                                                                            expInfo =
                                                                              Info
                                                                                {refsFree =
-                                                                                  []}})
+                                                                                  fromList
+                                                                                    []}})
                                                                        (Exp
                                                                           {unExp =
                                                                              Prim
@@ -349,20 +396,24 @@
                                                                                               expInfo =
                                                                                                 Info
                                                                                                   {refsFree =
-                                                                                                     []}})
+                                                                                                     fromList
+                                                                                                       []}})
                                                                                           1,
                                                                                       expInfo =
                                                                                         Info
                                                                                           {refsFree =
-                                                                                             []}})),
+                                                                                             fromList
+                                                                                               []}})),
                                                                            expInfo =
                                                                              Info
                                                                                {refsFree =
-                                                                                  []}})),
+                                                                                  fromList
+                                                                                    []}})),
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}})
+                                                                       fromList
+                                                                         []}})
                                                             (Exp
                                                                {unExp =
                                                                   Lit
@@ -370,7 +421,8 @@
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}})
+                                                                       fromList
+                                                                         []}})
                                                             (Exp
                                                                {unExp =
                                                                   Lit
@@ -378,19 +430,23 @@
                                                                 expInfo =
                                                                   Info
                                                                     {refsFree =
-                                                                       []}}),
+                                                                       fromList
+                                                                         []}}),
                                                         expInfo =
                                                           Info
-                                                            {refsFree = []}}),
+                                                            {refsFree =
+                                                               fromList []}}),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp = Lit (Integer 6),
-                                expInfo = Info {refsFree = []}}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                expInfo = Info {refsFree = fromList []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports =
       [Name "Zero",

--- a/test/ps/output/Golden.TestPatternMatching2/golden.lua
+++ b/test/ps/output/Golden.TestPatternMatching2/golden.lua
@@ -1,66 +1,63 @@
-local Golden_TestPatternMatching2 = (function()
-  local Zero = function()
-    return { ["$ctor"] = "Golden_TestPatternMatching2.Zero" }
+local Golden_TestPatternMatching2_I_Zero = function()
+  return { ["$ctor"] = "Golden_TestPatternMatching2.Zero" }
+end
+local Golden_TestPatternMatching2_I_Succ = function(value0)
+  return { ["$ctor"] = "Golden_TestPatternMatching2.Succ", value0 = value0 }
+end
+local Golden_TestPatternMatching2_I_Add = function(value0, value1)
+  return {
+    ["$ctor"] = "Golden_TestPatternMatching2.Add",
+    value0 = value0,
+    value1 = value1
+  }
+end
+local Golden_TestPatternMatching2_I_Mul = function(value0, value1)
+  return {
+    ["$ctor"] = "Golden_TestPatternMatching2.Mul",
+    value0 = value0,
+    value1 = value1
+  }
+end
+local Golden_TestPatternMatching2_I_pat = function(e0)
+  if "Golden.TestPatternMatching2.Add" == e0["$ctor"] then
+    return (function()
+      if "Golden.TestPatternMatching2.Zero" == e0[1]["$ctor"] then
+        return (function()
+          if "Golden.TestPatternMatching2.Add" == e0[0]["$ctor"] then
+            return 1
+          else
+            return (function()
+              if "Golden.TestPatternMatching2.Mul" == e0[0]["$ctor"] then
+                return 2
+              else
+                return 5
+              end
+            end)()
+          end
+        end)()
+      else
+        return (function()
+          if "Golden.TestPatternMatching2.Mul" == e0[1]["$ctor"] then
+            return 3
+          else
+            return (function()
+              if "Golden.TestPatternMatching2.Add" == e0[1]["$ctor"] then
+                return 4
+              else
+                return (function()
+                  if "Golden.TestPatternMatching2.Zero" == e0[1]["$ctor"] then
+                    return 5
+                  else
+                    return 6
+                  end
+                end)()
+              end
+            end)()
+          end
+        end)()
+      end
+    end)()
+  else
+    return 6
   end
-  local Succ = function(value0)
-    return { ["$ctor"] = "Golden_TestPatternMatching2.Succ", value0 = value0 }
-  end
-  local Add = function(value0, value1)
-    return {
-      ["$ctor"] = "Golden_TestPatternMatching2.Add",
-      value0 = value0,
-      value1 = value1
-    }
-  end
-  local Mul = function(value0, value1)
-    return {
-      ["$ctor"] = "Golden_TestPatternMatching2.Mul",
-      value0 = value0,
-      value1 = value1
-    }
-  end
-  local pat = function(e0)
-    if "Golden.TestPatternMatching2.Add" == e0["$ctor"] then
-      return (function()
-        if "Golden.TestPatternMatching2.Zero" == e0[1]["$ctor"] then
-          return (function()
-            if "Golden.TestPatternMatching2.Add" == e0[0]["$ctor"] then
-              return 1
-            else
-              return (function()
-                if "Golden.TestPatternMatching2.Mul" == e0[0]["$ctor"] then
-                  return 2
-                else
-                  return 5
-                end
-              end)()
-            end
-          end)()
-        else
-          return (function()
-            if "Golden.TestPatternMatching2.Mul" == e0[1]["$ctor"] then
-              return 3
-            else
-              return (function()
-                if "Golden.TestPatternMatching2.Add" == e0[1]["$ctor"] then
-                  return 4
-                else
-                  return (function()
-                    if "Golden.TestPatternMatching2.Zero" == e0[1]["$ctor"] then
-                      return 5
-                    else
-                      return 6
-                    end
-                  end)()
-                end
-              end)()
-            end
-          end)()
-        end
-      end)()
-    else
-      return 6
-    end
-  end
-  return { Zero = Zero, Succ = Succ, Add = Add, Mul = Mul, pat = pat }
-end)()
+end

--- a/test/ps/output/Golden.TestRecDataDefs/golden.ir
+++ b/test/ps/output/Golden.TestRecDataDefs/golden.ir
@@ -5,7 +5,7 @@
          (Name "A",
           Exp
             {unExp = Ctor SumType (TyName "A") (CtorName "A") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "AB",
           Exp
@@ -15,12 +15,12 @@
                  (TyName "A")
                  (CtorName "AB")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "B",
           Exp
             {unExp = Ctor SumType (TyName "B") (CtorName "B") [],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "BA",
           Exp
@@ -30,12 +30,13 @@
                  (TyName "B")
                  (CtorName "BA")
                  [FieldName "value0"],
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "b",
           Exp
             {unExp = RefFree (Local (Name "B")),
-             expInfo = Info {refsFree = [Local (Name "B")]}}),
+             expInfo =
+               Info {refsFree = fromList [Local (Name "B")]}}),
        Standalone
          (Name "ab",
           Exp
@@ -43,13 +44,16 @@
                App
                  (Exp
                     {unExp = RefFree (Local (Name "AB")),
-                     expInfo = Info {refsFree = [Local (Name "AB")]}})
+                     expInfo =
+                       Info {refsFree = fromList [Local (Name "AB")]}})
                  (Exp
                     {unExp = RefFree (Local (Name "b")),
-                     expInfo = Info {refsFree = [Local (Name "b")]}}),
+                     expInfo =
+                       Info {refsFree = fromList [Local (Name "b")]}}),
              expInfo =
                Info
-                 {refsFree = [Local (Name "AB"), Local (Name "b")]}}),
+                 {refsFree =
+                    fromList [Local (Name "AB"), Local (Name "b")]}}),
        Standalone
          (Name "ba",
           Exp
@@ -57,19 +61,22 @@
                App
                  (Exp
                     {unExp = RefFree (Local (Name "BA")),
-                     expInfo = Info {refsFree = [Local (Name "BA")]}})
+                     expInfo =
+                       Info {refsFree = fromList [Local (Name "BA")]}})
                  (Exp
                     {unExp = RefFree (Local (Name "ab")),
-                     expInfo = Info {refsFree = [Local (Name "ab")]}}),
+                     expInfo =
+                       Info {refsFree = fromList [Local (Name "ab")]}}),
              expInfo =
                Info
                  {refsFree =
-                    [Local (Name "BA"), Local (Name "ab")]}}),
+                    fromList [Local (Name "BA"), Local (Name "ab")]}}),
        Standalone
          (Name "a",
           Exp
             {unExp = RefFree (Local (Name "A")),
-             expInfo = Info {refsFree = [Local (Name "A")]}})],
+             expInfo =
+               Info {refsFree = fromList [Local (Name "A")]}})],
     moduleImports = [],
     moduleExports =
       [Name "A",

--- a/test/ps/output/Golden.TestRecDataDefs/golden.lua
+++ b/test/ps/output/Golden.TestRecDataDefs/golden.lua
@@ -1,15 +1,16 @@
-local Golden_TestRecDataDefs = (function()
-  local A = function() return { ["$ctor"] = "Golden_TestRecDataDefs.A" } end
-  local AB = function(value0)
-    return { ["$ctor"] = "Golden_TestRecDataDefs.AB", value0 = value0 }
-  end
-  local B = function() return { ["$ctor"] = "Golden_TestRecDataDefs.B" } end
-  local BA = function(value0)
-    return { ["$ctor"] = "Golden_TestRecDataDefs.BA", value0 = value0 }
-  end
-  local b = B
-  local ab = AB(b)
-  local ba = BA(ab)
-  local a = A
-  return { A = A, AB = AB, B = B, BA = BA, a = a, b = b, ab = ab, ba = ba }
-end)()
+local Golden_TestRecDataDefs_I_A = function()
+  return { ["$ctor"] = "Golden_TestRecDataDefs.A" }
+end
+local Golden_TestRecDataDefs_I_AB = function(value0)
+  return { ["$ctor"] = "Golden_TestRecDataDefs.AB", value0 = value0 }
+end
+local Golden_TestRecDataDefs_I_B = function()
+  return { ["$ctor"] = "Golden_TestRecDataDefs.B" }
+end
+local Golden_TestRecDataDefs_I_BA = function(value0)
+  return { ["$ctor"] = "Golden_TestRecDataDefs.BA", value0 = value0 }
+end
+local Golden_TestRecDataDefs_I_b = Golden_TestRecDataDefs_I_B
+local Golden_TestRecDataDefs_I_ab = Golden_TestRecDataDefs_I_AB(Golden_TestRecDataDefs_I_b)
+local Golden_TestRecDataDefs_I_ba = Golden_TestRecDataDefs_I_BA(Golden_TestRecDataDefs_I_ab)
+local Golden_TestRecDataDefs_I_a = Golden_TestRecDataDefs_I_A

--- a/test/ps/output/Golden.TestRecordsAccess/golden.ir
+++ b/test/ps/output/Golden.TestRecordsAccess/golden.ir
@@ -22,17 +22,18 @@
                                                 RefBound
                                                   (Index
                                                      {level = 1, offset = 0}),
-                                              expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}})
                                           (PropName "x"),
-                                      expInfo = Info {refsFree = []}})
+                                      expInfo = Info {refsFree = fromList []}})
                                   :|
                                   [])
                                (Exp
                                   {unExp =
                                      RefBound (Index {level = 0, offset = 0}),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "test3",
           Exp
@@ -54,17 +55,18 @@
                                                 RefBound
                                                   (Index
                                                      {level = 1, offset = 0}),
-                                              expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}})
                                           (PropName "x"),
-                                      expInfo = Info {refsFree = []}})
+                                      expInfo = Info {refsFree = fromList []}})
                                   :|
                                   [])
                                (Exp
                                   {unExp =
                                      RefBound (Index {level = 0, offset = 0}),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "test2",
           Exp
@@ -78,10 +80,10 @@
                             (Exp
                                {unExp =
                                   RefBound (Index {level = 0, offset = 0}),
-                                expInfo = Info {refsFree = []}})
+                                expInfo = Info {refsFree = fromList []}})
                             (PropName "x"),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "r",
           Exp
@@ -91,12 +93,12 @@
                     [(PropName "x",
                       Exp
                         {unExp = Lit (Integer 1),
-                         expInfo = Info {refsFree = []}}),
+                         expInfo = Info {refsFree = fromList []}}),
                      (PropName "y",
                       Exp
                         {unExp = Lit (Boolean True),
-                         expInfo = Info {refsFree = []}})]),
-             expInfo = Info {refsFree = []}}),
+                         expInfo = Info {refsFree = fromList []}})]),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "test1",
           Exp
@@ -104,9 +106,11 @@
                ObjectProp
                  (Exp
                     {unExp = RefFree (Local (Name "r")),
-                     expInfo = Info {refsFree = [Local (Name "r")]}})
+                     expInfo =
+                       Info {refsFree = fromList [Local (Name "r")]}})
                  (PropName "x"),
-             expInfo = Info {refsFree = [Local (Name "r")]}})],
+             expInfo =
+               Info {refsFree = fromList [Local (Name "r")]}})],
     moduleImports = [],
     moduleExports =
       [Name "r",

--- a/test/ps/output/Golden.TestRecordsAccess/golden.lua
+++ b/test/ps/output/Golden.TestRecordsAccess/golden.lua
@@ -1,8 +1,11 @@
-local Golden_TestRecordsAccess = (function()
-  local test4 = function(v0) local x1 = v0.x return x1 end
-  local test3 = function(v2) local x3 = v2.x return x3 end
-  local test2 = function(v4) return v4.x end
-  local r = { x = 1, y = true }
-  local test1 = r.x
-  return { r = r, test1 = test1, test2 = test2, test3 = test3, test4 = test4 }
-end)()
+local Golden_TestRecordsAccess_I_test4 = function(v0)
+  local x1 = v0.x
+  return x1
+end
+local Golden_TestRecordsAccess_I_test3 = function(v2)
+  local x3 = v2.x
+  return x3
+end
+local Golden_TestRecordsAccess_I_test2 = function(v4) return v4.x end
+local Golden_TestRecordsAccess_I_r = { x = 1, y = true }
+local Golden_TestRecordsAccess_I_test1 = Golden_TestRecordsAccess_I_r.x

--- a/test/ps/output/Golden.TestRecursiveBindings/golden.ir
+++ b/test/ps/output/Golden.TestRecursiveBindings/golden.ir
@@ -27,7 +27,8 @@
                                                             Lit (Boolean True),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             RefBound
@@ -37,8 +38,10 @@
                                                           expInfo =
                                                             Info
                                                               {refsFree =
-                                                                 []}})),
-                                               expInfo = Info {refsFree = []}})
+                                                                 fromList
+                                                                   []}})),
+                                               expInfo =
+                                                 Info {refsFree = fromList []}})
                                            (Exp
                                               {unExp =
                                                  App
@@ -49,13 +52,18 @@
                                                               {level = 1,
                                                                offset = 1}),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          Lit (Boolean False),
                                                        expInfo =
-                                                         Info {refsFree = []}}),
-                                               expInfo = Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}}),
+                                               expInfo =
+                                                 Info {refsFree = fromList []}})
                                            (Exp
                                               {unExp =
                                                  IfThenElse
@@ -71,7 +79,8 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})
+                                                                         fromList
+                                                                           []}})
                                                               (Exp
                                                                  {unExp =
                                                                     RefBound
@@ -83,9 +92,12 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})),
+                                                                         fromList
+                                                                           []}})),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          App
@@ -100,7 +112,8 @@
                                                                expInfo =
                                                                  Info
                                                                    {refsFree =
-                                                                      []}})
+                                                                      fromList
+                                                                        []}})
                                                            (Exp
                                                               {unExp =
                                                                  Lit
@@ -109,18 +122,26 @@
                                                                expInfo =
                                                                  Info
                                                                    {refsFree =
-                                                                      []}}),
+                                                                      fromList
+                                                                        []}}),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          Exception
                                                            "No patterns matched",
                                                        expInfo =
-                                                         Info {refsFree = []}}),
-                                               expInfo = Info {refsFree = []}}),
-                                       expInfo = Info {refsFree = []}})),
-                            expInfo = Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}}),
+                                               expInfo =
+                                                 Info
+                                                   {refsFree = fromList []}}),
+                                       expInfo =
+                                         Info {refsFree = fromList []}})),
+                            expInfo = Info {refsFree = fromList []}})
                           :|
                           [(Name "no",
                             Exp
@@ -142,7 +163,8 @@
                                                              expInfo =
                                                                Info
                                                                  {refsFree =
-                                                                    []}})
+                                                                    fromList
+                                                                      []}})
                                                          (Exp
                                                             {unExp =
                                                                RefBound
@@ -153,9 +175,11 @@
                                                              expInfo =
                                                                Info
                                                                  {refsFree =
-                                                                    []}})),
+                                                                    fromList
+                                                                      []}})),
                                                   expInfo =
-                                                    Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree = fromList []}})
                                               (Exp
                                                  {unExp =
                                                     App
@@ -167,15 +191,18 @@
                                                                   offset = 0}),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             Lit (Boolean False),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}}),
+                                                              {refsFree =
+                                                                 fromList []}}),
                                                   expInfo =
-                                                    Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree = fromList []}})
                                               (Exp
                                                  {unExp =
                                                     IfThenElse
@@ -191,7 +218,8 @@
                                                                      expInfo =
                                                                        Info
                                                                          {refsFree =
-                                                                            []}})
+                                                                            fromList
+                                                                              []}})
                                                                  (Exp
                                                                     {unExp =
                                                                        RefBound
@@ -203,10 +231,12 @@
                                                                      expInfo =
                                                                        Info
                                                                          {refsFree =
-                                                                            []}})),
+                                                                            fromList
+                                                                              []}})),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             App
@@ -221,7 +251,8 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})
+                                                                         fromList
+                                                                           []}})
                                                               (Exp
                                                                  {unExp =
                                                                     Lit
@@ -230,21 +261,27 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}}),
+                                                                         fromList
+                                                                           []}}),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             Exception
                                                               "No patterns matched",
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}}),
+                                                              {refsFree =
+                                                                 fromList []}}),
                                                   expInfo =
-                                                    Info {refsFree = []}}),
-                                          expInfo = Info {refsFree = []}})),
-                               expInfo = Info {refsFree = []}})])
+                                                    Info
+                                                      {refsFree =
+                                                         fromList []}}),
+                                          expInfo =
+                                            Info {refsFree = fromList []}})),
+                               expInfo = Info {refsFree = fromList []}})])
                        :|
                        [])
                     (Exp
@@ -253,12 +290,12 @@
                             (Exp
                                {unExp =
                                   RefBound (Index {level = 0, offset = 1}),
-                                expInfo = Info {refsFree = []}})
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp = Lit (Boolean False),
-                                expInfo = Info {refsFree = []}}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                expInfo = Info {refsFree = fromList []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "letRecMixed",
           Exp
@@ -269,7 +306,7 @@
                        (Name "z",
                         Exp
                           {unExp = Lit (Integer 1),
-                           expInfo = Info {refsFree = []}})
+                           expInfo = Info {refsFree = fromList []}})
                        :|
                        [RecursiveGroup
                           ((Name "b",
@@ -288,7 +325,8 @@
                                                          {level = 1,
                                                           offset = 2}),
                                                   expInfo =
-                                                    Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree = fromList []}})
                                               (Exp
                                                  {unExp =
                                                     RefBound
@@ -296,9 +334,12 @@
                                                          {level = 1,
                                                           offset = 0}),
                                                   expInfo =
-                                                    Info {refsFree = []}}),
-                                          expInfo = Info {refsFree = []}})),
-                               expInfo = Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree =
+                                                         fromList []}}),
+                                          expInfo =
+                                            Info {refsFree = fromList []}})),
+                               expInfo = Info {refsFree = fromList []}})
                              :|
                              [(Name "a",
                                Exp
@@ -316,7 +357,9 @@
                                                             {level = 1,
                                                              offset = 1}),
                                                      expInfo =
-                                                       Info {refsFree = []}})
+                                                       Info
+                                                         {refsFree =
+                                                            fromList []}})
                                                  (Exp
                                                     {unExp =
                                                        RefBound
@@ -324,9 +367,12 @@
                                                             {level = 1,
                                                              offset = 0}),
                                                      expInfo =
-                                                       Info {refsFree = []}}),
-                                             expInfo = Info {refsFree = []}})),
-                                  expInfo = Info {refsFree = []}})]),
+                                                       Info
+                                                         {refsFree =
+                                                            fromList []}}),
+                                             expInfo =
+                                               Info {refsFree = fromList []}})),
+                                  expInfo = Info {refsFree = fromList []}})]),
                         Standalone
                           (Name "f",
                            Exp
@@ -352,7 +398,8 @@
                                                             expInfo =
                                                               Info
                                                                 {refsFree =
-                                                                   []}})
+                                                                   fromList
+                                                                     []}})
                                                         (Exp
                                                            {unExp =
                                                               RefBound
@@ -363,11 +410,15 @@
                                                             expInfo =
                                                               Info
                                                                 {refsFree =
-                                                                   []}}),
+                                                                   fromList
+                                                                     []}}),
                                                     expInfo =
-                                                      Info {refsFree = []}})),
-                                         expInfo = Info {refsFree = []}})),
-                              expInfo = Info {refsFree = []}}),
+                                                      Info
+                                                        {refsFree =
+                                                           fromList []}})),
+                                         expInfo =
+                                           Info {refsFree = fromList []}})),
+                              expInfo = Info {refsFree = fromList []}}),
                         Standalone
                           (Name "y",
                            Exp
@@ -381,20 +432,22 @@
                                                 RefBound
                                                   (Index
                                                      {level = 0, offset = 3}),
-                                              expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}})
                                           (Exp
                                              {unExp =
                                                 RefBound
                                                   (Index
                                                      {level = 0, offset = 0}),
-                                              expInfo = Info {refsFree = []}}),
-                                      expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}}),
+                                      expInfo = Info {refsFree = fromList []}})
                                   (Exp
                                      {unExp =
                                         RefBound
                                           (Index {level = 0, offset = 0}),
-                                      expInfo = Info {refsFree = []}}),
-                              expInfo = Info {refsFree = []}}),
+                                      expInfo = Info {refsFree = fromList []}}),
+                              expInfo = Info {refsFree = fromList []}}),
                         Standalone
                           (Name "x",
                            Exp
@@ -408,20 +461,22 @@
                                                 RefBound
                                                   (Index
                                                      {level = 0, offset = 3}),
-                                              expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}})
                                           (Exp
                                              {unExp =
                                                 RefBound
                                                   (Index
                                                      {level = 0, offset = 4}),
-                                              expInfo = Info {refsFree = []}}),
-                                      expInfo = Info {refsFree = []}})
+                                              expInfo =
+                                                Info {refsFree = fromList []}}),
+                                      expInfo = Info {refsFree = fromList []}})
                                   (Exp
                                      {unExp =
                                         RefBound
                                           (Index {level = 0, offset = 4}),
-                                      expInfo = Info {refsFree = []}}),
-                              expInfo = Info {refsFree = []}})])
+                                      expInfo = Info {refsFree = fromList []}}),
+                              expInfo = Info {refsFree = fromList []}})])
                     (Exp
                        {unExp =
                           App
@@ -432,13 +487,15 @@
                                        {unExp =
                                           RefBound
                                             (Index {level = 0, offset = 3}),
-                                        expInfo = Info {refsFree = []}})
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp =
                                           RefBound
                                             (Index {level = 0, offset = 5}),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}})
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp =
                                   App
@@ -450,21 +507,26 @@
                                                   RefBound
                                                     (Index
                                                        {level = 0, offset = 3}),
-                                                expInfo = Info {refsFree = []}})
+                                                expInfo =
+                                                  Info
+                                                    {refsFree = fromList []}})
                                             (Exp
                                                {unExp =
                                                   RefBound
                                                     (Index
                                                        {level = 0, offset = 4}),
                                                 expInfo =
-                                                  Info {refsFree = []}}),
-                                        expInfo = Info {refsFree = []}})
+                                                  Info
+                                                    {refsFree = fromList []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}})
                                     (Exp
                                        {unExp = Lit (Integer 0),
-                                        expInfo = Info {refsFree = []}}),
-                                expInfo = Info {refsFree = []}}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                        expInfo =
+                                          Info {refsFree = fromList []}}),
+                                expInfo = Info {refsFree = fromList []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "letRec",
           Exp
@@ -490,7 +552,8 @@
                                                             Lit (Boolean True),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             RefBound
@@ -500,8 +563,10 @@
                                                           expInfo =
                                                             Info
                                                               {refsFree =
-                                                                 []}})),
-                                               expInfo = Info {refsFree = []}})
+                                                                 fromList
+                                                                   []}})),
+                                               expInfo =
+                                                 Info {refsFree = fromList []}})
                                            (Exp
                                               {unExp =
                                                  App
@@ -512,13 +577,18 @@
                                                               {level = 1,
                                                                offset = 1}),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          Lit (Boolean False),
                                                        expInfo =
-                                                         Info {refsFree = []}}),
-                                               expInfo = Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}}),
+                                               expInfo =
+                                                 Info {refsFree = fromList []}})
                                            (Exp
                                               {unExp =
                                                  IfThenElse
@@ -534,7 +604,8 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})
+                                                                         fromList
+                                                                           []}})
                                                               (Exp
                                                                  {unExp =
                                                                     RefBound
@@ -546,9 +617,12 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})),
+                                                                         fromList
+                                                                           []}})),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          App
@@ -563,7 +637,8 @@
                                                                expInfo =
                                                                  Info
                                                                    {refsFree =
-                                                                      []}})
+                                                                      fromList
+                                                                        []}})
                                                            (Exp
                                                               {unExp =
                                                                  Lit
@@ -572,18 +647,26 @@
                                                                expInfo =
                                                                  Info
                                                                    {refsFree =
-                                                                      []}}),
+                                                                      fromList
+                                                                        []}}),
                                                        expInfo =
-                                                         Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}})
                                                    (Exp
                                                       {unExp =
                                                          Exception
                                                            "No patterns matched",
                                                        expInfo =
-                                                         Info {refsFree = []}}),
-                                               expInfo = Info {refsFree = []}}),
-                                       expInfo = Info {refsFree = []}})),
-                            expInfo = Info {refsFree = []}})
+                                                         Info
+                                                           {refsFree =
+                                                              fromList []}}),
+                                               expInfo =
+                                                 Info
+                                                   {refsFree = fromList []}}),
+                                       expInfo =
+                                         Info {refsFree = fromList []}})),
+                            expInfo = Info {refsFree = fromList []}})
                           :|
                           [(Name "no",
                             Exp
@@ -605,7 +688,8 @@
                                                              expInfo =
                                                                Info
                                                                  {refsFree =
-                                                                    []}})
+                                                                    fromList
+                                                                      []}})
                                                          (Exp
                                                             {unExp =
                                                                RefBound
@@ -616,9 +700,11 @@
                                                              expInfo =
                                                                Info
                                                                  {refsFree =
-                                                                    []}})),
+                                                                    fromList
+                                                                      []}})),
                                                   expInfo =
-                                                    Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree = fromList []}})
                                               (Exp
                                                  {unExp =
                                                     App
@@ -630,15 +716,18 @@
                                                                   offset = 0}),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             Lit (Boolean False),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}}),
+                                                              {refsFree =
+                                                                 fromList []}}),
                                                   expInfo =
-                                                    Info {refsFree = []}})
+                                                    Info
+                                                      {refsFree = fromList []}})
                                               (Exp
                                                  {unExp =
                                                     IfThenElse
@@ -654,7 +743,8 @@
                                                                      expInfo =
                                                                        Info
                                                                          {refsFree =
-                                                                            []}})
+                                                                            fromList
+                                                                              []}})
                                                                  (Exp
                                                                     {unExp =
                                                                        RefBound
@@ -666,10 +756,12 @@
                                                                      expInfo =
                                                                        Info
                                                                          {refsFree =
-                                                                            []}})),
+                                                                            fromList
+                                                                              []}})),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             App
@@ -684,7 +776,8 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}})
+                                                                         fromList
+                                                                           []}})
                                                               (Exp
                                                                  {unExp =
                                                                     Lit
@@ -693,21 +786,27 @@
                                                                   expInfo =
                                                                     Info
                                                                       {refsFree =
-                                                                         []}}),
+                                                                         fromList
+                                                                           []}}),
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}})
+                                                              {refsFree =
+                                                                 fromList []}})
                                                       (Exp
                                                          {unExp =
                                                             Exception
                                                               "No patterns matched",
                                                           expInfo =
                                                             Info
-                                                              {refsFree = []}}),
+                                                              {refsFree =
+                                                                 fromList []}}),
                                                   expInfo =
-                                                    Info {refsFree = []}}),
-                                          expInfo = Info {refsFree = []}})),
-                               expInfo = Info {refsFree = []}})])
+                                                    Info
+                                                      {refsFree =
+                                                         fromList []}}),
+                                          expInfo =
+                                            Info {refsFree = fromList []}})),
+                               expInfo = Info {refsFree = fromList []}})])
                        :|
                        [])
                     (Exp
@@ -716,12 +815,12 @@
                             (Exp
                                {unExp =
                                   RefBound (Index {level = 0, offset = 1}),
-                                expInfo = Info {refsFree = []}})
+                                expInfo = Info {refsFree = fromList []}})
                             (Exp
                                {unExp = Lit (Boolean False),
-                                expInfo = Info {refsFree = []}}),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}})],
+                                expInfo = Info {refsFree = fromList []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports =
       [Name "letRec", Name "whereRec", Name "letRecMixed"],

--- a/test/ps/output/Golden.TestRecursiveBindings/golden.lua
+++ b/test/ps/output/Golden.TestRecursiveBindings/golden.lua
@@ -1,84 +1,73 @@
-local Golden_TestRecursiveBindings = (function()
-  local whereRec = (function()
-    local yes0
-    local no1
-    yes0 = function(v2)
+local Golden_TestRecursiveBindings_I_whereRec = (function()
+  local yes0
+  local no1
+  yes0 = function(v2)
+    if true == v2 then
+      return no1(false)
+    else
       return (function()
-        if true == v2 then
-          return no1(false)
+        if false == v2 then
+          return no1(true)
         else
-          return (function()
-            if false == v2 then
-              return no1(true)
-            else
-              return error("No patterns matched")
-            end
-          end)()
+          return error("No patterns matched")
         end
       end)()
     end
-    no1 = function(v3)
+  end
+  no1 = function(v3)
+    if true == v3 then
+      return yes0(false)
+    else
       return (function()
-        if true == v3 then
-          return yes0(false)
+        if false == v3 then
+          return yes0(true)
         else
-          return (function()
-            if false == v3 then
-              return yes0(true)
-            else
-              return error("No patterns matched")
-            end
-          end)()
+          return error("No patterns matched")
         end
       end)()
     end
-    return no1(false)
-  end)()
-  local letRecMixed = (function()
-    local z4 = 1
-    local b5
-    local a6
-    b5 = function() return a6(z4) end
-    a6 = function() return b5(z4) end
-    local f7 = function() return function(k10) return a6(k10) end end
-    local y8 = f7(z4)(z4)
-    local x9 = f7(y8)(y8)
-    return f7(x9)(f7(y8)(0))
-  end)()
-  local letRec = (function()
-    local yes11
-    local no12
-    yes11 = function(v13)
+  end
+  return no1(false)
+end)()
+local Golden_TestRecursiveBindings_I_letRecMixed = (function()
+  local z4 = 1
+  local b5
+  local a6
+  b5 = function() return a6(z4) end
+  a6 = function() return b5(z4) end
+  local f7 = function() return function(k10) return a6(k10) end end
+  local y8 = f7(z4)(z4)
+  local x9 = f7(y8)(y8)
+  return f7(x9)(f7(y8)(0))
+end)()
+local Golden_TestRecursiveBindings_I_letRec = (function()
+  local yes11
+  local no12
+  yes11 = function(v13)
+    if true == v13 then
+      return no12(false)
+    else
       return (function()
-        if true == v13 then
-          return no12(false)
+        if false == v13 then
+          return no12(true)
         else
-          return (function()
-            if false == v13 then
-              return no12(true)
-            else
-              return error("No patterns matched")
-            end
-          end)()
+          return error("No patterns matched")
         end
       end)()
     end
-    no12 = function(v14)
+  end
+  no12 = function(v14)
+    if true == v14 then
+      return yes11(false)
+    else
       return (function()
-        if true == v14 then
-          return yes11(false)
+        if false == v14 then
+          return yes11(true)
         else
-          return (function()
-            if false == v14 then
-              return yes11(true)
-            else
-              return error("No patterns matched")
-            end
-          end)()
+          return error("No patterns matched")
         end
       end)()
     end
-    return no12(false)
-  end)()
-  return { letRec = letRec, whereRec = whereRec, letRecMixed = letRecMixed }
+  end
+  return no12(false)
 end)()

--- a/test/ps/output/Golden.TestReexport/golden.ir
+++ b/test/ps/output/Golden.TestReexport/golden.ir
@@ -5,7 +5,7 @@
          (Name "binding1",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}})],
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "binding1"],
     moduleReExports = fromList [],
@@ -19,7 +19,7 @@
          (Name "binding2",
           Exp
             {unExp = Lit (Integer 2),
-             expInfo = Info {refsFree = []}})],
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports = [Name "binding2"],
     moduleReExports =
@@ -46,9 +46,10 @@
                         expInfo =
                           Info
                             {refsFree =
-                               [Imported
-                                  (ModuleName "Golden.Reexport.Exports")
-                                  (Name "binding1")]}},
+                               fromList
+                                 [Imported
+                                    (ModuleName "Golden.Reexport.Exports")
+                                    (Name "binding1")]}},
                      Exp
                        {unExp =
                           RefFree
@@ -58,18 +59,20 @@
                         expInfo =
                           Info
                             {refsFree =
-                               [Imported
-                                  (ModuleName "Golden.Reexport.ReExports")
-                                  (Name "binding2")]}}]),
+                               fromList
+                                 [Imported
+                                    (ModuleName "Golden.Reexport.ReExports")
+                                    (Name "binding2")]}}]),
              expInfo =
                Info
                  {refsFree =
-                    [Imported
-                       (ModuleName "Golden.Reexport.Exports")
-                       (Name "binding1"),
-                     Imported
-                       (ModuleName "Golden.Reexport.ReExports")
-                       (Name "binding2")]}})],
+                    fromList
+                      [Imported
+                         (ModuleName "Golden.Reexport.Exports")
+                         (Name "binding1"),
+                       Imported
+                         (ModuleName "Golden.Reexport.ReExports")
+                         (Name "binding2")]}})],
     moduleImports =
       [ModuleName "Golden.Reexport.Exports",
        ModuleName "Golden.Reexport.ReExports"],

--- a/test/ps/output/Golden.TestReexport/golden.lua
+++ b/test/ps/output/Golden.TestReexport/golden.lua
@@ -1,15 +1,6 @@
-local Golden_Reexport_Exports = (function()
-  local binding1 = 1
-  return { binding1 = binding1 }
-end)()
-local Golden_Reexport_ReExports = (function()
-  local binding2 = 2
-  return { binding2 = binding2 }
-end)()
-local Golden_TestReexport = (function()
-  local binding3 = {
-    Golden_Reexport_Exports.binding1,
-    Golden_Reexport_ReExports.binding2
-  }
-  return { binding3 = binding3 }
-end)()
+local Golden_Reexport_Exports_I_binding1 = 1
+local Golden_Reexport_ReExports_I_binding2 = 2
+local Golden_TestReexport_I_binding3 = {
+  Golden_Reexport_Exports_I_binding1,
+  Golden_Reexport_ReExports_I_binding2
+}

--- a/test/ps/output/Golden.TestUnbinding/golden.ir
+++ b/test/ps/output/Golden.TestUnbinding/golden.ir
@@ -15,19 +15,19 @@
                                ArgUnused
                                (Exp
                                   {unExp = Lit (Integer 3),
-                                   expInfo = Info {refsFree = []}})),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                                   expInfo = Info {refsFree = fromList []}})),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "b",
           Exp
             {unExp = Lit (Integer 2),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "a",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "c",
           Exp
@@ -38,13 +38,16 @@
                        App
                          (Exp
                             {unExp = RefFree (Local (Name "f")),
-                             expInfo = Info {refsFree = [Local (Name "f")]}})
+                             expInfo =
+                               Info {refsFree = fromList [Local (Name "f")]}})
                          (Exp
                             {unExp = RefFree (Local (Name "a")),
-                             expInfo = Info {refsFree = [Local (Name "a")]}}),
+                             expInfo =
+                               Info {refsFree = fromList [Local (Name "a")]}}),
                      expInfo =
                        Info
-                         {refsFree = [Local (Name "f"), Local (Name "a")]}})
+                         {refsFree =
+                            fromList [Local (Name "a"), Local (Name "f")]}})
                  (Exp
                     {unExp =
                        App
@@ -54,32 +57,38 @@
                                  (Exp
                                     {unExp = RefFree (Local (Name "f")),
                                      expInfo =
-                                       Info {refsFree = [Local (Name "f")]}})
+                                       Info
+                                         {refsFree =
+                                            fromList [Local (Name "f")]}})
                                  (Exp
                                     {unExp = RefFree (Local (Name "b")),
                                      expInfo =
-                                       Info {refsFree = [Local (Name "b")]}}),
+                                       Info
+                                         {refsFree =
+                                            fromList [Local (Name "b")]}}),
                              expInfo =
                                Info
                                  {refsFree =
-                                    [Local (Name "f"), Local (Name "b")]}})
+                                    fromList
+                                      [Local (Name "b"), Local (Name "f")]}})
                          (Exp
                             {unExp = RefFree (Local (Name "a")),
-                             expInfo = Info {refsFree = [Local (Name "a")]}}),
+                             expInfo =
+                               Info {refsFree = fromList [Local (Name "a")]}}),
                      expInfo =
                        Info
                          {refsFree =
-                            [Local (Name "f"),
-                             Local (Name "b"),
-                             Local (Name "a")]}}),
+                            fromList
+                              [Local (Name "a"),
+                               Local (Name "b"),
+                               Local (Name "f")]}}),
              expInfo =
                Info
                  {refsFree =
-                    [Local (Name "f"),
-                     Local (Name "a"),
-                     Local (Name "f"),
-                     Local (Name "b"),
-                     Local (Name "a")]}})],
+                    fromList
+                      [Local (Name "a"),
+                       Local (Name "b"),
+                       Local (Name "f")]}})],
     moduleImports = [],
     moduleExports =
       [Name "a", Name "b", Name "f", Name "c"],

--- a/test/ps/output/Golden.TestUnbinding/golden.lua
+++ b/test/ps/output/Golden.TestUnbinding/golden.lua
@@ -1,7 +1,4 @@
-local Golden_TestUnbinding = (function()
-  local f = function() return function() return 3 end end
-  local b = 2
-  local a = 1
-  local c = f(a)(f(b)(a))
-  return { a = a, b = b, f = f, c = c }
-end)()
+local Golden_TestUnbinding_I_f = function() return function() return 3 end end
+local Golden_TestUnbinding_I_b = 2
+local Golden_TestUnbinding_I_a = 1
+local Golden_TestUnbinding_I_c = Golden_TestUnbinding_I_f(Golden_TestUnbinding_I_a)(Golden_TestUnbinding_I_f(Golden_TestUnbinding_I_b)(Golden_TestUnbinding_I_a))

--- a/test/ps/output/Golden.TestValues/golden.ir
+++ b/test/ps/output/Golden.TestValues/golden.ir
@@ -5,7 +5,7 @@
          (Name "i",
           Exp
             {unExp = Lit (Integer 1),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "f",
           Exp
@@ -15,18 +15,18 @@
                     ArgUnused
                     (Exp
                        {unExp = Lit (Boolean True),
-                        expInfo = Info {refsFree = []}})),
-             expInfo = Info {refsFree = []}}),
+                        expInfo = Info {refsFree = fromList []}})),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "c",
           Exp
             {unExp = Lit (Char 'c'),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "b",
           Exp
             {unExp = Lit (Boolean True),
-             expInfo = Info {refsFree = []}}),
+             expInfo = Info {refsFree = fromList []}}),
        Standalone
          (Name "o",
           Exp
@@ -36,21 +36,25 @@
                     [(PropName "i",
                       Exp
                         {unExp = RefFree (Local (Name "i")),
-                         expInfo = Info {refsFree = [Local (Name "i")]}}),
+                         expInfo =
+                           Info {refsFree = fromList [Local (Name "i")]}}),
                      (PropName "b",
                       Exp
                         {unExp = RefFree (Local (Name "b")),
-                         expInfo = Info {refsFree = [Local (Name "b")]}}),
+                         expInfo =
+                           Info {refsFree = fromList [Local (Name "b")]}}),
                      (PropName "c",
                       Exp
                         {unExp = RefFree (Local (Name "c")),
-                         expInfo = Info {refsFree = [Local (Name "c")]}})]),
+                         expInfo =
+                           Info {refsFree = fromList [Local (Name "c")]}})]),
              expInfo =
                Info
                  {refsFree =
-                    [Local (Name "i"),
-                     Local (Name "b"),
-                     Local (Name "c")]}}),
+                    fromList
+                      [Local (Name "b"),
+                       Local (Name "c"),
+                       Local (Name "i")]}}),
        Standalone
          (Name "a",
           Exp
@@ -59,14 +63,14 @@
                  (Array
                     [Exp
                        {unExp = Lit (Integer 1),
-                        expInfo = Info {refsFree = []}},
+                        expInfo = Info {refsFree = fromList []}},
                      Exp
                        {unExp = Lit (Integer 2),
-                        expInfo = Info {refsFree = []}},
+                        expInfo = Info {refsFree = fromList []}},
                      Exp
                        {unExp = Lit (Integer 3),
-                        expInfo = Info {refsFree = []}}]),
-             expInfo = Info {refsFree = []}})],
+                        expInfo = Info {refsFree = fromList []}}]),
+             expInfo = Info {refsFree = fromList []}})],
     moduleImports = [],
     moduleExports =
       [Name "i",

--- a/test/ps/output/Golden.TestValues/golden.lua
+++ b/test/ps/output/Golden.TestValues/golden.lua
@@ -1,9 +1,10 @@
-local Golden_TestValues = (function()
-  local i = 1
-  local f = function() return true end
-  local c = "c"
-  local b = true
-  local o = { i = i, b = b, c = c }
-  local a = { 1, 2, 3 }
-  return { i = i, b = b, c = c, a = a, o = o, f = f }
-end)()
+local Golden_TestValues_I_i = 1
+local Golden_TestValues_I_f = function() return true end
+local Golden_TestValues_I_c = "c"
+local Golden_TestValues_I_b = true
+local Golden_TestValues_I_o = {
+  i = Golden_TestValues_I_i,
+  b = Golden_TestValues_I_b,
+  c = Golden_TestValues_I_c
+}
+local Golden_TestValues_I_a = { 1, 2, 3 }

--- a/test/ps/packages.dhall
+++ b/test/ps/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230217/packages.dhall
-        sha256:af3cf6d8c64c6092d4daf9503a9299a17a8f8bf964138d6b3c7d3641b2c41ffa
+      https://github.com/Unisay/purescript-lua-package-sets/releases/download/psc-0.15.8-20230330/packages.dhall
+        sha256:e555e52121a430d2e2a9b14f9705d1186c8c755cbb099c04e6bd441cf7ae8d9f
 
 in  upstream

--- a/test/ps/spago.dhall
+++ b/test/ps/spago.dhall
@@ -1,8 +1,5 @@
 { name = "test-project"
-, dependencies = [ ] : List Text
+, dependencies = [ "lua-effect", "lua-prelude" ]
 , packages = ./packages.dhall
-, sources =
-    [ "src/**/*.purs"
-    , "golden/**/*.purs"
-    ]
+, sources = [ "golden/**/*.purs" ]
 }


### PR DESCRIPTION
but uses fully-qualified local names instead.