### PR TITLE
fix: wrap table literals in parentheses before indexing

### DIFF
--- a/lib/Language/PureScript/Backend/Lua/Printer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Printer.hs
@@ -108,7 +108,7 @@ printRow = \case
 printVar ∷ Lua.Var → ADoc
 printVar = \case
   Lua.VarName name → printName name
-  Lua.VarIndex (Ann e) (Ann i) → printedExp e <> brackets (printedExp i)
+  Lua.VarIndex (Ann e) (Ann i) → wrapPrec PrecAtom (printExp e) <> brackets (printedExp i)
   Lua.VarField (Ann e) n → wrapPrec PrecAtom (printExp e) <> "." <> printName n
 
 printFunctionCall ∷ PADoc → [PADoc] → ADoc


### PR DESCRIPTION
Hi there, i (Andrew) am submitting this PR but, full disclosure, the bug diagnosis, change and PR text were all prepared by Claude, an LLM. I watched it run the test suite and the logic seems sound so i'm pushing it upstream for your consideration. I very much hope this is helpful and not a burden.


In Lua, table constructor literals cannot be directly indexed without parentheses. The expression `{ ["key"] = val }["key"]` is a syntax error, while `({ ["key"] = val })["key"]` is valid.

This fix adds the same `wrapPrec PrecAtom` wrapping to `VarIndex` that was already applied to `VarField`, ensuring table literals are properly parenthesized when used with bracket indexing.

Fixes pattern matching on ADT constructors that would generate invalid Lua like:

  if "Mod∷Type.Ctor" == { ["$ctor"] = "Mod∷Type.Ctor" }["$ctor"] then

Now correctly generates:

  if "Mod∷Type.Ctor" == ({ ["$ctor"] = "Mod∷Type.Ctor" })["$ctor"] then