### PR TITLE
fix: parenthesise table literals before bracket indexing

### DIFF
--- a/lib/Language/PureScript/Backend/Lua/Printer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Printer.hs
@@ -108,7 +108,7 @@ printRow = \case
 printVar ∷ Lua.Var → ADoc
 printVar = \case
   Lua.VarName name → printName name
-  Lua.VarIndex (Ann e) (Ann i) → printedExp e <> brackets (printedExp i)
+  Lua.VarIndex (Ann e) (Ann i) → wrapPrec PrecAtom (printExp e) <> brackets (printedExp i)
   Lua.VarField (Ann e) n → wrapPrec PrecAtom (printExp e) <> "." <> printName n
 
 printFunctionCall ∷ PADoc → [PADoc] → ADoc

--- a/test/Language/PureScript/Backend/Lua/Printer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Printer/Spec.hs
@@ -35,6 +35,19 @@ spec = do
       let s = Lua.assign (Lua.VarName [Lua.name|foo|]) (Lua.Boolean True)
       renderedStatement s `shouldBe` "foo = true"
 
+  describe "VarIndex" do
+    it "var[index]" do
+      let e = Lua.varName [Lua.name|expr|]
+      renderedExpression (Lua.varIndex e (Lua.String "foo"))
+        `shouldBe` "expr[\"foo\"]"
+
+    -- A table constructor must be parenthesised before bracket indexing:
+    -- `{ ["foo"] = 1 }["foo"]` is a Lua syntax error, `({ … })["foo"]` is not.
+    it "({[\"foo\"] = 1})[\"foo\"]" do
+      let e = Lua.table [Lua.tableRowKV (Lua.String "foo") (Lua.Integer 1)]
+      renderedExpression (Lua.varIndex e (Lua.String "foo"))
+        `shouldBe` "({ [\"foo\"] = 1 })[\"foo\"]"
+
   describe "Local declaration" do
     it "without a value" do
       let s = Lua.Local [Lua.name|foo|] Nothing

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -124,7 +124,7 @@ return M.Golden_CharLiterals_Test_discard(M.Effect_Console_foreign.log(M.Golden_
           return M.Golden_CharLiterals_Test_discard(M.Effect_Console_foreign.log(M.Golden_CharLiterals_Test_show("a")))(function(  )
             return M.Golden_CharLiterals_Test_discard(M.Effect_Console_foreign.log(M.Golden_CharLiterals_Test_show1(M.Data_Eq_eqChar.eq("\n")("\n"))))(function(  )
               return M.Effect_Console_foreign.log(M.Golden_CharLiterals_Test_show1((function(  )
-                if "Data.Ordering∷Ordering.LT" == ((function()
+                if "Data.Ordering∷Ordering.LT" == (((function()
                   local unsafeCoerceImpl = function(lt)
                     return function(eq)
                       return function(gt)
@@ -147,7 +147,7 @@ return M.Golden_CharLiterals_Test_discard(M.Effect_Console_foreign.log(M.Golden_
                   ["$ctor"] = "Data.Ordering∷Ordering.LT"
                 })({ ["$ctor"] = "Data.Ordering∷Ordering.EQ" })({
                   ["$ctor"] = "Data.Ordering∷Ordering.GT"
-                })("\t")("\n")["$ctor"] then
+                })("\t")("\n"))["$ctor"] then
                   return true
                 else
                   return false

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -301,7 +301,7 @@ M.Data_Ord_compare = function(dict) return dict.compare end
 M.Data_Ord_greaterThanOrEq = function(dictOrd)
   return function(a1)
     return function(a2)
-      if "Data.Ordering∷Ordering.LT" == M.Data_Ord_compare(dictOrd)(a1)(a2)["$ctor"] then
+      if "Data.Ordering∷Ordering.LT" == (M.Data_Ord_compare(dictOrd)(a1)(a2))["$ctor"] then
         return false
       else
         return true
@@ -312,7 +312,7 @@ end
 M.Data_Ord_lessThan = function(dictOrd)
   return function(a1)
     return function(a2)
-      if "Data.Ordering∷Ordering.LT" == M.Data_Ord_compare(dictOrd)(a1)(a2)["$ctor"] then
+      if "Data.Ordering∷Ordering.LT" == (M.Data_Ord_compare(dictOrd)(a1)(a2))["$ctor"] then
         return true
       else
         return false
@@ -323,7 +323,7 @@ end
 M.Data_Ord_lessThanOrEq = function(dictOrd)
   return function(a1)
     return function(a2)
-      if "Data.Ordering∷Ordering.GT" == M.Data_Ord_compare(dictOrd)(a1)(a2)["$ctor"] then
+      if "Data.Ordering∷Ordering.GT" == (M.Data_Ord_compare(dictOrd)(a1)(a2))["$ctor"] then
         return false
       else
         return true
@@ -496,7 +496,7 @@ M.Data_String_CodePoints_unsafeCodePointAt0 = M.Data_String_CodePoints_foreign._
       end
     end)(0)(s))
   if M.Data_String_CodePoints_conj(M.Data_String_CodePoints_conj(M.Data_String_CodePoints_lessThanOrEq(55296)(cu0))(M.Data_String_CodePoints_lessThanOrEq(cu0)(56319)))((function(  )
-    if "Data.Ordering∷Ordering.GT" == M.Data_Ord_compare(M.Data_Ord_ordInt)(M.Data_String_CodeUnits_foreign.length(s))(1)["$ctor"] then
+    if "Data.Ordering∷Ordering.GT" == (M.Data_Ord_compare(M.Data_Ord_ordInt)(M.Data_String_CodeUnits_foreign.length(s))(1))["$ctor"] then
       return true
     else
       return false


### PR DESCRIPTION
Carries @afcondon's fix from #40 (rebased onto current main) and adds the test it was missing.

## The bug

In Lua a table constructor cannot be indexed directly: `{ ["k"] = v }["k"]` is a syntax error, while `({ ["k"] = v })["k"]` is valid. The Lua printer wrapped `VarField` targets in `wrapPrec PrecAtom` but not `VarIndex`, so a table literal in index position emitted invalid Lua.

## The fix

`VarIndex` now wraps its target with `wrapPrec PrecAtom`, exactly like `VarField` already did. That commit is @afcondon's, preserved as-is.

## Tests

- A new `Printer` spec case mirroring the existing `VarField` one: `({ ["foo"] = 1 })["foo"]`. Without the fix it renders `{ ["foo"] = 1 }["foo"]` and the assertion fails with a clear diff, which is the regression guard the original PR was asked for.
- The `CharLiterals` and `StringCodePoints` goldens are regenerated. The same wrapping now also parenthesises function-call results before `["$ctor"]` indexing (e.g. `f(x)(y)["$ctor"]` becomes `(f(x)(y))["$ctor"]`). That change is purely syntactic: the IR and eval output are unchanged and both files pass luacheck.

Supersedes #40, whose branch predates the `StringCodePoints` golden, so the work has to sit on current main.
