### PR TITLE
fix: create the parent directory of --lua-output-file

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -9,6 +9,7 @@ import Language.PureScript.Backend qualified as Backend
 import Language.PureScript.Backend.IR qualified as IR
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
+import Language.PureScript.Backend.Output (withOutputFile)
 import Language.PureScript.CoreFn.Reader qualified as CoreFn
 import Language.PureScript.Names (runIdent, runModuleName)
 import Main.Utf8 qualified as Utf8
@@ -53,19 +54,19 @@ main = Utf8.withUtf8 do
       & Oops.runOops
 
   let outputFile = toFilePath luaOutput
-  withFile outputFile WriteMode \h →
+  withOutputFile luaOutput \h →
     renderIO h . layoutPretty defaultLayoutOptions $
       Printer.printLuaChunk lua
 
   when (OutputIR `elem` extraOutputs) do
-    irOutputFile ← toFilePath <$> replaceExtension ".ir" luaOutput
-    withFile irOutputFile WriteMode (`pHPrint` ir)
-    putTextLn $ "Wrote IR to " <> toText irOutputFile
+    irOutputPath ← replaceExtension ".ir" luaOutput
+    withOutputFile irOutputPath (`pHPrint` ir)
+    putTextLn $ "Wrote IR to " <> toText (toFilePath irOutputPath)
 
   when (OutputLuaAst `elem` extraOutputs) do
-    luaAstOutputFile ← toFilePath <$> replaceExtension ".lua-ast" luaOutput
-    withFile luaAstOutputFile WriteMode (`pHPrint` lua)
-    putTextLn $ "Wrote Lua AST to " <> toText luaAstOutputFile
+    luaAstOutputPath ← replaceExtension ".lua-ast" luaOutput
+    withOutputFile luaAstOutputPath (`pHPrint` lua)
+    putTextLn $ "Wrote Lua AST to " <> toText (toFilePath luaAstOutputPath)
 
   putTextLn $ "Wrote linked modules to " <> toText outputFile
 

--- a/lib/Language/PureScript/Backend/Output.hs
+++ b/lib/Language/PureScript/Backend/Output.hs
@@ -1,0 +1,20 @@
+module Language.PureScript.Backend.Output
+  ( withOutputFile
+  ) where
+
+import Path (Abs, File, Path, parent, toFilePath)
+import Path.IO (ensureDir)
+
+--------------------------------------------------------------------------------
+-- Output ----------------------------------------------------------------------
+
+{- | Open a file for writing, first creating its parent directory (and any
+missing ancestors). pslua's @--lua-output-file@ may point into a directory
+that does not exist yet (a gitignored @dist/@, say); plain 'withFile' would
+abort with @does not exist@, a sharp edge each fork's build script would
+otherwise work around with @mkdir -p@.
+-}
+withOutputFile ∷ Path Abs File → (Handle → IO r) → IO r
+withOutputFile path action = do
+  ensureDir (parent path)
+  withFile (toFilePath path) WriteMode action

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -140,6 +140,7 @@ library
     Language.PureScript.Backend.Lua.Printer
     Language.PureScript.Backend.Lua.Traversal
     Language.PureScript.Backend.Lua.Types
+    Language.PureScript.Backend.Output
     Language.PureScript.Backend.Types
     Language.PureScript.Comments
     Language.PureScript.CoreFn
@@ -172,6 +173,7 @@ test-suite spec
     Language.PureScript.Backend.Lua.Linker.Foreign.Spec
     Language.PureScript.Backend.Lua.Optimizer.Spec
     Language.PureScript.Backend.Lua.Printer.Spec
+    Language.PureScript.Backend.Output.Spec
     Test.Hspec.Expectations.Pretty
     Test.Hspec.Extra
     Test.Hspec.Golden

--- a/test/Language/PureScript/Backend/Output/Spec.hs
+++ b/test/Language/PureScript/Backend/Output/Spec.hs
@@ -1,0 +1,14 @@
+module Language.PureScript.Backend.Output.Spec (spec) where
+
+import Language.PureScript.Backend.Output (withOutputFile)
+import Path (parseRelFile, (</>))
+import Path.IO (doesFileExist, withSystemTempDir)
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+spec ∷ Spec
+spec = describe "Language.PureScript.Backend.Output" do
+  it "withOutputFile creates the missing parent directory" do
+    withSystemTempDir "pslua-output" \tmp → do
+      file ← (tmp </>) <$> parseRelFile "nested/dir/out.lua"
+      withOutputFile file (const pass)
+      doesFileExist file `shouldReturn` True

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,6 +11,7 @@ import Language.PureScript.Backend.Lua.Golden.Spec qualified as Golden
 import Language.PureScript.Backend.Lua.Linker.Foreign.Spec qualified as LuaLinkerForeign
 import Language.PureScript.Backend.Lua.Optimizer.Spec qualified as LuaOptimizer
 import Language.PureScript.Backend.Lua.Printer.Spec qualified as Printer
+import Language.PureScript.Backend.Output.Spec qualified as Output
 import Test.Hspec (hspec)
 
 main ∷ IO ()
@@ -26,3 +27,4 @@ main = hspec do
   LuaOptimizer.spec
   Printer.spec
   LuaLinkerForeign.spec
+  Output.spec


### PR DESCRIPTION

Closes #61.

`pslua` opened the output file with `withFile ... WriteMode`, which does not create the parent directory. Passing `--lua-output-file dist/X.lua` when `dist/` is absent (a gitignored output dir, say) aborted with `withFile: does not exist`. Every fork's build script had to work around it with `mkdir -p`.

This adds a small helper, `Language.PureScript.Backend.Output.withOutputFile`, that runs `ensureDir` on the parent before opening the handle, and routes all three CLI outputs (the Lua chunk, the optional IR dump, the optional Lua AST dump) through it. They share one directory, so the parent is ensured once per run.

Test: a unit spec writes to a nested non-existent path under a temp dir and asserts the file appears. End-to-end, the built binary now writes `--lua-output-file /tmp/a/b/c/out.lua` into directories that did not exist.

Once this is released, forks can drop their `mkdir -p dist` lines (tracked in the assert fork, #59).
