### PR TITLE
chore: point package-set + fork links at purescript-lua org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ The project uses Hedgehog for property-based testing:
    edit `compiler-nix-name` / `easy-ps.purs-*` in `flake.nix`.
 2. PureScript package sets live in `test/ps/packages.dhall` as
    `upstream-ps // upstream-lua`. The right operand wins: `upstream-lua`
-   (releases of `Unisay/purescript-lua-package-sets`) overrides core
+   (releases of `purescript-lua/purescript-lua-package-sets`) overrides core
    packages with Lua forks that ship `.lua` FFI files.
 3. After changing package sets or `purs`: `cd test/ps && spago build -u
    '-g corefn'`, then `cabal test all`. Drop the `sha256:` annotations
@@ -311,7 +311,7 @@ The project uses Hedgehog for property-based testing:
 
 - **`unit` must not be `nil`**: Lua tables cannot hold `nil` values, so
   `Array Unit` silently collapses to an empty table if the prelude defines
-  `unit = nil`. Requires `Unisay/purescript-lua-prelude` ≥ v7.2.0, where
+  `unit = nil`. Requires `purescript-lua/purescript-lua-prelude` ≥ v7.2.0, where
   `unit = {}`. If eval goldens for unit arrays start printing `0`, a
   package set downgraded the prelude — do not accept such goldens.
 - A generated-Lua change that only passes `luacheck` is not verified:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Purescript Backend for Lua
 
-[![Purescript Lua CI](https://github.com/Unisay/purescript-lua/actions/workflows/ci.yaml/badge.svg)](https://github.com/Unisay/purescript-lua/actions/workflows/ci.yaml)
+[![Purescript Lua CI](https://github.com/purescript-lua/purescript-lua/actions/workflows/ci.yaml/badge.svg)](https://github.com/purescript-lua/purescript-lua/actions/workflows/ci.yaml)
 
 🔋 Status: (2024-04-20) the project is in the "_ready to be experimented with_" state (read: it likely contains bugs but is already usable). 
 
 💡 If you have an idea on how to use Purescript to Lua compilation please contribute it here:
-https://github.com/Unisay/purescript-lua/discussions/categories/ideas
+https://github.com/purescript-lua/purescript-lua/discussions/categories/ideas
 
 ## Features
 
@@ -13,7 +13,7 @@ https://github.com/Unisay/purescript-lua/discussions/categories/ideas
 - [x] FFI with Lua.
 - [x] Dead Code Elimination (DCE).
 - [x] Code inlining.
-- [x] [Package Set](https://github.com/Unisay/purescript-lua-package-sets) for PureScript/Lua libs.
+- [x] [Package Set](https://github.com/purescript-lua/purescript-lua-package-sets) for PureScript/Lua libs.
 - [x] All core libs added to the package set.
 
 ## Quick Start
@@ -56,15 +56,15 @@ Assuming that `pslua` executable is already available on your PATH
 ### Using nix with flakes
 
 ```
-nix run 'github:Unisay/purescript-lua' -- --help
+nix run 'github:purescript-lua/purescript-lua' -- --help
 ```
 
 ## Installation
 
-If you're on a x86 64bit Linux system then you can download a pre-built executable from the [releases](https://github.com/Unisay/purescript-lua/releases) page:
+If you're on a x86 64bit Linux system then you can download a pre-built executable from the [releases](https://github.com/purescript-lua/purescript-lua/releases) page:
 
 ```
-wget -c https://github.com/Unisay/purescript-lua/releases/download/0.1.1-alpha/pslua-linux_x86_64.tar.gz -O - | tar -xz
+wget -c https://github.com/purescript-lua/purescript-lua/releases/download/0.1.1-alpha/pslua-linux_x86_64.tar.gz -O - | tar -xz
 ```
 
 alternatively,
@@ -72,7 +72,7 @@ alternatively,
 ### Using nix with flakes
 
 ```
-nix profile install 'github:Unisay/purescript-lua'
+nix profile install 'github:purescript-lua/purescript-lua'
 ```
 
 will make `pslua` executable available for use.

--- a/test/ps/golden/Golden/StringCodePoints/Test.purs
+++ b/test/ps/golden/Golden/StringCodePoints/Test.purs
@@ -1,5 +1,5 @@
 -- Exercises Data.String.CodePoints end to end on the released package set
--- (Unisay/purescript-lua-strings v6.2.0). The test string mixes UTF-8 widths
+-- (purescript-lua/purescript-lua-strings v6.2.0). The test string mixes UTF-8 widths
 -- 1..4: 'a' (1 byte), 'é' (2), 'Я' (2, Cyrillic), '𝐀' (4, astral), 'z' (1).
 -- Output is all Ints/Bools via fromEnum so the golden stays ASCII and does
 -- not depend on how strings are shown.

--- a/test/ps/packages.dhall
+++ b/test/ps/packages.dhall
@@ -3,7 +3,7 @@ let upstream-ps =
         sha256:e48c9b283ca89ec994453459fb74c4b5b5a9432349f83a2e104f39dd869a0f6e
 
 let upstream-lua =
-      https://github.com/Unisay/purescript-lua-package-sets/releases/download/psc-0.15.15-20260613-2/packages.dhall
+      https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260613-2/packages.dhall
         sha256:b006e1fd8aa8cd290faf65852f37f62ad3bf5fe97fa3a7c30c97ff7ddfa49807
 
 in  upstream-ps // upstream-lua


### PR DESCRIPTION
The package set, the prelude/strings forks, and this compiler repo moved from `Unisay/*` to the `purescript-lua` org. This updates the README badges and links, the CLAUDE.md references, the test package-set URL (`test/ps/packages.dhall`, same release content so the sha256 freeze is unchanged), and a golden-test comment. The `template` and `example` repos stay under Unisay, so those two links are left as is.