### PR TITLE
address copilot review on #111: robust luacParse + looser local-count check

### DIFF
--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -9,6 +9,7 @@ import Data.List qualified as List
 import Data.String qualified as String
 import Data.Tagged (Tagged (..))
 import Data.Text qualified as Text
+import Data.Text.IO qualified as Text.IO
 import Language.PureScript.Backend.IR qualified as IR
 import Language.PureScript.Backend.IR.FlattenDeepBinds (flattenDeepBinds)
 import Language.PureScript.Backend.IR.Linker (LinkMode (..))
@@ -49,7 +50,6 @@ import Path.Posix (mkRelFile)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath qualified as FilePath
-import System.IO (hClose)
 import System.Process.Typed
   ( ExitCode (..)
   , proc
@@ -254,8 +254,10 @@ paths with spaces or concurrent runs.
 luacParse ∷ Text → IO (ExitCode, Text)
 luacParse src =
   withSystemTempFile "pslua-nesting.lua" \file handle → do
-    hClose handle
-    writeFileText (toFilePath file) src
+    -- Write through the handle the bracket owns and flush (so the separate
+    -- `luac` process sees the bytes); the bracket closes it on cleanup.
+    Text.IO.hPutStr handle src
+    hFlush handle
     (code, out) ← readProcessInterleaved (proc "luac" ["-p", toFilePath file])
     pure (code, decodeUtf8 out)
 

--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -43,13 +43,16 @@ import Path.IO
   , makeAbsolute
   , walkDirAccum
   , withCurrentDir
+  , withSystemTempFile
   )
 import Path.Posix (mkRelFile)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath qualified as FilePath
+import System.IO (hClose)
 import System.Process.Typed
   ( ExitCode (..)
+  , proc
   , readProcessInterleaved
   , runProcess
   , setWorkingDir
@@ -201,13 +204,17 @@ spec = do
         nested ← compileIr (AsModule psModname) uber
         flat ← compileIr (AsModule psModname) (flattenDeepBinds uber)
 
-        -- The unflattened spine is a single nested expression whose ONLY `local`
-        -- is the module table, so a load failure here cannot be Lua's
-        -- 200-locals-per-function cap — it can only be parser nesting.
-        Text.count "local " nested `shouldBe` 1
+        -- The error message below is the real discriminator: `luac` reports
+        -- "too many syntax levels" (nesting), a distinct message from its locals
+        -- error ("too many local variables"). As corroboration, the unflattened
+        -- spine is a single nested expression that introduces almost no locals,
+        -- so it sits far below Lua's 200-locals-per-function cap — that cap
+        -- cannot be why it fails to load. (A loose bound, not == 1, to stay
+        -- robust to unrelated module/runtime-setup locals the emitter may add.)
+        Text.count "local " nested `shouldSatisfy` (< 50)
 
-        (nestedExit, nestedOut) ← luacParse "pslua-applyspine-nested" nested
-        (flatExit, _flatOut) ← luacParse "pslua-applyspine-flat" flat
+        (nestedExit, nestedOut) ← luacParse nested
+        (flatExit, _flatOut) ← luacParse flat
 
         nestedExit `shouldSatisfy` (/= ExitSuccess)
         nestedOut `shouldSatisfy` ("too many syntax levels" `Text.isInfixOf`)
@@ -240,14 +247,17 @@ applySpineUberModule n =
       (IR.LiteralInt IR.noAnn (fromIntegral i))
 
 {- | Parse-check (no execution) a Lua source with @luac -p@; returns the exit
-code and combined output.
+code and combined output. Writes to a unique auto-cleaned temp file and invokes
+@luac@ via 'proc' (an argv list, no shell), so it is portable and safe against
+paths with spaces or concurrent runs.
 -}
-luacParse ∷ MonadIO m ⇒ String → Text → m (ExitCode, Text)
-luacParse name src = liftIO do
-  let file = "/tmp/" <> name <> ".lua"
-  writeFileText file src
-  (code, out) ← readProcessInterleaved (shell ("luac -p " <> file))
-  pure (code, decodeUtf8 out)
+luacParse ∷ Text → IO (ExitCode, Text)
+luacParse src =
+  withSystemTempFile "pslua-nesting.lua" \file handle → do
+    hClose handle
+    writeFileText (toFilePath file) src
+    (code, out) ← readProcessInterleaved (proc "luac" ["-p", toFilePath file])
+    pure (code, decodeUtf8 out)
 
 collectGoldenCorefns ∷ MonadIO m ⇒ Path Rel Dir → m [Path Abs File]
 collectGoldenCorefns = walkDirAccum


### PR DESCRIPTION
Follow-up to #111, applying both Copilot review comments on the parser-nesting reproduction test.

- **`Spec.hs:207`** — the unflattened local-count assertion was `== 1`, which is brittle to unrelated codegen changes (e.g. if the emitter later adds a module/runtime-setup `local`). Relaxed to `< 50`: still far below Lua's 200-locals cap (so it corroborates "the crash isn't the locals cap"), but robust. The real cause-discriminator is unchanged — `luac` reports `too many syntax levels`, a distinct message from its locals error.
- **`Spec.hs:250`** — `luacParse` wrote to a hard-coded `/tmp/...` path and ran `luac` via `shell` string concatenation. Switched to `withSystemTempFile` (unique, auto-cleaned) + `proc "luac" ["-p", file]` (argv list, no shell), so it is portable and safe against paths with spaces and concurrent test runs.

Test-only; the assertion still passes and still pins the failure to parser nesting.