### PR TITLE
chore: source the PureScript toolchain from purescript-overlay (#54)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,20 @@ The project uses **Nix with flakes** for reproducible builds and **Cabal** for H
 
 ### Toolchain
 
-Versions are pinned by the flake (`compiler-nix-name` and `easy-ps.purs-*`
-in `flake.nix`); update them there, not locally:
+Versions are pinned by the flake (`compiler-nix-name` and the
+`purs-bin.*` / `spago-bin.*` attrs in `flake.nix`); update them there, not
+locally:
 
 - **GHC**: 9.8.x (haskell.nix `ghc98`)
-- **PureScript**: `purs` 0.15.16 (from easy-purescript-nix; note that attr
-  names may carry an upstream release suffix, e.g. `purs-0_15_16-0`)
+- **PureScript**: `purs` 0.15.16, from [purescript-overlay] pinned as
+  `purs-bin.purs-0_15_16` (explicit pin so `nix flake update` never silently
+  bumps the compiler and churns goldens)
 - **Spago**: 0.21.x — the *legacy* Haskell spago driven by `spago.dhall` /
-  `packages.dhall` (not the newer `spago.yaml`-based one)
+  `packages.dhall` (not the newer `spago.yaml`-based one), pinned as
+  `spago-bin.spago-0_21_0`. NB: the overlay's plain `spago` attr now resolves
+  to the new PureScript spago (1.x), hence the explicit legacy pin.
+
+[purescript-overlay]: https://github.com/thomashoneyman/purescript-overlay
 
 ### Development Environment
 
@@ -312,8 +318,10 @@ often enough; add more when the bug spans several code paths).
 ## Updating Dependencies
 
 1. `nix flake update` — refreshes haskell.nix (and with it the Hackage
-   index pin), nixpkgs, and easy-purescript-nix. To bump GHC or `purs`,
-   edit `compiler-nix-name` / `easy-ps.purs-*` in `flake.nix`.
+   index pin), nixpkgs, and purescript-overlay. To bump GHC, `purs`, or
+   spago, edit `compiler-nix-name` / `purs-bin.*` / `spago-bin.*` in
+   `flake.nix` (the toolchain attrs are explicitly version-pinned, so a flake
+   update alone never changes them).
 2. PureScript package sets live in `test/ps/packages.dhall` as
    `upstream-ps // upstream-lua`. The right operand wins: `upstream-lua`
    (releases of `purescript-lua/purescript-lua-package-sets`) overrides core

--- a/flake.lock
+++ b/flake.lock
@@ -66,24 +66,6 @@
         "type": "github"
       }
     },
-    "easy-purescript-nix": {
-      "inputs": {
-        "flake-utils": "flake-utils"
-      },
-      "locked": {
-        "lastModified": 1763814099,
-        "narHash": "sha256-YazeA9u0JdxykexV6HHG5DMtsnwqXoiAcWPjncO1XHM=",
-        "owner": "justinwoo",
-        "repo": "easy-purescript-nix",
-        "rev": "8fcd84f54d75d9007b2f1c7c9da5af843105a55f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "justinwoo",
-        "repo": "easy-purescript-nix",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -101,27 +83,25 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "flake-compat_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -639,15 +619,36 @@
         "type": "github"
       }
     },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780972251,
+        "narHash": "sha256-PwHYPpfLP+WjSwj765zJ1N0Xp4ET3+8vRqxJ031ua3M=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "1cf88ab9d83596db0e0c0d304a16809c410e2917",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "easy-purescript-nix": "easy-purescript-nix",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
+        "purescript-overlay": "purescript-overlay",
         "treefmt-nix": "treefmt-nix"
       }
     },
@@ -668,21 +669,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,8 @@
     haskellNix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    easy-purescript-nix.url = "github:justinwoo/easy-purescript-nix";
+    purescript-overlay.url = "github:thomashoneyman/purescript-overlay";
+    purescript-overlay.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -13,7 +14,7 @@
       nixpkgs,
       flake-utils,
       haskellNix,
-      easy-purescript-nix,
+      purescript-overlay,
       treefmt-nix,
     }:
     let
@@ -22,13 +23,13 @@
     flake-utils.lib.eachSystem supportedSystems (
       system:
       let
-        easy-ps = easy-purescript-nix.packages.${system};
         pkgs = import nixpkgs {
           inherit system overlays;
           inherit (haskellNix) config;
         };
         overlays = [
           haskellNix.overlay
+          purescript-overlay.overlays.default
           (final: prev: {
             psluaProject = final.haskell-nix.project' {
               src = ./.;
@@ -58,8 +59,8 @@
                 };
                 buildInputs = with pkgs; [
                   cachix
-                  easy-ps.purs-0_15_16-0
-                  easy-ps.spago
+                  purs-bin.purs-0_15_16
+                  spago-bin.spago-0_21_0
                   lua51Packages.lua
                   lua51Packages.luacheck
                   nil


### PR DESCRIPTION
## What

Swap the dev-shell toolchain provider from [`easy-purescript-nix`](https://github.com/justinwoo/easy-purescript-nix) (lightly maintained, only packages legacy spago 0.21.0) to [`purescript-overlay`](https://github.com/thomashoneyman/purescript-overlay) — **without changing the build**: same `purs` 0.15.16, same legacy spago 0.21.0, same Dhall-based `test/ps` project.

This is the verified-safe prerequisite that unblocks #55 (migrate to the new spago), which becomes a one-attribute pin swap once the overlay is in place.

## Changes

- **`flake.nix`**: add `purescript-overlay` as an input (its `nixpkgs` follows ours) plus `purescript-overlay.overlays.default`; remove `easy-purescript-nix` entirely. Pin the toolchain explicitly as `purs-bin.purs-0_15_16` / `spago-bin.spago-0_21_0`.
- **`flake.lock`**: regenerated — `easy-purescript-nix` dropped, `purescript-overlay` added (its `nixpkgs` deduped via `follows`).
- **`CLAUDE.md`**: refresh the Toolchain and Updating-Dependencies prose.

## Why explicit `*-bin.*` pins (not plain `purs` / `spago`)

The overlay's stable `spago` now resolves to the **new PureScript spago 1.0.4**, so plain `spago` would not be the legacy 0.21 we want — the `spago-bin.spago-0_21_0` pin is mandatory. For consistency `purs` is pinned the same way (`purs-bin.purs-0_15_16`): the top-level `purs`/`spago` "stable" aliases are mutable across overlay versions, so an explicit pin stops a future `nix flake update` from silently bumping the compiler and churning goldens. Matches the repo's stated philosophy ("pinned by the flake; update them there, not locally").

## Verification

- `nix develop`: `purs --version` → **0.15.16**, `spago --version` → **0.21.0**.
- `cd test/ps && spago build -u '-g corefn'` → CoreFn regenerates **byte-identically** (no `corefn.json` diff), confirming the overlay's purs build matches easy-ps's.
- `cabal test all` → **314 examples, 0 failures**; no golden churn.
- `git diff` touches only `flake.nix`, `flake.lock`, `CLAUDE.md`.

## Out of scope (→ #55)

No `spago.yaml`, registry, package-set, or build-command changes; no new tools (`purs-tidy`/`purs-backend-es`) added to the shell.

Closes #54