### PR TITLE
Register pslua as a first-class Spago backend (`--run`) + docs on the published set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,17 @@ pslua \
   --entry Main.main
 ```
 
+`pslua` is also a first-class Spago backend (`workspace.backend.cmd: pslua` in
+`spago.yaml`). Spago compiles to CoreFn and then runs the backend command, so
+`spago build` links the project to Lua via the configured `--entry` /
+`--lua-output-file`. For `spago run`, Spago invokes the backend a second time
+as `pslua --run <Module>.<entry>` (without the build-phase args); `--run`
+compiles that entry point, writes it to a temp file, executes it with `lua`,
+and forwards lua's exit code (`Language.PureScript.Backend.Lua.Run.runChunk`).
+Foreign `.lua` files are resolved next to each module's source (recorded in the
+CoreFn `modulePath`), so dependency FFI in `.spago/**` is found automatically;
+`--foreign-path` is only a secondary fallback.
+
 ## Code Architecture
 
 ### Compilation Pipeline

--- a/README.md
+++ b/README.md
@@ -29,29 +29,35 @@ You can use this [template repository](https://github.com/purescript-lua/purescr
 
 Here is an another [example](https://github.com/purescript-lua/purescript-lua-example) project: Nginx server running Lua code using [OpenResty](https://openresty.org/).
 
-If you use [Spago](https://github.com/purescript/spago) to build your PureScript project, then you can configure `pslua` as a custom backend like this:
+If you use [Spago](https://github.com/purescript/spago) to build your PureScript project, configure `pslua` as a custom backend in `spago.yaml`. The package set is the published [Lua package set](https://github.com/purescript-lua/purescript-lua-package-sets) (the registry baseline with the Lua FFI forks overlaid), consumed via `workspace.packageSet.url`. Assuming `pslua` is on your PATH:
 
-<details> <summary>spago.dhall</summary>
+<details> <summary>spago.yaml</summary>
 
-Assuming that `pslua` executable is already available on your PATH
-
-```dhall
-{ name = "acme-project"
-, dependencies = [ "effect", "prelude" ]
-, packages = ./packages.dhall
-, sources = [ "src/**/*.purs" ]
-, backend =
-    ''
-    pslua \
-    --foreign-path . \
-    --ps-output output \
-    --lua-output-file dist/Acme_Main.lua \
-    --entry Acme.Main
-    ''
-}
+```yaml
+package:
+  name: acme-project
+  dependencies:
+    - effect
+    - prelude
+workspace:
+  packageSet:
+    url: https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260624/packages.json
+  backend:
+    cmd: pslua
+    args:
+      - --foreign-path
+      - .
+      - --ps-output
+      - output
+      - --lua-output-file
+      - dist/Acme_Main.lua
+      - --entry
+      - Acme.Main
 ```
 
 </details>
+
+With a backend configured, Spago compiles the project to CoreFn and then runs the backend command, so `spago build` links the result into `dist/Acme_Main.lua`. `spago run` additionally executes the entry point: Spago invokes `pslua --run Acme.Main`, which compiles and runs it with `lua`, forwarding lua's exit code.
 
 ### Using nix with flakes
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ workspace:
       - --ps-output
       - output
       - --lua-output-file
-      - dist/Acme_Main.lua
+      - dist/main.lua
       - --entry
-      - Acme.Main
+      - Main.main
 ```
 
 </details>
 
-With a backend configured, Spago compiles the project to CoreFn and then runs the backend command, so `spago build` links the result into `dist/Acme_Main.lua`. `spago run` additionally executes the entry point: Spago invokes `pslua --run Acme.Main`, which compiles and runs it with `lua`, forwarding lua's exit code.
+With a backend configured, Spago compiles the project to CoreFn and then runs the backend command, so `spago build` links the result into `dist/main.lua`. `spago run` additionally executes the entry point: Spago invokes `pslua --run Main.main`, which compiles and runs it with `lua`, forwarding lua's exit code. (`--run` needs an application entry point `<Module>.<binding>`.)
 
 ### Using nix with flakes
 

--- a/exe/Cli.hs
+++ b/exe/Cli.hs
@@ -127,7 +127,7 @@ options = do
             ]
       ]
   runEntry ←
-    optional . option (eitherReader parseAppOrModule) . fold $
+    optional . option (eitherReader parseRunEntry) . fold $
       [ metavar "ENTRY"
       , long "run"
       , helpDoc . Just $
@@ -142,6 +142,19 @@ options = do
             ]
       ]
   pure Args {..}
+
+{- | `--run` must name an application entry point (`<Module>.<binding>`): there
+is nothing to execute without a binding, so a bare module name is rejected.
+-}
+parseRunEntry ∷ String → Either String AppOrModule
+parseRunEntry s =
+  parseAppOrModule s >>= \case
+    app@AsApplication {} → pure app
+    AsModule _ →
+      Left $
+        "--run requires an application entry point <Module>.<binding> "
+          <> "(e.g. Main.main), not a bare module name: "
+          <> s
 
 parseAppOrModule ∷ String → Either String AppOrModule
 parseAppOrModule s = case splitOn "." (toText s) of

--- a/exe/Cli.hs
+++ b/exe/Cli.hs
@@ -47,6 +47,7 @@ data Args = Args
   , outputIR ∷ Maybe ExtraOutput
   , outputLuaAst ∷ Maybe ExtraOutput
   , appOrModule ∷ AppOrModule
+  , runEntry ∷ Maybe AppOrModule
   }
   deriving stock (Show)
 
@@ -123,6 +124,21 @@ options = do
             , "- Module format:" <+> magenta "<Module>"
             , green $ indent 2 "Example: Acme.Lib"
             , bold "Default: Main.main"
+            ]
+      ]
+  runEntry ←
+    optional . option (eitherReader parseAppOrModule) . fold $
+      [ metavar "ENTRY"
+      , long "run"
+      , helpDoc . Just $
+          vsep
+            [ "Compile the given application entry point and run it with"
+                <> softbreak
+                <> magenta "lua"
+                <> ", forwarding lua's exit code."
+            , "This is what" <+> magenta "spago run" <+> "invokes."
+            , "Format:" <+> magenta "<Module>.<binding>"
+            , green $ indent 2 "Example: Acme.App.main"
             ]
       ]
   pure Args {..}

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -9,6 +9,7 @@ import Language.PureScript.Backend qualified as Backend
 import Language.PureScript.Backend.IR qualified as IR
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
+import Language.PureScript.Backend.Lua.Run qualified as Run
 import Language.PureScript.Backend.Output (withOutputFile)
 import Language.PureScript.CoreFn.Reader qualified as CoreFn
 import Language.PureScript.Names (runIdent, runModuleName)
@@ -28,6 +29,7 @@ main = Utf8.withUtf8 do
     , outputLuaAst
     , psOutputPath
     , appOrModule
+    , runEntry
     } ←
     Cli.parseArguments
 
@@ -37,38 +39,50 @@ main = Utf8.withUtf8 do
         Path.Abs a → pure a
         Path.Rel r → Path.makeAbsolute r
 
-  luaOutput ←
-    case unTagged luaOutputFile of
-      Path.Abs a → pure a
-      Path.Rel r → Path.makeAbsolute r
+  -- `--run` overrides `--entry`: Spago's run phase invokes the backend a second
+  -- time as `pslua --run <Entry>` (without the build-phase args), so the entry
+  -- to compile comes from `--run` when present.
+  let entry = fromMaybe appOrModule runEntry
 
   let extraOutputs = catMaybes [outputLuaAst, outputIR]
 
   CompilationResult {lua, ir} ← do
-    putTextLn "PS Lua: compiling ..."
-    Backend.compileModules psOutputPath foreignDir appOrModule
+    -- Stay silent in run mode so the program's own stdout isn't polluted (the
+    -- output may be piped); Spago already logs the run/build phases itself.
+    when (isNothing runEntry) $ putTextLn "PS Lua: compiling ..."
+    Backend.compileModules psOutputPath foreignDir entry
       & handleModuleNotFoundError
       & handleModuleDecodingError
       & handleCoreFnError
       & handleLuaError
       & Oops.runOops
 
-  let outputFile = toFilePath luaOutput
-  withOutputFile luaOutput \h →
-    renderIO h . layoutPretty defaultLayoutOptions $
-      Printer.printLuaChunk lua
+  case runEntry of
+    Just _ →
+      -- Compile-and-run: execute the linked chunk and exit with lua's code.
+      Run.runChunk lua >>= exitWith
+    Nothing → do
+      luaOutput ←
+        case unTagged luaOutputFile of
+          Path.Abs a → pure a
+          Path.Rel r → Path.makeAbsolute r
 
-  when (OutputIR `elem` extraOutputs) do
-    irOutputPath ← replaceExtension ".ir" luaOutput
-    withOutputFile irOutputPath (`pHPrint` ir)
-    putTextLn $ "Wrote IR to " <> toText (toFilePath irOutputPath)
+      let outputFile = toFilePath luaOutput
+      withOutputFile luaOutput \h →
+        renderIO h . layoutPretty defaultLayoutOptions $
+          Printer.printLuaChunk lua
 
-  when (OutputLuaAst `elem` extraOutputs) do
-    luaAstOutputPath ← replaceExtension ".lua-ast" luaOutput
-    withOutputFile luaAstOutputPath (`pHPrint` lua)
-    putTextLn $ "Wrote Lua AST to " <> toText (toFilePath luaAstOutputPath)
+      when (OutputIR `elem` extraOutputs) do
+        irOutputPath ← replaceExtension ".ir" luaOutput
+        withOutputFile irOutputPath (`pHPrint` ir)
+        putTextLn $ "Wrote IR to " <> toText (toFilePath irOutputPath)
 
-  putTextLn $ "Wrote linked modules to " <> toText outputFile
+      when (OutputLuaAst `elem` extraOutputs) do
+        luaAstOutputPath ← replaceExtension ".lua-ast" luaOutput
+        withOutputFile luaAstOutputPath (`pHPrint` lua)
+        putTextLn $ "Wrote Lua AST to " <> toText (toFilePath luaAstOutputPath)
+
+      putTextLn $ "Wrote linked modules to " <> toText outputFile
 
 --------------------------------------------------------------------------------
 -- Error handlers --------------------------------------------------------------

--- a/lib/Language/PureScript/Backend/Lua/Run.hs
+++ b/lib/Language/PureScript/Backend/Lua/Run.hs
@@ -1,0 +1,29 @@
+module Language.PureScript.Backend.Lua.Run (runChunk) where
+
+import Language.PureScript.Backend.Lua.Printer qualified as Printer
+import Language.PureScript.Backend.Lua.Types qualified as Lua
+import Path (toFilePath)
+import Path.IO (withSystemTempFile)
+import Prettyprinter (defaultLayoutOptions, layoutPretty)
+import Prettyprinter.Render.Text (renderIO)
+import System.Exit (ExitCode)
+import System.IO (hSetEncoding, utf8)
+import System.Process.Typed (proc, runProcess)
+
+{- | Render a Lua chunk to a temporary file and execute it with the @lua@
+interpreter found on @PATH@, inheriting the parent's stdin/stdout/stderr and
+forwarding the interpreter's exit code verbatim.
+
+This is what makes @pslua@ a runnable Spago backend: for @spago run@, Spago
+first builds (the configured backend command emits the linked Lua), then invokes
+the backend a second time as @pslua --run <Module>.<entry>@; that second call
+compiles the entry point and hands the result here.
+-}
+runChunk ∷ Lua.Chunk → IO ExitCode
+runChunk chunk =
+  withSystemTempFile "pslua-run.lua" \file handle → do
+    hSetEncoding handle utf8
+    renderIO handle . layoutPretty defaultLayoutOptions $
+      Printer.printLuaChunk chunk
+    hFlush handle
+    runProcess (proc "lua" [toFilePath file])

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -103,6 +103,7 @@ common shared
     , template-haskell             ^>=2.21
     , text                         ^>=2.1.1
     , transformers                 ^>=0.6.1.1
+    , typed-process                ^>=0.2.11.1
     , vector                       ^>=0.13.1
 
   default-language:   Haskell2010
@@ -142,6 +143,7 @@ library
     Language.PureScript.Backend.Lua.NestingCheck
     Language.PureScript.Backend.Lua.Optimizer
     Language.PureScript.Backend.Lua.Printer
+    Language.PureScript.Backend.Lua.Run
     Language.PureScript.Backend.Lua.Traversal
     Language.PureScript.Backend.Lua.Types
     Language.PureScript.Backend.Output
@@ -179,6 +181,7 @@ test-suite spec
     Language.PureScript.Backend.Lua.NestingCheck.Spec
     Language.PureScript.Backend.Lua.Optimizer.Spec
     Language.PureScript.Backend.Lua.Printer.Spec
+    Language.PureScript.Backend.Lua.Run.Spec
     Language.PureScript.Backend.Output.Spec
     Test.Hspec.Expectations.Pretty
     Test.Hspec.Extra
@@ -207,4 +210,3 @@ test-suite spec
     , hspec-hedgehog                  ^>=0.1.1
     , HUnit                           ^>=1.6.2.0
     , pslua
-    , typed-process                   ^>=0.2.11.1

--- a/test/Language/PureScript/Backend/Lua/Run/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Run/Spec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Language.PureScript.Backend.Lua.Run.Spec where
+
+import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Run (runChunk)
+import Language.PureScript.Backend.Lua.Types qualified as Lua
+import System.Exit (ExitCode (..))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec ∷ Spec
+spec = describe "Lua.Run.runChunk (powers `spago run`)" do
+  it "runs a well-formed chunk through `lua` and reports success" do
+    -- `return print("…")` is a valid top-level Lua chunk; lua exits 0.
+    code ← runChunk [Lua.return (call [Lua.name|print|] [Lua.String "run-ok"])]
+    code `shouldBe` ExitSuccess
+
+  it "propagates the lua process exit code" do
+    -- `os.exit(3)` makes the interpreter exit with code 3; the wrapper must
+    -- forward it verbatim rather than swallowing it.
+    code ← runChunk [Lua.return (osExit 3)]
+    code `shouldBe` ExitFailure 3
+ where
+  call ∷ Lua.Name → [Lua.Exp] → Lua.Exp
+  call fn = Lua.functionCall (Lua.varName fn)
+
+  osExit ∷ Integer → Lua.Exp
+  osExit n =
+    Lua.functionCall
+      (Lua.varField (Lua.varName [Lua.name|os|]) [Lua.name|exit|])
+      [Lua.Integer n]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,6 +13,7 @@ import Language.PureScript.Backend.Lua.Linker.Foreign.Spec qualified as LuaLinke
 import Language.PureScript.Backend.Lua.NestingCheck.Spec qualified as NestingCheck
 import Language.PureScript.Backend.Lua.Optimizer.Spec qualified as LuaOptimizer
 import Language.PureScript.Backend.Lua.Printer.Spec qualified as Printer
+import Language.PureScript.Backend.Lua.Run.Spec qualified as Run
 import Language.PureScript.Backend.Output.Spec qualified as Output
 import Test.Hspec (hspec)
 
@@ -28,6 +29,7 @@ main = hspec do
   IROptimizer.spec
   LuaOptimizer.spec
   Printer.spec
+  Run.spec
   LuaLinkerForeign.spec
   NestingCheck.spec
   FlattenDeepBinds.spec


### PR DESCRIPTION
Part of #117. Makes `pslua` usable as a real Spago backend so `spago build` and `spago run` target Lua directly, and updates the docs to the new `spago.yaml` form.

## What Spago's backend contract actually is

I measured it empirically with a throwaway project pointed at the published Lua set. With a `workspace.backend` configured, Spago compiles to CoreFn and then runs the backend command:

- `spago build` runs `pslua <backend.args>` once. This already worked with no code change: `pslua` reads the corefn from `--ps-output`, and foreign `.lua` is resolved next to each module's source path recorded in the corefn (`modulePath`), so dependency FFI living in `.spago/**` is found automatically. `--foreign-path` is only a secondary fallback, not the primary lookup.
- `spago run` runs the build phase and then invokes the backend a second time as `pslua --run <Module>.<entry>`, without the build-phase args. `pslua` had no `--run`, so the run phase failed with `Invalid option --run` even though the build succeeded.

## The change

Add a `--run ENTRY` flag. It compiles the given application entry point, writes the linked chunk to a temp file, executes it with `lua`, and forwards lua's exit code. The execution lives in `Language.PureScript.Backend.Lua.Run.runChunk`, with a regression test that pins exit-code propagation (`os.exit(3)` must surface as `ExitFailure 3`, not be swallowed). `--run` overrides `--entry`, matching the run phase that passes only `--run`.

The progress line is suppressed in run mode so a program's own stdout stays clean when piped.

## Docs

- `README.md`: the legacy `spago.dhall` backend snippet is replaced with the `spago.yaml` form (`workspace.packageSet.url` at the published set plus `workspace.backend`), and a note on what `spago build` vs `spago run` do.
- `CLAUDE.md`: documents the backend contract, the `--run` round-trip, and the foreign-resolution rule.

## Out of scope

Migrating the template and example repos to the new `spago.yaml` is the other half of #117 and lands separately (those are direct pushes to their own repos). Library forks stay on the per-module manual `pslua` calls in `scripts/build`: a single backend command can only produce one entry point, which fits applications, not multi-module libraries.

## Testing

Full suite green (316 examples, 0 failures; the 2 new ones are the `runChunk` regression tests). No golden churn: codegen is untouched, so the `.ir`/`.lua`/eval goldens are unchanged. `spago run` verified end-to-end against the published set: build links `dist/Main.lua`, run prints the program output and exits 0.
