### PR TITLE
docs: add a changelog and refresh status ahead of 0.3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to `pslua` (the PureScript-to-Lua compiler) are recorded
+here. The format is based on [Keep a Changelog][keepachangelog], and the
+project follows the [Package Versioning Policy (PVP)][pvp].
+
+New entries are assembled from fragments in `changelog.d/` with
+[scriv][scriv] on each release.
+
+<!-- scriv-insert-here -->
+
+## 0.3.0.0 - 2026-06-25
+
+### Added
+
+- `pslua` is now a first-class [Spago][spago] backend. With
+  `workspace.backend.cmd: pslua` in `spago.yaml`, `spago build` links the
+  project to Lua, and a new `--run <Module>.<entry>` flag lets `spago run` and
+  `spago test` compile an entry point, execute it with `lua`, and forward the
+  interpreter's exit code (#117).
+- Projects consume the published [Lua package set][pkgset] through
+  `workspace.packageSet.url` in `spago.yaml`: the PureScript Registry baseline
+  with the Lua FFI forks overlaid.
+
+### Changed
+
+- Migrated the toolchain to the current Spago (`spago.yaml` + `spago.lock` and
+  the PureScript Registry), replacing the Dhall-based configuration (#55).
+- Deeply nested `Effect`/`ST` do-blocks (magic-do) and other deep monadic
+  spines are flattened so the generated Lua stays under the interpreter's
+  syntactic nesting limit (#46, #104, #108).
+- The Nix toolchain moved to [purescript-overlay][overlay] for a pinned `purs`
+  0.15.16 and Spago 1.0.4 (#54).
+
+### Fixed
+
+- De Bruijn indices are lowered correctly when a binder is removed, closing a
+  class of silent miscompilations (#56).
+- Eta reduction no longer rewrites programs unsoundly (#32); `shift`,
+  `substitute`, and free-reference counting now respect sequential `Let`
+  scoping (#37).
+- Array-literal pattern binders read 1-based Lua indices instead of 0-based
+  (#49).
+- `Char` literals are escaped correctly, and table literals are parenthesised
+  before they are indexed.
+- The parent directory of `--lua-output-file` is created when it is missing
+  (#61).
+
+## 0.2 - 2024-04-21
+
+### Changed
+
+- Added inline-annotation support and reorganised the golden test suite.
+- Removed `Prim.undefined` and stopped emitting unused function arguments.
+
+### Fixed
+
+- Foreign-expression precedence, foreign-header parsing, and `PSString`
+  escaping when used as an object property.
+- Pattern matching on qualified constructors.
+
+## 0.1.2-alpha - 2023-07-17
+
+### Added
+
+- Support for polymorphic record updates.
+
+## 0.1.1-alpha - 2023-07-15
+
+### Changed
+
+- Build and release workflow adjustments.
+
+## 0.1.0-alpha - 2023-07-06
+
+### Added
+
+- Initial alpha release of the PureScript-to-Lua compiler backend: CoreFn to
+  Lua compilation, FFI with Lua, dead code elimination, inlining, and bundling
+  into a Lua module or a standalone application.
+
+<!-- scriv-end-here -->
+
+[keepachangelog]: https://keepachangelog.com/en/1.1.0/
+[pvp]: https://pvp.haskell.org/
+[scriv]: https://scriv.readthedocs.io/
+[spago]: https://github.com/purescript/spago
+[pkgset]: https://github.com/purescript-lua/purescript-lua-package-sets
+[overlay]: https://github.com/thomashoneyman/purescript-overlay

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,19 @@ often enough; add more when the bug spans several code paths).
 5. If golden tests fail, inspect `actual.*` files in `test/ps/output/`
 6. Update golden files if changes are correct
 
+## Versioning and Releases
+
+`pslua` follows the **Package Versioning Policy (PVP)**, not SemVer: versions
+are four components `A.B.C.D` where `A.B` is the major version. The same string
+is used everywhere — the `version:` field in `pslua.cabal`, the git tag (no `v`
+prefix, e.g. `0.3.0.0`), the GitHub release, and the `CHANGELOG.md` section
+header — and they must agree. A three-component version anywhere is a mistake to
+fix, not a second convention. The changelog is managed with `scriv` (fragments
+in `changelog.d/`, assembled by `scriv collect --version <A.B.C.D>` on release).
+
+See `docs/VERSIONING.md` for the full policy, the meaning of each component, and
+the release checklist.
+
 ## Updating Dependencies
 
 1. `nix flake update` — refreshes haskell.nix (and with it the Hackage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Purescript Lua CI](https://github.com/purescript-lua/purescript-lua/actions/workflows/ci.yaml/badge.svg)](https://github.com/purescript-lua/purescript-lua/actions/workflows/ci.yaml)
 
-🔋 Status: (2024-04-20) the project is in the "_ready to be experimented with_" state (read: it likely contains bugs but is already usable). 
+🔋 Status: (2026-06-25) usable as a [Spago](https://github.com/purescript/spago) backend against the published [Lua package set](https://github.com/purescript-lua/purescript-lua-package-sets). Still pre-1.0: it likely contains bugs, but `spago build`/`run`/`test` already target Lua out of the box. See the [changelog](./CHANGELOG.md) for what changed in each release.
 
 💡 If you have an idea on how to use Purescript to Lua compilation please contribute it here:
 https://github.com/purescript-lua/purescript-lua/discussions/categories/ideas
@@ -15,6 +15,7 @@ https://github.com/purescript-lua/purescript-lua/discussions/categories/ideas
 - [x] Code inlining.
 - [x] [Package Set](https://github.com/purescript-lua/purescript-lua-package-sets) for PureScript/Lua libs.
 - [x] All core libs added to the package set.
+- [x] First-class [Spago](https://github.com/purescript/spago) backend: `spago build`, `spago run`, and `spago test` target Lua via `pslua`.
 
 ## Quick Start
 
@@ -104,10 +105,10 @@ Completed    newtype-0.2.2.0 (lib)
 
 .... elided ....
 
-Starting     pslua-0.1.0.0 (exe:pslua)
-Building     pslua-0.1.0.0 (exe:pslua)
-Installing   pslua-0.1.0.0 (exe:pslua)
-Completed    pslua-0.1.0.0 (exe:pslua)
+Starting     pslua-0.3.0.0 (exe:pslua)
+Building     pslua-0.3.0.0 (exe:pslua)
+Installing   pslua-0.3.0.0 (exe:pslua)
+Completed    pslua-0.3.0.0 (exe:pslua)
 Copying 'pslua.exe' to 'C:\cabal\bin\pslua.exe'
 ```
 

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,9 @@
+[scriv]
+format = md
+md_header_level = 2
+categories = Added, Changed, Fixed, Removed
+# Hyphen separator (Keep a Changelog style), not scriv's default em dash, so
+# collected entries match the hand-written backfill. The `%` are doubled
+# because scriv reads this file with configparser interpolation, which treats a
+# bare `%` specially; `%%` is an escaped literal `%`.
+entry_title_template = {%% if version %%}{{ version }} - {%% endif %%}{{ date.strftime('%%Y-%%m-%%d') }}

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,53 @@
+# Versioning and releases
+
+`pslua` follows the [Package Versioning Policy (PVP)][pvp], the versioning
+convention of the Haskell ecosystem. We use one policy, in one shape, across
+every artifact that carries a version, so the package, its tags, its releases,
+and its changelog never disagree.
+
+## The version number
+
+A version is four components, `A.B.C.D`:
+
+- `A.B` together are the **major** version. Bump them for any breaking change
+  (a removed or changed compiler flag, a change in generated-Lua semantics, a
+  breaking change to the public library API).
+- `C` is the **minor** version. Bump it for backwards-compatible additions
+  (a new flag, a new optimization that does not change existing output).
+- `D` is the **patch** version. Bump it for changes that add nothing to the
+  interface (bug fixes, internal refactors).
+
+This is PVP, not Semantic Versioning. SemVer's three-component `A.B.C` and PVP's
+four-component `A.B.C.D` look similar but split the "major" differently, so
+mixing them is the one thing to avoid. If you find a version written as three
+components anywhere, it is a mistake to correct, not a second convention.
+
+## Where the version lives
+
+The same string appears in all of these, and they must match:
+
+- the `version:` field in `pslua.cabal`;
+- the git tag for the release (for example `0.3.0.0`, without a `v` prefix, to
+  match the existing tags);
+- the GitHub release built from that tag;
+- the section header in [`CHANGELOG.md`](../CHANGELOG.md).
+
+Releases before `0.3.0.0` predate this policy: their tags are ad-hoc
+(`0.2`, `0.1.2-alpha`) and the cabal `version:` had drifted away from them
+entirely. `0.3.0.0` is where the four artifacts were unified; the historical
+changelog sections keep their original tag names on purpose, because those are
+the tags that actually exist.
+
+## Cutting a release
+
+1. Decide the new version from the nature of the changes (see above).
+2. Bump `version:` in `pslua.cabal`.
+3. Collect the changelog: `scriv collect --version <A.B.C.D>` assembles the
+   fragments from `changelog.d/` into a new `CHANGELOG.md` section. (Until the
+   fragment workflow is in routine use, the section may be written by hand in
+   the same format.)
+4. Merge to `main`.
+5. Tag `main` with `<A.B.C.D>` (annotated) and create the GitHub release, using
+   the new changelog section as the release notes.
+
+[pvp]: https://pvp.haskell.org/

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
                   lua51Packages.lua
                   lua51Packages.luacheck
                   nil
+                  scriv
                   upx
                   yamlfmt
                 ];

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -1,13 +1,15 @@
 cabal-version:      2.4
 name:               pslua
-version:            0.1.0.0
+version:            0.3.0.0
 license:            MIT
 copyright:          2023 Yura Lazarev
 author:             Yura Lazarev
 category:           Compiler
-extra-source-files:
-  LICENSE
+extra-doc-files:
+  CHANGELOG.md
   README.md
+
+extra-source-files: LICENSE
 
 common shared
   ghc-options:


### PR DESCRIPTION


## Why

`pslua` has release tags (the latest is `0.2`, from 2024-04-21) but no changelog. Since `0.2`, 85 commits have landed: De Bruijn index lowering, magic-do / deep do-block flattening, and the Spago-backend work. Nothing recorded what changed, so neither compiler users nor the forks that pin `pslua` by git rev could tell one release from another. This is the `pslua` side of #101.

## What

- Add `CHANGELOG.md`, backfilled with one section per existing tag and a detailed `0.3.0.0` section for the current cycle. It carries the scriv insert/end markers, so future releases collect into it instead of being written by hand.
- Add `changelog.d/scriv.ini`: Markdown output, `Added/Changed/Fixed/Removed` categories, and a hyphen title separator so collected entries match Keep a Changelog and the backfilled sections (the `%` are doubled because scriv reads the file through configparser interpolation).
- Reference `CHANGELOG.md` (and `README.md`) from the cabal `extra-doc-files`, so the changelog ships with any future source distribution.
- Settle the project on the Package Versioning Policy (PVP) and apply it consistently. The cabal `version:`, stuck at `0.1.0.0` and surfaced nowhere, is bumped to `0.3.0.0`; the changelog now references PVP instead of SemVer; and the cabal version, the release tag, and the changelog section all use the same four-component string.
- Record the versioning decision in `docs/VERSIONING.md`, with a pointer from `CLAUDE.md`.
- Provide `scriv` in the dev shell (`flake.nix` buildInputs), so `scriv create` / `scriv collect` work under `nix develop`.
- Refresh the README status line and Features list for the Spago backend.

The `0.3.0.0` entry covers only compiler changes. The FFI fork audit (#73-#100) lives in the package set, not here, so it belongs in the forks' own changelogs rather than this one.

## Scope

This is partial #101. The ecosystem canon (an ADR, a CONTRIBUTING fragment requirement, and the forks' changelogs) is a follow-up.

The tag `0.3.0.0` and its GitHub release will be cut from `main` once this merges, with the `0.3.0.0` changelog section as the release notes.

## Verification

- `scriv --version` resolves in the dev shell (1.7.0); `scriv create` parses the config; `scriv collect --version 0.4.0.0` produces a `## 0.4.0.0 - <date>` header consistent with the backfill.
- `nix fmt` clean.
- No code, build, or codegen changes, so the golden and unit suites are unaffected; the flake change touches only `shell.buildInputs`, not the package build.
