### PR TITLE
docs: require a changelog fragment per change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@
 - [ ] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
       in the dev shell), or this change ships nothing releasable (CI, docs, or an
       internal refactor).
-- [ ] `fourmolu -i lib/ exe/ test/` and `hlint lib/ exe/ test/` are clean.
-- [ ] `cabal test all` passes; structural goldens were re-accepted on purpose if
-      codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and `eval/golden.txt` still holds.
+- [ ] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
+      `hlint lib/ exe/ test/` are clean.
+- [ ] In the dev shell, `cabal test all` passes; structural goldens were
+      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
+      `eval/golden.txt` still holds.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Describe the change and link the issue it closes, if any. -->
+
+## Summary
+
+## Checklist
+
+- [ ] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
+      in the dev shell), or this change ships nothing releasable (CI, docs, or an
+      internal refactor).
+- [ ] `fourmolu -i lib/ exe/ test/` and `hlint lib/ exe/ test/` are clean.
+- [ ] `cabal test all` passes; structural goldens were re-accepted on purpose if
+      codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and `eval/golden.txt` still holds.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -50,4 +50,18 @@ the tags that actually exist.
 5. Tag `main` with `<A.B.C.D>` (annotated) and create the GitHub release, using
    the new changelog section as the release notes.
 
+## Changelog fragments
+
+Every user-facing change adds a fragment under `changelog.d/`: run `scriv create`
+in the dev shell (which provides `scriv`), pick the right category
+(Added/Changed/Fixed/Removed), and commit the fragment alongside the change. The
+pull request template carries this as a checklist item. A change that ships
+nothing releasable (CI, docs, an internal refactor) needs no fragment. On
+release, `scriv collect` (step 3 above) folds the pending fragments into a new
+`CHANGELOG.md` section.
+
+This mirrors the rest of the ecosystem: the set forks and the package set keep
+scriv changelogs too, with the shared reasoning recorded in the package set's
+[ADR 0009](https://github.com/purescript-lua/purescript-lua-package-sets/blob/master/docs/adr/0009-changelogs-via-scriv.md).
+
 [pvp]: https://pvp.haskell.org/


### PR DESCRIPTION
docs: require a changelog fragment per change

Closes #101.

This is the umbrella PR for the ecosystem-wide changelog work. The compiler already shipped its scriv config, `CHANGELOG.md`, and release flow in 0.3.0.0; what was missing was the contributor-facing process and the matching scaffold across the package set. This PR adds the former, and the rest landed in the other repos (linked below).

## In this repo

- A pull request template whose checklist asks for a `changelog.d/` fragment on any user-facing change.
- A "Changelog fragments" section in `docs/VERSIONING.md` describing `scriv create` per change and how it folds into a release.

Both are docs/CI only, so this PR ships no fragment of its own.

## Across the ecosystem (issue #101 scope)

- **Package set** (purescript-lua/purescript-lua-package-sets#6): ADR 0009 records the decision and supersedes the no-changelog clause of ADR 0006; CONTRIBUTING gains a Changelogs section and a `scriv collect` release step; the set gets its own backfilled `CHANGELOG.md`.
- **20 set forks** (arrays, assert, console, control, effect, enums, exceptions, foldable-traversable, functions, integers, lazy, numbers, partial, prelude, refs, safe-coerce, st, strings, unfoldable, unsafe-coerce): each got a scriv config, `scriv` in the dev shell, an `AGENTS.md` release note pointing at the scriv flow, and a `CHANGELOG.md` that records the Lua fork's release line above the preserved upstream history. The FFI-campaign tags (#73-#102) are backfilled; forks with no campaign release carry the scaffold only. Pushed straight to `master` per the fork convention (no `src/` change, so no tag or set bump).
- **lua-ngx** (purescript-lua/purescript-lua-ngx#7): the same scaffold, via PR.

## Note on ADR 0006

ADR 0006 had decided "no per-fork changelog" as deliberately light process. The FFI campaign changed that: the fork tags carry one line each and the only aggregation point was the set-bump commit messages. ADR 0009 reverses just that clause and leaves the tag-driven release flow intact.
