### PR TITLE
refactor: type-safe integer conversions with int-cast (#68)

### DIFF
--- a/changelog.d/20260625_113236_unisay_int_cast.md
+++ b/changelog.d/20260625_113236_unisay_int_cast.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Integer conversions in the compiler now go through `int-cast` instead of
+  `fromIntegral`. Provably safe widenings use `intCast`, which is a compile
+  error if the target cannot hold the source. The optimizer's rename lookup no
+  longer narrows the `Natural` De Bruijn index to `Int` to index a list; it
+  indexes by the `Natural` directly. The few deliberate byte truncations keep
+  `fromIntegral` with a comment. No change to generated code (#68).

--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -6,6 +6,7 @@ module Language.PureScript.Backend.IR
 
 import Control.Monad.Error.Class (MonadError (throwError))
 import Control.Monad.Writer.Class (MonadWriter (..))
+import Data.IntCast (intCast)
 import Data.List qualified as List
 import Data.List.NonEmpty ((<|))
 import Data.List.NonEmpty qualified as NE
@@ -432,7 +433,7 @@ mkCaseClauses = mkClauses Map.empty
          in case matchPat of
               PatAny →
                 nextMatch history clause'
-              PatArrayLength (fromIntegral → len) →
+              PatArrayLength (intCast → len) →
                 ifThenElse (literalInt len `eq` arrayLength expr)
                   <$> nextMatch history clause'
                   <*> nextClause history

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -155,7 +155,11 @@ renameShadowedNamesInExpr scope = go
       case qname of
         Local lname
           | Just renames ← Map.lookup lname scope
-          , Just rename ← renames !!? fromIntegral (unIndex index) →
+          , -- Index by the De Bruijn 'Natural' directly. 'genericDrop' takes it
+            -- with no narrowing 'Int' conversion, and an index past the end
+            -- yields '[]', so 'viaNonEmpty head' gives 'Nothing' (no rename).
+            Just rename ←
+              viaNonEmpty head (genericDrop (unIndex index) renames) →
               Ref ann (Local rename) 0
         _ → Ref ann qname index
     Let ann binds body →

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -699,8 +699,7 @@ substitute name idx replacement = substitute' idx
               boundNames = bindingNames grouping
               i' =
                 i
-                  + fromIntegral
-                    (length (filter ((name ==) . Local) boundNames))
+                  + genericLength (filter ((name ==) . Local) boundNames)
               repl' = foldr (\n r → shift 1 n 0 r) repl boundNames
       App ann argument function →
         App ann (go argument) (go function)
@@ -787,8 +786,7 @@ overFreeIndex adjust namespace = go
              where
               minIdx' =
                 minIdx
-                  + fromIntegral
-                    (length (filter (== namespace) (bindingNames grouping)))
+                  + genericLength (filter (== namespace) (bindingNames grouping))
       App ann argument function →
         App ann (go minIndex argument) (go minIndex function)
       LiteralArray ann as →
@@ -818,8 +816,8 @@ overFreeIndex adjust namespace = go
 e.g. when substituting a term under a λ that shadows the name.
 -}
 shift
-  ∷ Int
-  -- ^ The amount to shift by
+  ∷ Natural
+  -- ^ The amount to shift by (a non-negative count, hence 'Natural')
   → Name
   -- ^ The variable name to match (a.k.a. the namespace)
   → Index
@@ -829,7 +827,7 @@ shift
   → RawExp ann
 shift offset =
   overFreeIndex \minIndex index →
-    if minIndex <= index then index + fromIntegral offset else index
+    if minIndex <= index then index + Index offset else index
 
 {- | Decrease by one the index of references to the given name bound strictly
 above @minIndex@: the inverse of @shift 1@, to be applied after a binder for

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -12,6 +12,7 @@ import Control.Monad.Oops (CouldBe, Variant)
 import Control.Monad.Oops qualified as Oops
 import Control.Monad.Trans.Accum (AccumT, add, runAccumT)
 import Data.DList qualified as DList
+import Data.IntCast (intCast)
 import Data.List qualified as List
 import Data.Set qualified as Set
 import Data.Tagged (Tagged (..), untag)
@@ -183,7 +184,7 @@ fromIR foreigns topLevelNames modname ir = case ir of
     -- IR array indices are 0-based (de Bruijn-style, like the source language),
     -- but Lua tables are 1-based, so shift by one. This mirrors the arrays FFI
     -- `indexImpl`, which reads `xs[i + 1]`. See issue #49.
-    Right . flip Lua.varIndex (Lua.Integer (fromIntegral index + 1)) <$> goExp expr
+    Right . flip Lua.varIndex (Lua.Integer (intCast index + 1)) <$> goExp expr
   IR.ObjectProp _ann expr propName →
     Right . flip Lua.varField (fromPropName propName) <$> goExp expr
   IR.ObjectUpdate _ann expr propValues → do

--- a/lib/Language/PureScript/PSString.hs
+++ b/lib/Language/PureScript/PSString.hs
@@ -15,6 +15,7 @@ import Data.Aeson.Types qualified as A
 import Data.Bits (shiftR)
 import Data.ByteString qualified as BS
 import Data.Char qualified as Char
+import Data.IntCast (intCast)
 import Data.Scientific (toBoundedInteger)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf16BE)
@@ -54,7 +55,7 @@ REPLACEMENT CHARACTER. Because this function requires care to use correctly,
 we do not export it.
 -}
 codePoints ∷ PSString → String
-codePoints = map (either (Char.chr . fromIntegral) id) . decodeStringEither
+codePoints = map (either (Char.chr . intCast) id) . decodeStringEither
 
 {- |
 Decode a PSString as UTF-16 text. Lone surrogates will be replaced with
@@ -96,9 +97,13 @@ decodeString =
  where
   unpair w = [highByte w, lowByte w]
 
+  -- Deliberate narrowing: fromIntegral keeps the low 8 bits, which is exactly
+  -- the low byte we want. intCast would (correctly) reject Word16 → Word8.
   lowByte ∷ Word16 → Word8
   lowByte = fromIntegral
 
+  -- The shiftR 8 leaves a value in 0..255, so the narrowing to Word8 is always
+  -- exact; intCast cannot see that bound statically, so keep fromIntegral.
   highByte ∷ Word16 → Word8
   highByte = fromIntegral . (`shiftR` 8)
 
@@ -194,6 +199,7 @@ decodeStringEscaping s = foldMap encodeChar (decodeStringEither s)
              , Char.ModifierSymbol
              , Char.OtherSymbol
              ]
+
 {- |
 Pretty print a PSString, using JavaScript escape sequences. Intended for
 use in compiled JS output.
@@ -229,13 +235,15 @@ isSurrogate ∷ Word16 → Bool
 isSurrogate c = isLead c || isTrail c
 
 toChar ∷ Word16 → Char
-toChar = toEnum . fromIntegral
+toChar = toEnum . intCast
 
+-- Deliberate narrowing: callers (surrogate encoding in 'fromString') guarantee
+-- the Int is already in Word16 range, so the truncation never loses data.
 toWord ∷ Int → Word16
 toWord = fromIntegral
 
 toInt ∷ Word16 → Int
-toInt = fromIntegral
+toInt = intCast
 
 mkString ∷ Text → PSString
 mkString = fromString . T.unpack

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -85,6 +85,7 @@ common shared
     , dlist                        ^>=1.0
     , filepath                     ^>=1.4.300.1
     , fmt                          ^>=0.6.3.0
+    , int-cast                     ^>=0.2
     , lens                         ^>=5.2.3
     , megaparsec                   ^>=9.6.1
     , monoidal-containers          ^>=0.6.4.0


### PR DESCRIPTION

<!-- Describe the change and link the issue it closes, if any. -->

## Summary

Closes #68.

`fromIntegral` is unchecked: it silently truncates or wraps when the target is narrower than the source, and the type checker stays quiet. That is the class of bug behind the array-index off-by-one in #49. This swaps the integer coercions in `lib/` over to [`int-cast`](https://hackage.haskell.org/package/int-cast) so the safe ones are statically guaranteed and the lossy ones are forced into the open.

Per site:

- Provably safe widenings use `intCast`, which is a compile error if the target cannot hold every source value. These are `Word16 -> Int` in `PSString` (`toChar`, `toInt`, code-point decode), `Int -> Integer` in the `PatArrayLength` pattern, and `Natural -> Integer` in the Lua array-index codegen.
- The optimizer's rename lookup drops the narrowing rather than guarding it. It used to convert a `Natural` De Bruijn index to `Int` only because the safe list-index operator `!!?` is typed to `Int`, so a value past `maxBound :: Int` could have wrapped to a valid-but-wrong position. It now indexes the rename list by the `Natural` directly with `viaNonEmpty head (genericDrop ...)`, which is total and yields "no rename" for any out-of-range index.
- The De Bruijn count increments drop the conversion entirely. `genericLength` yields the `Index` directly and cannot go negative, and `shift` takes a `Natural` amount so the increment is a total newtype wrap.
- The deliberate byte truncations keep `fromIntegral` with a comment saying why (`lowByte`/`highByte`/`toWord` in `PSString`, where keeping the low bits is the point).

`toEnum`/`fromEnum` on `Char` are left as is, since `Char` is outside what `int-cast` covers, and `CoreFn/Laziness.hs` is left untouched because it is adapted from upstream `purs`.

No behavior change is intended. The only difference is in the unreachable regime (a De Bruijn index past `maxBound :: Int` or past the rename list), where the lookup now yields "no rename" instead of `fromIntegral` wrapping. The existing golden and eval suites are the regression guard rather than a new dedicated test, since that regime cannot be constructed in practice.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds. (Goldens unchanged: this is a pure refactor.)
