### PR TITLE
docs: document core compiler invariants as GHC-style Notes (#44)

### DIFF
--- a/changelog.d/20260625_123034_unisay_notes_core_invariants.md
+++ b/changelog.d/20260625_123034_unisay_notes_core_invariants.md
@@ -1,0 +1,10 @@
+### Changed
+
+- Documented three load-bearing compiler invariants as GHC-style `Note`s, each
+  cited from its dependent sites: `Note [PSString is UTF-16 code units, not
+  text]` (the lone-surrogate invariant, the dual JSON encoding, and the
+  decode-or-escape path into Lua), `Note [The PSLUA_runtime_lazy coupling]` (the
+  bare string that ties the laziness transform, the Lua fixture, the usage scan,
+  and the emit gate together), and `Note [Graph-based dead code elimination for
+  Lua]` (an overview of the keying, graph, reachability, and pruning steps).
+  Comments only; no change to generated code. First batch of #44.

--- a/lib/Language/PureScript/Backend.hs
+++ b/lib/Language/PureScript/Backend.hs
@@ -42,6 +42,7 @@ compileModules outputDir foreignDir appOrModule = do
   let uberModule =
         Linker.makeUberModule (linkerMode appOrModule) irModules
           & optimizedUberModule
+  -- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names
   let needsRuntimeLazy = Tagged (any untag needsRuntimeLazys)
   chunk ← Lua.fromUberModule foreignDir needsRuntimeLazy appOrModule uberModule
   let optimizedChunk = optimizeChunk chunk

--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -246,6 +246,7 @@ mkLiteral ann = \case
   Cfn.NumericLiteral (Right d) →
     pure $ LiteralFloat ann d
   Cfn.StringLiteral s →
+    -- See Note [PSString is UTF-16 code units, not text]
     pure $ LiteralString ann $ decodeStringEscaping s
   Cfn.CharLiteral c →
     pure $ LiteralChar ann c
@@ -614,6 +615,7 @@ mkBinder matchExp = go mempty
         Cfn.NumericLiteral (Right d) →
           pure $ matchWhole $ PatFloating d
         Cfn.StringLiteral s →
+          -- See Note [PSString is UTF-16 code units, not text]
           pure $ matchWhole $ PatString (decodeStringEscaping s)
         Cfn.CharLiteral c →
           pure $ matchWhole $ PatChar c

--- a/lib/Language/PureScript/Backend/IR/Query.hs
+++ b/lib/Language/PureScript/Backend/IR/Query.hs
@@ -29,6 +29,7 @@ usesRuntimeLazy UberModule {uberModuleBindings, uberModuleExports} =
       uberModuleBindings
       <> foldMap (Any . findRuntimeLazyInExpr . snd) uberModuleExports
 
+-- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names
 findRuntimeLazyInExpr ∷ Exp → Bool
 findRuntimeLazyInExpr expr =
   countFreeRef (Local (Name runtimeLazyName)) expr > 0

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -111,6 +111,7 @@ fromUberModule foreigns needsRuntimeLazy appOrModule uber = (`evalStateT` 0) do
       )
 
   pure . mconcat $
+    -- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names
     [ [Fixture.runtimeLazy | untag needsRuntimeLazy && usesRuntimeLazy uber]
     , [Fixture.objectUpdate | UsesObjectUpdate ← [usesObjectUpdate]]
     , [Lua.local1 Fixture.moduleName (Lua.table []) | not (null bindings)]
@@ -154,6 +155,7 @@ fromIR foreigns topLevelNames modname ir = case ir of
   IR.LiteralString _ann s →
     pure . Right $ Lua.String s
   IR.LiteralChar _ann c →
+    -- See Note [PSString is UTF-16 code units, not text]
     pure (Right (Lua.String (decodeStringEscaping (mkString (Text.singleton c)))))
   IR.LiteralBool _ann b →
     pure . Right $ Lua.Boolean b

--- a/lib/Language/PureScript/Backend/Lua/DCE.hs
+++ b/lib/Language/PureScript/Backend/Lua/DCE.hs
@@ -25,6 +25,41 @@ data DceMode = PreserveTopLevel | PreserveReturned
 type Label = Text
 type Key = Int
 
+{- Note [Graph-based dead code elimination for Lua]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'eliminateDeadCode' drops the Lua bindings and assignments that the chosen
+entry points cannot reach. It runs in four steps; the helpers below cooperate
+to implement them.
+
+1. Key and scope every node. 'makeNodesStatement' annotates each AST node with
+   a unique integer 'Key' ('assignKeys') and the lexical chain of 'Scope's in
+   force at that node ('assignScopes'). A 'Scope' maps an in-scope 'Name' to
+   the 'Key' of the 'Local' that binds it, so a use can be linked back to its
+   definition.
+
+2. Build a dependency graph. 'adjacencyList' (with the per-construct
+   '*AdjacencyList' helpers) emits one @(Label, Key, [Key])@ entry per node:
+   the keys that node depends on. A 'Local' depends on its later
+   re-'Assign'ments (and its initialiser); a 'VarName' use depends on the
+   binding key found through the scope chain; structural nodes depend on their
+   children and on the 'Return's reachable inside them.
+
+3. Compute reachability. 'graphFromEdges' turns the entries into a 'Graph';
+   'reachableVertices' is everything 'reachable' from 'dceEntryVertices'. The
+   entry set depends on 'DceMode': 'PreserveTopLevel' roots every top-level
+   statement (module output), 'PreserveReturned' roots only the final 'Return'
+   and its value (application output).
+
+4. Prune. 'dceStatement' / 'dceExpression' rebuild the chunk, keeping only
+   nodes whose vertex is reachable. An unreachable 'Local' is dropped; an
+   unreachable function parameter is demoted to 'ParamUnused' rather than
+   removed, so the function keeps its arity.
+
+Keys must be unique across the whole chunk for the graph to be well formed;
+'assignKeys' guarantees that with a single monotonic counter.
+-}
+
+-- See Note [Graph-based dead code elimination for Lua]
 eliminateDeadCode ∷ DceMode → Lua.Chunk → Lua.Chunk
 eliminateDeadCode dceMode chunk = do
   unNodesStatement <$> dceChunk statementWithNodes

--- a/lib/Language/PureScript/Backend/Lua/Fixture.hs
+++ b/lib/Language/PureScript/Backend/Lua/Fixture.hs
@@ -22,6 +22,7 @@ psluaName = Name.join2 [name|PSLUA|]
 moduleName ∷ Name.Name
 moduleName = [name|M|]
 
+-- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names
 runtimeLazyName ∷ Name
 runtimeLazyName = psluaName [name|runtime_lazy|]
 

--- a/lib/Language/PureScript/CoreFn/FromJSON.hs
+++ b/lib/Language/PureScript/CoreFn/FromJSON.hs
@@ -194,6 +194,7 @@ recordFromJSON ∷ (Value → Parser a) → Value → Parser [(PSString, a)]
 recordFromJSON p = listParser parsePair
  where
   parsePair v = do
+    -- See Note [PSString is UTF-16 code units, not text]
     (l, v') ← parseJSON v ∷ Parser (PSString, Value)
     a ← p v'
     return (l, a)

--- a/lib/Language/PureScript/Names.hs
+++ b/lib/Language/PureScript/Names.hs
@@ -84,7 +84,39 @@ runIdent = \case
       RuntimeLazyFactory → runtimeLazyName
       Lazy t → "Lazy_" <> t
 
-runtimeLazyName :: Text
+{- Note [The PSLUA_runtime_lazy coupling]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lazy (self-recursive) bindings are compiled to a reference to a runtime
+helper, the "runtime lazy factory", carried by the bare name 'runtimeLazyName'
+below. That one string, "PSLUA_runtime_lazy", silently couples four sites;
+they must stay in agreement.
+
+  * Here ('runtimeLazyName'): the ident the laziness transform emits.
+    'Language.PureScript.CoreFn.Laziness' rewrites a lazy binding into a
+    reference to @InternalIdent RuntimeLazyFactory@, whose 'runIdent' is
+    exactly this string, so it surfaces in the IR as
+    @Local (Name "PSLUA_runtime_lazy")@.
+
+  * 'Language.PureScript.Backend.Lua.Fixture.runtimeLazyName': the name of
+    the hand-written Lua fixture @local function PSLUA_runtime_lazy(...)@.
+    It is rebuilt independently as @psluaName [name|runtime_lazy|]@ and must
+    mangle to the same string, or the emitted call targets a Lua local that
+    does not exist.
+
+  * 'Language.PureScript.Backend.IR.Query.usesRuntimeLazy': scans the linked
+    UberModule for a free @Local (Name runtimeLazyName)@ to decide whether
+    the fixture is actually referenced.
+
+  * 'Language.PureScript.Backend' and the emitter in
+    'Language.PureScript.Backend.Lua.fromUberModule': emit the fixture iff it
+    is both needed (the laziness transform ran) and used (the scan finds a
+    reference).
+
+Rename either side of the string and the halves stop matching: the fixture is
+judged unused and dropped, or the generated code calls a binding that was
+never emitted. Either way laziness silently miscompiles.
+-}
+runtimeLazyName ∷ Text
 runtimeLazyName = "PSLUA_runtime_lazy"
 
 unusedIdent ∷ Text

--- a/lib/Language/PureScript/PSString.hs
+++ b/lib/Language/PureScript/PSString.hs
@@ -25,24 +25,41 @@ import System.IO.Unsafe (unsafePerformIO)
 import Text.Show (Show (..))
 import Prelude hiding (show)
 
-{- |
-Strings in PureScript are sequences of UTF-16 code units, which do not
-necessarily represent UTF-16 encoded text. For example, it is permissible
-for a string to contain *lone surrogates,* i.e. characters in the range
-U+D800 to U+DFFF which do not appear as a part of a surrogate pair.
+{- Note [PSString is UTF-16 code units, not text]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A PSString is a sequence of UTF-16 code units that does not necessarily
+represent well-formed UTF-16 text. It may contain lone surrogates: code
+units in U+D800..U+DFFF that are not part of a surrogate pair. This is
+faithful to PureScript, where a string literal can hold any code-unit
+sequence.
 
-The Show instance for PSString produces a string literal which would
-represent the same data were it inserted into a PureScript source file.
+Two consequences are load-bearing across the compiler.
 
-Because JSON parsers vary wildly in terms of how they deal with lone
-surrogates in JSON strings, the ToJSON instance for PSString produces JSON
-strings where that would be safe (i.e. when there are no lone surrogates),
-and arrays of UTF-16 code units (integers) otherwise.
+Dual JSON encoding. Because JSON parsers disagree on lone surrogates inside
+JSON strings, the 'A.ToJSON' instance emits a plain JSON string only when
+that is lossless (no lone surrogates) and otherwise falls back to an array
+of UTF-16 code units (integers). The 'A.FromJSON' instance therefore accepts
+both shapes. CoreFn reading relies on this for record labels and string
+literals (see 'Language.PureScript.CoreFn.FromJSON').
+
+Decode-or-escape into Lua. A lone surrogate has no corresponding 'Char', so
+code generation never decodes literal data with 'decodeString'. It uses
+'decodeStringEscaping', which renders decodable code points directly and
+emits a lone surrogate as a \xNNNNNN escape. The IR string and char literal
+sites and the Lua backend rely on this to avoid failing on otherwise-legal
+PureScript strings.
+-}
+
+{- | A sequence of UTF-16 code units, not necessarily well-formed UTF-16
+text. See Note [PSString is UTF-16 code units, not text].
 -}
 newtype PSString = PSString {toUTF16CodeUnits ∷ [Word16]}
   deriving stock (Eq, Ord, Generic)
   deriving newtype (Semigroup, Monoid)
 
+{- | Produces a string literal that would represent the same data if
+inserted into a PureScript source file.
+-}
 instance Show PSString where
   show = show . codePoints
 


### PR DESCRIPTION
## Summary

Part of #44, the first batch. It documents three load-bearing invariants as GHC-style `Note`s and points each dependent site back at them with a `See Note` comment. The change is comments only, so generated code, goldens, and eval oracles are unchanged.

- `Note [PSString is UTF-16 code units, not text]` in `PSString`. A `PSString` is a sequence of UTF-16 code units that may contain lone surrogates, so it is not always well-formed text. Two things lean on that. CoreFn JSON encodes such a string either as a JSON string or as an array of code units, so `FromJSON` has to accept both shapes. And code generation escapes rather than decodes, because a lone surrogate has no `Char`. Cited from `CoreFn.FromJSON` and the IR and Lua literal sites.

- `Note [The PSLUA_runtime_lazy coupling]` in `Names`. The bare string `PSLUA_runtime_lazy` ties four sites together: the ident the laziness transform emits, the hand-written Lua fixture of the same name, the scan in `IR.Query` that decides the fixture is referenced, and the emit gate in the backend. Rename either side and the halves stop matching, so the fixture is dropped as unused or the generated code calls a binding that was never emitted. Cited from `Lua.Fixture`, `IR.Query`, `Backend`, and the emitter in `Backend.Lua`.

- `Note [Graph-based dead code elimination for Lua]` in `Lua.DCE`. An overview of the four steps the module's six helpers implement: key and scope every node, build a dependency graph, compute reachability from the entry set, then prune unreachable bindings (demoting unused parameters rather than removing them, to keep arity).

I kept this batch to invariants that do not touch `CoreFn.Laziness`. That file is adapted from upstream `purs`, and the issue asks to weigh the divergence before retitling its comments, so its Notes will come in a later batch along with the decision-tree and Linker items.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
