### PR TITLE
docs: Notes for decision-tree case compilation and Linker foreign bindings (#44)

### DIFF
--- a/changelog.d/20260625_132407_unisay_notes_decision_tree_linker.md
+++ b/changelog.d/20260625_132407_unisay_notes_decision_tree_linker.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Documented two more compiler subsystems as GHC-style `Note`s, cited from
+  their dependent sites: `Note [Compiling case expressions to decision trees]`
+  (the Jacobs-based algorithm, with the scrutinee-binding, column-selection
+  heuristic, and match-history pruning sub-rules) and `Note [Foreign bindings
+  structure emitted by the Linker]` (the `ForeignImport` plus per-name
+  `ObjectProp` shapes that the IR dead-code pass matches by structure). Comments
+  only; no change to generated code. Continues #44.

--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -346,6 +346,59 @@ mkLet ann binds expr = do
 -- The algorithm is based on this document: ------------------------------------
 -- https://julesjacobs.com/notes/patternmatching/patternmatching.pdf -----------
 
+{- Note [Compiling case expressions to decision trees]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A CoreFn @case@ is compiled to a decision tree of nested if/else expressions,
+following Jules Jacobs' algorithm (linked above). 'mkCase' drives it; the
+types and helpers in this section implement the pieces.
+
+Data:
+
+  * 'Match' is one pattern test against a sub-value of a scrutinee: the
+    scrutinee expression ('matchExp'), the path of 'Step's into it
+    ('stepsToFocus', e.g. take field "value0" then array index 2), the
+    'Pattern' to test, the names this binder introduces ('matchBinds'), and the
+    'nestedMatches' for a constructor's or literal's fields.
+  * 'CaseClause' is one source alternative: its outstanding 'Match'es, its
+    result (or guarded results), and the bindings accumulated as matches pass.
+  * 'MatchHistory' records, per scrutinee expression, which constructor was
+    tested and whether the test succeeded; see the pruning paragraph.
+
+Pipeline:
+
+  1. 'mkBinder' turns each CoreFn 'Binder' into a 'Match', recording the
+     'stepsToFocus' that reach the matched sub-value. A newtype constructor
+     binder is erased here: it recurses straight into its single inner binder,
+     emitting no test of its own.
+  2. 'prepareBindings' binds each non-trivial scrutinee to a fresh name once,
+     so the tree refers to it instead of duplicating (and re-evaluating) it.
+     Literals and refs are left inline. See the scrutinee paragraph.
+  3. 'mkCaseClauses' / 'mkClause' build the tree clause by clause.
+     'matchChosenByHeuristic' picks which 'Match' of the current clause to test
+     next; on success the clause's remaining matches are tried ('nextMatch'),
+     on failure the next clause is tried ('nextClause'). When a clause has no
+     matches left its result is emitted (guards become a final nested if/else,
+     and 'usedClauseBinds' are let-bound around it).
+
+Binding scrutinees once ('prepareBindings'): a scrutinee that is not already a
+literal or a 'Ref' is bound to a fresh name, because the decision tree may test
+and project it many times. Without the shared binding each use would re-emit
+(and the codegen re-evaluate) the whole expression.
+
+Column-selection heuristic ('matchChosenByHeuristic'): when a clause has
+several outstanding matches, pick the one shared by the most other clauses
+('countAffectedClauses'). Testing a shared sub-value first lets one test serve
+many clauses, which keeps the tree small.
+
+Match-history pruning ('MatchHistory'): a constructor test on a given scrutinee
+is remembered as positive or negative. A later match on the same scrutinee is
+then pruned: a constructor already known to match proceeds without re-testing;
+one ruled out (a sibling matched positively, or this one matched negatively)
+falls straight through to the next clause. A 'ProductType' has one constructor,
+so it needs no tag test at all; a 'SumType' emits the @reflectCtor == ctorId@
+test.
+-}
+
 mkCase ∷ Ann → [CfnExp] → NonEmpty (Cfn.CaseAlternative Cfn.Ann) → RepM Exp
 mkCase ann cfnExpressions alternatives = do
   expressions ← traverse makeExpr cfnExpressions
@@ -490,6 +543,7 @@ mkCaseClauses = mkClauses Map.empty
 usedClauseBinds ∷ CaseClause → [Binding]
 usedClauseBinds CaseClause {clauseBindings} = clauseBindings
 
+-- See Note [Compiling case expressions to decision trees] (column heuristic)
 matchChosenByHeuristic
   ∷ CaseClause → [CaseClause] → Maybe (Match, CaseClause)
 matchChosenByHeuristic thisClause otherClauses =
@@ -663,6 +717,7 @@ mkBinder matchExp = go mempty
         , nestedMatches = mempty
         }
 
+-- See Note [Compiling case expressions to decision trees] (history pruning)
 type MatchHistory = Map Exp (CtorName, Bool)
 
 alternativeToClauses

--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -356,8 +356,9 @@ Data:
 
   * 'Match' is one pattern test against a sub-value of a scrutinee: the
     scrutinee expression ('matchExp'), the path of 'Step's into it
-    ('stepsToFocus', e.g. take field "value0" then array index 2), the
-    'Pattern' to test, the names this binder introduces ('matchBinds'), and the
+    ('stepsToFocus', e.g. take field "value0" then take the 0-based array
+    index 2; the Lua codegen shifts indices to 1-based), the 'Pattern' to
+    test, the names this binder introduces ('matchBinds'), and the
     'nestedMatches' for a constructor's or literal's fields.
   * 'CaseClause' is one source alternative: its outstanding 'Match'es, its
     result (or guarded results), and the bindings accumulated as matches pass.
@@ -372,7 +373,9 @@ Pipeline:
      emitting no test of its own.
   2. 'prepareBindings' binds each non-trivial scrutinee to a fresh name once,
      so the tree refers to it instead of duplicating (and re-evaluating) it.
-     Literals and refs are left inline. See the scrutinee paragraph.
+     Primitive literals (int, float, char, bool) and refs are left inline;
+     string, array, and object scrutinees are bound. See the scrutinee
+     paragraph.
   3. 'mkCaseClauses' / 'mkClause' build the tree clause by clause.
      'matchChosenByHeuristic' picks which 'Match' of the current clause to test
      next; on success the clause's remaining matches are tried ('nextMatch'),
@@ -381,9 +384,10 @@ Pipeline:
      and 'usedClauseBinds' are let-bound around it).
 
 Binding scrutinees once ('prepareBindings'): a scrutinee that is not already a
-literal or a 'Ref' is bound to a fresh name, because the decision tree may test
-and project it many times. Without the shared binding each use would re-emit
-(and the codegen re-evaluate) the whole expression.
+primitive literal (int, float, char, bool) or a 'Ref' is bound to a fresh
+name, because the decision tree may test and project it many times. Without
+the shared binding each use would re-emit (and the codegen re-evaluate) the
+whole expression. String, array, and object scrutinees are bound too.
 
 Column-selection heuristic ('matchChosenByHeuristic'): when a clause has
 several outstanding matches, pick the one shared by the most other clauses

--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -65,6 +65,7 @@ eliminateDeadCode uber@UberModule {..} =
   --           { outputOptionsCompact = True
   --           }
 
+  -- See Note [Foreign bindings structure emitted by the Linker]
   preservedForeigns ∷ [(QName, Exp)]
   preservedForeigns = do
     (name, expr) ← annotatedForeigns
@@ -111,6 +112,7 @@ eliminateDeadCode uber@UberModule {..} =
         (traverse (traverse (traverse assignUniqueIds)) uberModuleBindings)
         (traverse (traverse assignUniqueIds) uberModuleExports)
 
+  -- See Note [Foreign bindings structure emitted by the Linker]
   annotatedForeignImports ∷ [(QName, AExp)] =
     [i | i@(_qname, ForeignImport {}) ← annotatedForeigns]
 

--- a/lib/Language/PureScript/Backend/IR/Linker.hs
+++ b/lib/Language/PureScript/Backend/IR/Linker.hs
@@ -55,6 +55,24 @@ makeUberModule linkMode (topoSorted → modules) =
             ]
     }
 
+{- Note [Foreign bindings structure emitted by the Linker]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'foreignBindings' lowers a module's FFI into a fixed pair of expression shapes
+that downstream passes pattern-match by structure, so the producer here and the
+consumers must agree.
+
+  * One 'ForeignImport' per module that has any foreigns, bound to the special
+    name @foreign@ (@QName moduleName "foreign"@). It carries the module name,
+    the source path, and the list of foreign names.
+  * One 'ObjectProp' per foreign name, bound to @QName moduleName name@, that
+    reads that name as a field off the @foreign@ import and is marked
+    'Inline.Always'.
+
+'Language.PureScript.Backend.IR.DCE' depends on exactly these shapes: it splits
+the foreigns into 'ForeignImport's and 'ObjectProp's by pattern, and when it
+keeps a 'ForeignImport' it prunes the carried name list to the reachable names.
+Change either shape here and the DCE patterns silently stop matching.
+-}
 foreignBindings ∷ Module → [(QName, Exp)]
 foreignBindings Module {moduleName, modulePath, moduleForeigns} =
   foreignModuleBinding <> foreignNamesBindings

--- a/lib/Language/PureScript/Backend/IR/Linker.hs
+++ b/lib/Language/PureScript/Backend/IR/Linker.hs
@@ -62,8 +62,8 @@ that downstream passes pattern-match by structure, so the producer here and the
 consumers must agree.
 
   * One 'ForeignImport' per module that has any foreigns, bound to the special
-    name @foreign@ (@QName moduleName "foreign"@). It carries the module name,
-    the source path, and the list of foreign names.
+    name @foreign@ (@QName moduleName (Name "foreign")@). It carries the module
+    name, the source path, and the list of foreign names.
   * One 'ObjectProp' per foreign name, bound to @QName moduleName name@, that
     reads that name as a field off the @foreign@ import and is marked
     'Inline.Always'.


### PR DESCRIPTION
## Summary

Continues #44, the second batch. Two more High-priority subsystems get a GHC-style `Note`, with `See Note` backlinks from the sites that depend on them. Comments only, so generated code, goldens, and eval oracles are unchanged.

- `Note [Compiling case expressions to decision trees]` in `Backend.IR`. The case-compilation section had only a banner and a link to the Jacobs paper, yet it spans seven functions and four types. The Note lays out the data (`Match`, `CaseClause`, `MatchHistory`) and the pipeline (`mkBinder`, `prepareBindings`, `mkCaseClauses`), and folds in the two related Medium items the issue suggested: binding each scrutinee once and pruning constructor tests through the match history. Cited from `matchChosenByHeuristic` and the `MatchHistory` type.

- `Note [Foreign bindings structure emitted by the Linker]` in `IR.Linker`. The Linker lowers a module's FFI into a fixed pair of shapes: one `ForeignImport` bound to the special `foreign` name, and one `Inline.Always` `ObjectProp` per foreign name. The IR dead-code pass matches those shapes by structure, so the contract was load-bearing but documented only on the consumer side. Cited from the two consumer sites in `IR.DCE`.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
