### PR TITLE
fix: PSLUA_runtime_lazy did not memoize (state reset on every force)

### DIFF
--- a/changelog.d/20260625_185827_unisay_runtime_lazy_memoization.md
+++ b/changelog.d/20260625_185827_unisay_runtime_lazy_memoization.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The `PSLUA_runtime_lazy` runtime fixture now memoizes. Its `state` and `val`
+  locals were declared inside the forcing thunk, so they reset on every force:
+  a lazy recursive binding re-ran its initializer on every reference, returned a
+  fresh value each time (breaking reference identity), and looped instead of
+  reporting the "needed before it finished initializing" error on an ill-founded
+  cycle. The locals now live in the enclosing closure, so the initializer runs
+  at most once. A new `Lua.Run` test forces a counted initializer twice and
+  asserts it ran once.

--- a/lib/Language/PureScript/Backend/Lua/Fixture.hs
+++ b/lib/Language/PureScript/Backend/Lua/Fixture.hs
@@ -32,9 +32,9 @@ runtimeLazy =
     [__i|
     local function #{Name.toText runtimeLazyName}(name)
       return function(init)
+        local state = 0
+        local val = nil
         return function()
-          local state = 0
-          local val = nil
           if state == 2 then
             return val
           else

--- a/test/Language/PureScript/Backend/Lua/Run/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Run/Spec.hs
@@ -33,7 +33,7 @@ spec = describe "Lua.Run.runChunk (powers `spago run`)" do
             [ "local count = 0"
             , "local lazy = "
                 <> Lua.toText Fixture.runtimeLazyName
-                <> "(\"x\")(function() count = count + 1 return {} end)"
+                <> "(\"x\")(function() count = count + 1; return {} end)"
             , "lazy(1)"
             , "lazy(2)"
             , "os.exit(count == 1 and 0 or 1)"

--- a/test/Language/PureScript/Backend/Lua/Run/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Run/Spec.hs
@@ -2,6 +2,7 @@
 
 module Language.PureScript.Backend.Lua.Run.Spec where
 
+import Language.PureScript.Backend.Lua.Fixture qualified as Fixture
 import Language.PureScript.Backend.Lua.Name qualified as Lua
 import Language.PureScript.Backend.Lua.Run (runChunk)
 import Language.PureScript.Backend.Lua.Types qualified as Lua
@@ -20,6 +21,25 @@ spec = describe "Lua.Run.runChunk (powers `spago run`)" do
     -- forward it verbatim rather than swallowing it.
     code ← runChunk [Lua.return (osExit 3)]
     code `shouldBe` ExitFailure 3
+
+  it "PSLUA_runtime_lazy memoizes: the initializer runs at most once" do
+    -- Define the runtime-lazy fixture, build a lazy value whose initializer
+    -- bumps a counter, force it twice, and exit 0 only if the initializer ran
+    -- exactly once. A non-memoizing fixture runs it on every force and exits 1.
+    code ←
+      runChunk
+        [ Fixture.runtimeLazy
+        , Lua.ForeignSourceStat . unlines $
+            [ "local count = 0"
+            , "local lazy = "
+                <> Lua.toText Fixture.runtimeLazyName
+                <> "(\"x\")(function() count = count + 1 return {} end)"
+            , "lazy(1)"
+            , "lazy(2)"
+            , "os.exit(count == 1 and 0 or 1)"
+            ]
+        ]
+    code `shouldBe` ExitSuccess
  where
   call ∷ Lua.Name → [Lua.Exp] → Lua.Exp
   call fn = Lua.functionCall (Lua.varName fn)

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.ArrayPatternMatch.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayPatternMatch.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.DerivedFunctor.Test/golden.lua
+++ b/test/ps/output/Golden.DerivedFunctor.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.HelloPrelude.Test/golden.lua
+++ b/test/ps/output/Golden.HelloPrelude.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.Issue37.Test/golden.lua
+++ b/test/ps/output/Golden.Issue37.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.LongDoBlock.Test/golden.lua
+++ b/test/ps/output/Golden.LongDoBlock.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.MaybeChain.Test/golden.lua
+++ b/test/ps/output/Golden.MaybeChain.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.ProfunctorDictLens.Test/golden.lua
+++ b/test/ps/output/Golden.ProfunctorDictLens.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
@@ -1,8 +1,8 @@
 local function PSLUA_runtime_lazy(name)
   return function(init)
+    local state = 0
+    local val = nil
     return function()
-      local state = 0
-      local val = nil
       if state == 2 then
         return val
       else


### PR DESCRIPTION
## Summary

The `PSLUA_runtime_lazy` runtime fixture declared its `state` and `val` locals inside the forcing thunk (`return function() local state = 0 ... end`) rather than in the enclosing `function(init)` closure. Because a fresh `state`/`val` was created on every call to the thunk, the memoizing state machine never advanced past its initial state. All three of the fixture's jobs were dead code:

- The initializer re-ran on every reference to the lazy binding, instead of once.
- Each force returned a fresh value, so reference identity was not preserved (a correctness hazard for identity- or effect-bearing lazy values).
- An ill-founded cycle (a binding that forces itself during initialization) looped until the stack overflowed instead of raising the intended "X was needed before it finished initializing" error.

The fixture is emitted whenever the laziness transform falls back to a runtime lazy initializer, which happens for recursive binding groups it cannot statically order. It shows up in 13 of the golden outputs (typeclass-dictionary recursion), so real programs hit it.

The fix moves the two `local` declarations up one scope so they become upvalues of the returned thunk and persist across forces. The initializer now runs at most once.

I found this while reading `CoreFn.Laziness` to document it for #44; it is unrelated to the documentation work, so it ships on its own.

## How it was verified

A new `Lua.Run` test runs the actual fixture through `lua`: it builds a lazy value whose initializer bumps a counter, forces it twice, and exits 0 only if the counter is 1. The test was red before the fix (exit 1, initializer ran twice) and is green after. The 13 affected `golden.lua` files change only by the two-line move; `golden.ir` is untouched (the fixture is a codegen-level artifact).

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose because codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
