### PR TITLE
docs: Notes for the laziness runtime contract (#44)

### DIFF
--- a/changelog.d/20260625_191608_unisay_notes_laziness.md
+++ b/changelog.d/20260625_191608_unisay_notes_laziness.md
@@ -1,0 +1,10 @@
+### Changed
+
+- Documented the laziness runtime's cross-module contract: `Note [The runtimeLazy
+  calling convention]` in the Lua fixture spells out the curried
+  `name -> init -> force` shape and why `state`/`val` must live in the closure
+  that returns the forcing thunk, and `Note [Laziness transform for recursive
+  binding groups]` gives `CoreFn.Laziness` a citable anchor. Corrected two stale
+  comments inherited from the upstream JS backend (the factory takes two
+  arguments in the Lua port, not three, and the Lua fixture ignores the line
+  number). Comments only; no change to generated code. Continues #44.

--- a/lib/Language/PureScript/Backend/Lua/Fixture.hs
+++ b/lib/Language/PureScript/Backend/Lua/Fixture.hs
@@ -26,6 +26,34 @@ moduleName = [name|M|]
 runtimeLazyName ∷ Name
 runtimeLazyName = psluaName [name|runtime_lazy|]
 
+{- Note [The runtimeLazy calling convention]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'runtimeLazy' is the hand-written Lua fixture that the laziness transform
+('Language.PureScript.CoreFn.Laziness') calls to build a memoized,
+cycle-checked initializer for a recursive binding. The generated code and the
+fixture share a fixed curried calling convention:
+
+  PSLUA_runtime_lazy(name)(init)(line)
+
+  * @name@ (string): the identifier being initialized, used only in the
+    "<name> was needed before it finished initializing" message.
+  * @init@ (thunk): a nullary function holding the binding's initializer.
+  * The result is the forcing thunk, bound to the lazy name. Each force passes
+    a @line@ number (the source line of the reference); the fixture ignores it.
+
+'state' and 'val' live in the @function(init)@ closure, not in the forcing
+thunk, so they persist across forces: 'state' moves 0 (unforced) -> 1
+(forcing) -> 2 (done), and a force that re-enters while 'state' is 1 raises the
+cycle error. Declaring them inside the thunk instead resets them on every
+force, silently defeating both memoization and cycle detection.
+
+The transform builds the partial applications in 'fromRGI'
+(@runtimeLazy(name)(thunk)@) and the force calls in 'makeForceCall'
+(@lazyName(line)@). Keep this fixture's curried arity and the scope of
+'state'/'val' in step with those sites. Adapted from the PureScript JS
+backend's @$runtime_lazy@, a single 3-argument @(name, moduleName, init)@
+function; the Lua port is curried and omits @moduleName@.
+-}
 runtimeLazy ∷ Statement
 runtimeLazy =
   ForeignSourceStat

--- a/lib/Language/PureScript/Backend/Lua/Fixture.hs
+++ b/lib/Language/PureScript/Backend/Lua/Fixture.hs
@@ -38,8 +38,10 @@ fixture share a fixed curried calling convention:
   * @name@ (string): the identifier being initialized, used only in the
     "<name> was needed before it finished initializing" message.
   * @init@ (thunk): a nullary function holding the binding's initializer.
-  * The result is the forcing thunk, bound to the lazy name. Each force passes
-    a @line@ number (the source line of the reference); the fixture ignores it.
+  * The result is the forcing thunk, bound to the lazy name. Each force is
+    applied to one argument that the fixture ignores; the transform currently
+    hardcodes it to 0 (see 'makeForceCall'). In the JS backend this argument is
+    the reference's line number, used in the loop error message.
 
 'state' and 'val' live in the @function(init)@ closure, not in the forcing
 thunk, so they persist across forces: 'state' moves 0 (unforced) -> 1

--- a/lib/Language/PureScript/CoreFn/Laziness.hs
+++ b/lib/Language/PureScript/CoreFn/Laziness.hs
@@ -33,6 +33,18 @@ import Language.PureScript.PSString (mkString)
 import Prelude hiding (force)
 import qualified Data.List.NonEmpty as NE
 
+{- Note [Laziness transform for recursive binding groups]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'applyLazinessTransform' takes a recursive binding group and reorders it into a
+valid initialization order where one can be found statically, otherwise
+rewriting the offending bindings to lazy, run-time-checked initializers (see
+Note [The runtimeLazy calling convention] in
+Language.PureScript.Backend.Lua.Fixture). The analysis rests on the delay and
+force attributes and the USE-INIT / USE-USE / USE-IMMEDIATE ordering rules, both
+explained in the comments below. This anchor exists so the rest of the compiler
+can cite the transform by name.
+-}
+
 -- This module is responsible for ensuring that the bindings in recursive
 -- binding groups are initialized in a valid order, introducing run-time
 -- laziness and initialization checks as necessary.
@@ -644,10 +656,10 @@ applyLazinessTransform mn rawItems =
 
   makeForceCall ∷ Ann → Ident → Expr Ann
   makeForceCall _ ident =
-    -- We expect the functions produced by `runtimeLazy` to accept one
-    -- argument: the line number on which this reference is made. The runtime
-    -- code uses this number to generate a message that identifies where the
-    -- evaluation looped.
+    -- See Note [The runtimeLazy calling convention] in
+    -- Language.PureScript.Backend.Lua.Fixture. The force call is applied to one
+    -- argument, the line number of this reference. (The current Lua fixture
+    -- ignores it; the JS backend uses it in the loop error message.)
     App nullAnn (Var nullAnn . Qualified ByNullSourcePos $ lazifyIdent ident)
       . Literal nullAnn
       . NumericLiteral
@@ -657,9 +669,10 @@ applyLazinessTransform mn rawItems =
   fromRGI i = \case
     EagerBinding a e → ((a, i), e)
     LazyBinding a → ((a, i), makeForceCall a i)
-    -- We expect the `runtimeLazy` factory to accept three arguments: the
-    -- identifier being initialized, the name of the module, and of course a
-    -- thunk that actually contains the initialization code.
+    -- See Note [The runtimeLazy calling convention] in
+    -- Language.PureScript.Backend.Lua.Fixture. The factory is applied to two
+    -- arguments here: the identifier being initialized and the init thunk.
+    -- (The JS backend also threads the module name; the Lua fixture omits it.)
     LazyDefinition e →
       ( (nullAnn, lazifyIdent i)
       , app (app runtimeLazy (strLit (runIdent i))) (thunk e)

--- a/lib/Language/PureScript/CoreFn/Laziness.hs
+++ b/lib/Language/PureScript/CoreFn/Laziness.hs
@@ -658,8 +658,9 @@ applyLazinessTransform mn rawItems =
   makeForceCall _ ident =
     -- See Note [The runtimeLazy calling convention] in
     -- Language.PureScript.Backend.Lua.Fixture. The force call is applied to one
-    -- argument, the line number of this reference. (The current Lua fixture
-    -- ignores it; the JS backend uses it in the loop error message.)
+    -- argument, which this port hardcodes to 0 (the Ann is ignored) and the
+    -- fixture ignores too. In the JS backend it is the reference's line number,
+    -- used in the loop error message.
     App nullAnn (Var nullAnn . Qualified ByNullSourcePos $ lazifyIdent ident)
       . Literal nullAnn
       . NumericLiteral


### PR DESCRIPTION
## Summary

Continues #44, the laziness batch. The runtime-lazy path is the part of the compiler most exposed to silent breakage (the bug fixed in #126 lived here and went unnoticed because nothing documented or tested the contract). This batch documents that contract and corrects two stale comments. Comments only, so generated code, goldens, and eval oracles are unchanged.

- `Note [The runtimeLazy calling convention]` in `Backend.Lua.Fixture`. The fixture side had no comment at all. The Note spells out the curried `PSLUA_runtime_lazy(name)(init)(line)` shape, and in particular why `state` and `val` must live in the `function(init)` closure rather than the forcing thunk (declaring them in the thunk is exactly what broke memoization in #126). It also points back at the two transform sites that must keep the arity in step.

- `Note [Laziness transform for recursive binding groups]` in `CoreFn.Laziness`. The module had a thorough overview comment but no titled anchor, so nothing could cite the transform by name. This adds a short anchor that points at the existing prose.

- Corrected two comments inherited from the upstream JS backend that no longer match this port: the factory is applied to two arguments here (identifier, thunk), not three (the JS backend also threads the module name), and the Lua fixture ignores the line number passed to a force call (the JS backend uses it in the loop error message).

## A note on scope

`CoreFn.Laziness` is adapted from the upstream `purs` compiler, and the issue asks to weigh divergence before retitling its comments. The delay/force and USE-INIT/USE-USE/USE-IMMEDIATE rules there are already documented thoroughly and are only cited from within the file, so I deliberately left that prose untouched rather than wrap it in `Note` blocks for marginal intra-file benefit. The cross-module contract (the runtime-lazy convention) is where the citable Note earns its keep, and the fixture half of it is our own code.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
