### PR TITLE
docs: Notes for four Lua-backend invariants (#44)

### DIFF
--- a/changelog.d/20260625_200309_unisay_notes_lua_backend.md
+++ b/changelog.d/20260625_200309_unisay_notes_lua_backend.md
@@ -1,0 +1,12 @@
+### Changed
+
+- Documented four Lua-backend invariants as GHC-style `Note`s, cited from their
+  dependent sites: `Note [Lua reserved words as foreign export keys]` (the
+  `Key`/`reserved`/`toSafeName` round-trip across `Key`, `Name`, and the
+  backend), `Note [Lua operator precedence]` (titles the precedence table that
+  the `HasPrecedence` instances transcribe and the printer's parenthesisation
+  reads), `Note [Foreign module source format]` (the two load-bearing FFI-file
+  constraints: paren-wrapped values and a `return`-free header), and `Note
+  [Nullary functions and Prim.undefined]` (why `ParamUnused` and the
+  `Prim.undefined` argument elision must stay arity-synced). Comments only; no
+  change to generated code. Continues #44.

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -139,6 +139,17 @@ fromModuleName = Name.makeSafe . runModuleName
 fromPropName ∷ IR.PropName → Lua.Name
 fromPropName (IR.PropName name) = Name.makeSafe name
 
+{- Note [Nullary functions and Prim.undefined]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'ParamUnused' compiles to a zero-parameter Lua function and a 'Prim.undefined'
+argument compiles to a zero-argument call. These two arity-changing encodings
+are halves of one convention and must stay in sync. PureScript emits a thunk as
+@(\_unused -> body) Prim.undefined@, which 'fromIR' lowers to
+@(function() body end)()@: zero parameters, called with zero arguments. If only
+one side elided, the generated function and its call sites would disagree on
+arity. The Lua printer likewise drops 'ParamUnused' from the parameter list
+(Language.PureScript.Backend.Lua.Printer).
+-}
 fromIR
   ∷ ∀ e
    . e `CouldBe` Error
@@ -197,6 +208,7 @@ fromIR foreigns topLevelNames modname ir = case ir of
         Lua.tableRowNV (fromPropName propName) <$> goExp e
     pure . Right $
       Lua.functionCall (Lua.varName Fixture.objectUpdateName) [obj, vals]
+  -- See Note [Nullary functions and Prim.undefined]
   IR.Abs _ann param expr → do
     e ← goExp expr
     let luaParams = case param of
@@ -206,7 +218,8 @@ fromIR foreigns topLevelNames modname ir = case ir of
   IR.App _ann expr arg → do
     e ← goExp expr
     Right . Lua.functionCall e <$> case arg of
-      -- PS sometimes inserts syntetic unused argument "Prim.undefined"
+      -- See Note [Nullary functions and Prim.undefined]. PS sometimes inserts
+      -- a synthetic unused argument "Prim.undefined", which is elided here.
       IR.Ref _ann (IR.Imported (IR.ModuleName "Prim") (IR.Name "undefined")) _ →
         pure []
       _ → (: []) <$> goExp arg
@@ -267,6 +280,7 @@ fromIR foreigns topLevelNames modname ir = case ir of
     pure . Right $ Lua.error msg
   IR.ForeignImport _ann _moduleName path annotatedNames → do
     let foreignNames = fromName <<$>> annotatedNames
+    -- See Note [Foreign module source format] in ...Lua.Linker.Foreign
     Foreign.Source {header, exports} ←
       Oops.hoistEither =<< liftIO do
         left LinkerErrorForeign
@@ -275,8 +289,9 @@ fromIR foreigns topLevelNames modname ir = case ir of
           Lua.table
             [ Lua.tableRowNV name (Lua.ForeignSourceExp src)
             | (key, src) ← toList exports
-            , -- Export tables can contain Lua-reserved words as keys
-            -- for example: `{ ["for"] = 42 }`
+            , -- See Note [Lua reserved words as foreign export keys]
+            -- Export tables can contain Lua-reserved words as keys, for
+            -- example `{ ["for"] = 42 }`; toSafeName mangles them.
             let name = Key.toSafeName key
             , name `elem` fmap snd foreignNames
             ]

--- a/lib/Language/PureScript/Backend/Lua/Key.hs
+++ b/lib/Language/PureScript/Backend/Lua/Key.hs
@@ -12,6 +12,25 @@ import Language.PureScript.Backend.Lua.Name qualified as Name
 import Text.Megaparsec qualified as Mega
 import Text.Megaparsec.Char qualified as M
 
+{- Note [Lua reserved words as foreign export keys]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+An FFI foreign module exports its values through a Lua table, and a PureScript
+identifier that collides with a Lua keyword (@if@, @for@, @end@, ...) has to
+appear there as a bracketed string key: @{ ["for"] = ... }@. 'Key' captures
+that distinction: 'KeyName' for an ordinary identifier, 'KeyReserved' for a
+keyword read from @["..."]@ syntax.
+
+The round-trip spans three modules, which must agree on the keyword set:
+
+  * 'Language.PureScript.Backend.Lua.Name.reserved' is the authoritative set of
+    Lua keywords, and 'Name.makeSafe' mangles one (e.g. @if@ becomes @_if_@).
+  * 'parser' below reads a bracketed-quoted key as 'KeyReserved' by matching
+    against that set, and a bare identifier as 'KeyName'.
+  * 'toSafeName' maps a 'Key' back to a safe 'Name': 'KeyName' passes through,
+    'KeyReserved' goes through 'Name.makeSafe'. The Lua backend uses the result
+    as the export's table field name, so a reserved key reaches the generated
+    table as a mangled but valid identifier.
+-}
 data Key = KeyName Name | KeyReserved Text
   deriving stock (Eq, Show)
 

--- a/lib/Language/PureScript/Backend/Lua/Key.hs
+++ b/lib/Language/PureScript/Backend/Lua/Key.hs
@@ -22,8 +22,10 @@ keyword read from @["..."]@ syntax.
 
 The round-trip spans three modules, which must agree on the keyword set:
 
-  * 'Language.PureScript.Backend.Lua.Name.reserved' is the authoritative set of
-    Lua keywords, and 'Name.makeSafe' mangles one (e.g. @if@ becomes @_if_@).
+  * 'Language.PureScript.Backend.Lua.Name.reserved' is the reserved-word set the
+    backend escapes against -- the Lua keywords, kept conservative (it also
+    lists later additions like @goto@, harmless on the Lua 5.1 target) -- and
+    'Name.makeSafe' mangles one (e.g. @if@ becomes @_if_@).
   * 'parser' below reads a bracketed-quoted key as 'KeyReserved' by matching
     against that set, and a bare identifier as 'KeyName'.
   * 'toSafeName' maps a 'Key' back to a safe 'Name': 'KeyName' passes through,

--- a/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
+++ b/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
@@ -33,7 +33,7 @@ data Source = Source {header ∷ Maybe Text, exports ∷ NonEmpty (Key, Text)}
 {- Note [Foreign module source format]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The FFI file contract (see the Haddock on 'parseForeignSource' below) has two
-constraints that are easy to miss and each load-bearing:
+constraints that are easy to miss and each is load-bearing:
 
   * Every export value is wrapped in parentheses: @name = (<value>)@. The
     parens delimit the value so 'valueParser' can extract a balanced Lua

--- a/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
+++ b/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
@@ -30,6 +30,25 @@ import Prelude hiding (show)
 data Source = Source {header ∷ Maybe Text, exports ∷ NonEmpty (Key, Text)}
   deriving stock (Eq, Show)
 
+{- Note [Foreign module source format]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The FFI file contract (see the Haddock on 'parseForeignSource' below) has two
+constraints that are easy to miss and each load-bearing:
+
+  * Every export value is wrapped in parentheses: @name = (<value>)@. The
+    parens delimit the value so 'valueParser' can extract a balanced Lua
+    expression by counting nested @()@; without them it cannot tell where one
+    export ends and the next begins.
+  * The optional header must contain no @return@. 'parseForeignSource' splits
+    the file at the first line beginning with @return@ ('break isReturn'),
+    taking everything before it as the shared header and the rest as the export
+    table; a @return@ in the header would truncate it.
+
+The result is a two-part 'Source' (optional 'header', non-empty 'exports'),
+which 'Language.PureScript.Backend.Lua' consumes: the header becomes a
+'ForeignSourceStat' and each export a table row keyed by 'Key.toSafeName'.
+-}
+
 {- | Parse a foreign source file which has to be in the following format:
 @@
   <header>
@@ -49,6 +68,7 @@ parseForeignSource ∷ Path Abs Dir → FilePath → IO (Either Error Source)
 parseForeignSource foreigns path = runExceptT do
   filePath ← toFilePath <$> resolveForModule path foreigns
   src ← Text.strip . decodeUtf8 <$> liftIO (readFileBS filePath)
+  -- See Note [Foreign module source format] (header must contain no return)
   let (headerLines, returnStat) = break isReturn (Text.lines src)
   case Megaparsec.parse moduleParser filePath (unlines returnStat) of
     Left err → throwE $ ForeignErrorParse filePath err
@@ -94,11 +114,13 @@ moduleParser = do
 
 foreignExport ∷ Parser (Key, Text)
 foreignExport = do
+  -- See Note [Lua reserved words as foreign export keys] in ...Backend.Lua.Key
   exportKey ← Key.parser
   char '='
   exportValue ← valueParser
   pure (exportKey, toText exportValue)
 
+-- See Note [Foreign module source format] (values are paren-wrapped)
 valueParser ∷ Parser String
 valueParser = char '(' *> go 0 DL.empty <* MP.space
  where

--- a/lib/Language/PureScript/Backend/Lua/Name.hs
+++ b/lib/Language/PureScript/Backend/Lua/Name.hs
@@ -94,6 +94,7 @@ specialNameType = Name "$type"
 specialNameCtor ∷ Name
 specialNameCtor = Name "$ctor"
 
+-- See Note [Lua reserved words as foreign export keys] in ...Backend.Lua.Key
 reserved ∷ Set Text
 reserved =
   Set.fromList

--- a/lib/Language/PureScript/Backend/Lua/Printer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Printer.hs
@@ -81,6 +81,7 @@ printExp = \case
 printUnaryOp ∷ Lua.UnaryOp → PADoc → PADoc
 printUnaryOp op (_, a) = (prec op, pretty (sym op) <> parens a)
 
+-- See Note [Lua operator precedence] in ...Backend.Lua.Types
 printBinaryOp ∷ Lua.BinaryOp → PADoc → PADoc → PADoc
 printBinaryOp op l r =
   (prec op, wrapPrec op l <+> pretty (sym op) <+> wrapPrec op r)

--- a/lib/Language/PureScript/Backend/Lua/Types.hs
+++ b/lib/Language/PureScript/Backend/Lua/Types.hs
@@ -118,7 +118,11 @@ data BinaryOp
   | Exp
   deriving stock (Show, Eq, Ord, Enum, Bounded)
 
-{- 1   or
+{- Note [Lua operator precedence]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Lua's operators bind at these levels (1 loosest, 12 tightest):
+
+   1   or
    2   and
    3   <     >     <=    >=    ~=    ==
    4   |
@@ -130,6 +134,12 @@ data BinaryOp
    10  *     /     //    %
    11  unary operators (not   #     -     ~)
    12  ^
+
+The 'HasPrecedence' instances for 'BinaryOp' and 'UnaryOp' transcribe this
+table into 'PrecOperation' levels. 'Language.PureScript.Backend.Lua.Printer'
+parenthesises an operand only when its precedence is looser than the enclosing
+operator's ('wrapPrec'). Keep the instances and this table in step, or the
+printer emits wrongly-associated or over-bracketed expressions.
 -}
 
 instance HasPrecedence BinaryOp where


### PR DESCRIPTION
## Summary

Continues #44, the Lua-backend batch. Four Medium-priority invariants get a GHC-style `Note`, each cited from the sites that depend on it. Comments only, so generated code, goldens, and eval oracles are unchanged.

- `Note [Lua reserved words as foreign export keys]` in `Backend.Lua.Key`. A foreign export whose name is a Lua keyword has to appear as a bracketed key (`{ ["for"] = ... }`). The Note ties together the three modules that must agree on the keyword set: `Name.reserved`/`Name.makeSafe`, the `Key` parser, and `Key.toSafeName` as used by the backend.

- `Note [Lua operator precedence]` in `Backend.Lua.Types`. The Lua 5.x precedence table was an anonymous comment block; this titles it and explains that the `HasPrecedence` instances transcribe it and the printer's `wrapPrec` reads it to decide parenthesisation. Cited from `Printer.printBinaryOp`.

- `Note [Foreign module source format]` in `Backend.Lua.Linker.Foreign`. Calls out the two easy-to-miss FFI-file constraints, each enforced by a separate parser: every export value is paren-wrapped (so `valueParser` can balance it), and the optional header contains no `return` (so the `break isReturn` split works). Cited from both parser sites and the backend consumer.

- `Note [Nullary functions and Prim.undefined]` in `Backend.Lua`. `ParamUnused` becoming a zero-parameter function and a `Prim.undefined` argument becoming a zero-argument call are two halves of one arity-changing convention that must stay in sync. Only one half was commented before.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
