### PR TITLE
docs: close out the GHC-style Note pass (#44)

### DIFF
--- a/changelog.d/20260625_203341_unisay_notes_low_items.md
+++ b/changelog.d/20260625_203341_unisay_notes_low_items.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Documented the optimizer's `Note [IR is assumed well-typed]`, cited from the
+  constant-folding and beta-reduction rewrites that rely on it, and made the
+  conscious calls on the remaining low-priority candidates from #44 (leaving the
+  already-adequate inline comments in place). This closes out the GHC-style
+  `Note` documentation pass (#44). Comments only; no change to generated code.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -300,13 +300,22 @@ optimizedExpression =
       `thenRewrite` removeIfWithEqualBranches
       `thenRewrite` inlineLocalBindings
 
+{- Note [IR is assumed well-typed]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The optimizer assumes its input IR is well-typed -- it has already passed the
+PureScript type checker -- and several rewrites rely on that rather than
+re-checking. 'constantFolding' rewrites @Eq True b@ to @b@ on the grounds that
+@b@ must then be a 'Bool', and 'betaReduce' substitutes an argument for a
+parameter without checking their types match. A rewrite must not introduce an
+assumption the type checker would not already guarantee.
+-}
 constantFolding ∷ RewriteRule Ann
 constantFolding =
   pure . \case
     Eq _ (LiteralBool _ a) (LiteralBool _ b) →
       Rewritten Stop $ literalBool $ a == b
     Eq _ (LiteralBool _ True) b →
-      -- 'b' must be of type Bool
+      -- 'b' must be of type Bool; see Note [IR is assumed well-typed]
       Rewritten Stop b
     Eq _ (LiteralInt _ a) (LiteralInt _ b) →
       Rewritten Stop $ literalBool $ a == b
@@ -319,6 +328,7 @@ constantFolding =
     _ → NoChange
 
 -- (λx. M) N ===> M[x := N]
+-- See Note [IR is assumed well-typed]
 betaReduce ∷ RewriteRule Ann
 betaReduce =
   pure . \case


### PR DESCRIPTION
## Summary

The final #44 batch. It adds the one remaining low-priority Note that earns its keep and makes a conscious call on the rest, so the issue's "decide consciously rather than by omission" goal is met for every listed item. Comments only, so generated code, goldens, and eval oracles are unchanged.

Closes #44.

- Added `Note [IR is assumed well-typed]` in `IR.Optimizer`. The optimizer trusts the type checker rather than re-checking: `constantFolding` rewrites `Eq True b` to `b` because `b` must be a `Bool`, and `betaReduce` substitutes an argument for a parameter without checking the types match. Cited from both rewrites.

## Conscious calls on the rest

Left as adequate inline documentation (a titled Note would add ceremony without a second citation site):

- `InternalIdentData` (`Names`) already has a complete Haddock.
- "Prim is always imported" (`Backend.IR.mkImports`) has a one-line comment explaining the always-add-then-DCE approach; it is a single site.
- `unsafePerformIO` in `PSString.decodeString` already carries the standard safety argument.
- The case-alternatives ASCII diagram lives in the IR spec; it is test-local and fine where it is.

Deliberately not retitled, to avoid divergence from upstream `purs`:

- The remaining `CoreFn.Laziness` prose (the full delay/force rules, the USE-INIT/USE-USE/USE-IMMEDIATE derivation, and the `MaxRoseTree` termination argument) is thorough and only cited from within that file. Batch 3 already gave the cross-module contract (the runtime-lazy convention) and the transform a citable anchor; titling the rest would diverge from the adapted upstream source for marginal benefit.

## Note discovered along the way

`@inline never` does not currently veto inlining (documented in `Note [Inline annotations and inlining heuristics]` from the previous batch): `isInlinableExpr` treats `Just Never` like `Nothing`, so a ref / small literal / single-use binding is still inlined. Flagging it here; whether `never` should actually veto is a behavior question for a separate change, not this docs pass.

## Checklist

- [x] Added a `changelog.d/` fragment for any user-facing change (`scriv create`
      in the dev shell), or this change ships nothing releasable (CI, docs, or an
      internal refactor).
- [x] In the dev shell (`nix develop`), `fourmolu -i lib/ exe/ test/` and
      `hlint lib/ exe/ test/` are clean.
- [x] In the dev shell, `cabal test all` passes; structural goldens were
      re-accepted on purpose if codegen moved (`PSLUA_GOLDEN_ACCEPT=1`), and
      `eval/golden.txt` still holds.
