### PR TITLE
First-class passes for the IR pipeline: Pass values, invariant checks, deterministic name supply

### DIFF
--- a/changelog.d/20260703_120000_unisay_pass_pipeline.md
+++ b/changelog.d/20260703_120000_unisay_pass_pipeline.md
@@ -1,0 +1,14 @@
+### Added
+
+- A `--lint-ir` debug flag: checks IR well-scopedness invariants before and
+  after every optimizer pass (including every fixpoint iteration) and fails
+  compilation naming the offending pass. The same checks always run in the
+  test suite, so every golden module now doubles as a scope-invariant test
+  of the whole pipeline (#138).
+
+### Changed
+
+- The IR optimization pipeline is restructured into first-class passes:
+  each pass is a value carrying its invariant contract, sequenced by a
+  runner instead of plain function composition. Fresh names are drawn from
+  a deterministic supply. No change to generated code (#138).

--- a/changelog.d/20260703_121000_unisay_dce_nested_let.md
+++ b/changelog.d/20260703_121000_unisay_dce_nested_let.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- IR dead code elimination missed dead bindings of a `Let` that another,
+  fully dead `Let` collapsed into: the dead binding was kept while the
+  parameters of lambdas inside it were blanked, leaving unbound references
+  in the intermediate IR. The next optimizer iteration masked the damage,
+  so generated code was unaffected; the invariant checks introduced for
+  #138 surfaced the bug on the golden corpus.

--- a/exe/Cli.hs
+++ b/exe/Cli.hs
@@ -46,6 +46,7 @@ data Args = Args
   , luaOutputFile ∷ Tagged "output-lua" (SomeBase File)
   , outputIR ∷ Maybe ExtraOutput
   , outputLuaAst ∷ Maybe ExtraOutput
+  , lintIR ∷ Tagged "lint-ir" Bool
   , appOrModule ∷ AppOrModule
   , runEntry ∷ Maybe AppOrModule
   }
@@ -105,6 +106,14 @@ options = do
       [ long "output-ir"
       , helpDoc . Just $
           "Output IR."
+            <> linebreak
+            <> bold "Default: false"
+      ]
+  lintIR ←
+    flag (Tagged False) (Tagged True) . fold $
+      [ long "lint-ir"
+      , helpDoc . Just $
+          "Check IR invariants after every optimizer pass (debug)."
             <> linebreak
             <> bold "Default: false"
       ]

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -7,6 +7,7 @@ import Data.Tagged (Tagged (..))
 import Language.PureScript.Backend (CompilationResult (..))
 import Language.PureScript.Backend qualified as Backend
 import Language.PureScript.Backend.IR qualified as IR
+import Language.PureScript.Backend.IR.Pass (PassCheckFailure (..))
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
 import Language.PureScript.Backend.Lua.Run qualified as Run
@@ -27,6 +28,7 @@ main = Utf8.withUtf8 do
     , luaOutputFile
     , outputIR
     , outputLuaAst
+    , lintIR
     , psOutputPath
     , appOrModule
     , runEntry
@@ -50,10 +52,11 @@ main = Utf8.withUtf8 do
     -- Stay silent in run mode so the program's own stdout isn't polluted (the
     -- output may be piped); Spago already logs the run/build phases itself.
     when (isNothing runEntry) $ putTextLn "PS Lua: compiling ..."
-    Backend.compileModules psOutputPath foreignDir entry
+    Backend.compileModules psOutputPath foreignDir lintIR entry
       & handleModuleNotFoundError
       & handleModuleDecodingError
       & handleCoreFnError
+      & handlePassCheckFailure
       & handleLuaError
       & Oops.runOops
 
@@ -111,6 +114,20 @@ handleCoreFnError
 handleCoreFnError =
   Oops.catch \(e ∷ IR.CoreFnError) →
     die $ "CoreFn contains an unexpected value " <> show e
+
+handlePassCheckFailure
+  ∷ ExceptT (Oops.Variant (PassCheckFailure ': e)) IO a
+  → ExceptT (Oops.Variant e) IO a
+handlePassCheckFailure =
+  Oops.catch \PassCheckFailure {failedPassName, failedPhase, failedViolations} →
+    die . toString . unlines $
+      [ "IR invariants violated "
+          <> show failedPhase
+          <> " optimizer pass "
+          <> failedPassName
+          <> ":"
+      ]
+        <> (show <$> toList failedViolations)
 
 handleLuaError
   ∷ ExceptT (Oops.Variant (Lua.Error ': e)) IO a

--- a/lib/Language/PureScript/Backend.hs
+++ b/lib/Language/PureScript/Backend.hs
@@ -6,7 +6,11 @@ import Data.Map qualified as Map
 import Data.Tagged (Tagged (..), untag)
 import Language.PureScript.Backend.IR qualified as IR
 import Language.PureScript.Backend.IR.Linker qualified as Linker
-import Language.PureScript.Backend.IR.Optimizer (optimizedUberModule)
+import Language.PureScript.Backend.IR.Optimizer
+  ( optimizedUberModule
+  , optimizedUberModuleChecked
+  )
+import Language.PureScript.Backend.IR.Pass (PassCheckFailure)
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.NestingCheck (exceedsNestingLimit)
 import Language.PureScript.Backend.Lua.Optimizer (optimizeChunk)
@@ -26,22 +30,26 @@ compileModules
     `CouldBeAnyOf` '[ CoreFn.ModuleNotFound
                     , CoreFn.ModuleDecodingErr
                     , IR.CoreFnError
+                    , PassCheckFailure
                     , Lua.Error
                     ]
   ⇒ Tagged "output" (SomeBase Dir)
   → Tagged "foreign" (Path Abs Dir)
+  → Tagged "lint-ir" Bool
   → AppOrModule
   → ExceptT (Variant e) IO CompilationResult
-compileModules outputDir foreignDir appOrModule = do
+compileModules outputDir foreignDir lintIR appOrModule = do
   let entryModuleName = entryPointModule appOrModule
   cfnModules ← CoreFn.readModuleRecursively outputDir entryModuleName
   let dataDecls = IR.collectDataDeclarations cfnModules
   irResults ← forM (Map.toList cfnModules) \(_psModuleName, cfnModule) →
     Oops.hoistEither $ IR.mkModule cfnModule dataDecls
   let (needsRuntimeLazys, irModules) = unzip irResults
-  let uberModule =
-        Linker.makeUberModule (linkerMode appOrModule) irModules
-          & optimizedUberModule
+  let linkedModule = Linker.makeUberModule (linkerMode appOrModule) irModules
+  uberModule ←
+    if untag lintIR
+      then Oops.hoistEither (optimizedUberModuleChecked linkedModule)
+      else pure (optimizedUberModule linkedModule)
   -- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names
   let needsRuntimeLazy = Tagged (any untag needsRuntimeLazys)
   chunk ← Lua.fromUberModule foreignDir needsRuntimeLazy appOrModule uberModule

--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -139,10 +139,21 @@ eliminateDeadCode uber@UberModule {..} =
               ParamUnused pann → (ParamUnused pann, b)
               ParamNamed pann name → (ParamUnused pann, unshift name 0 b)
         Let ann binds body →
-          Rewritten Recurse case preserveLetBinds (toList binds) body of
-            ([], body') → body'
-            (b : bs, body') → Let ann (b :| bs) body'
+          Rewritten Recurse (rebuild ann (preserveLetBinds (toList binds) body))
          where
+          -- 'Rewritten Recurse' descends into the result's children without
+          -- re-applying the rule to the result itself, so when every binding
+          -- of the Let is dropped and the node collapses to its body, a body
+          -- that is itself a Let would escape the rule: its dead bindings
+          -- would be kept, while the parameters of lambdas inside them get
+          -- blanked (their ids are unreachable), leaving unbound references
+          -- behind. Process such a body here; the collapse can cascade.
+          rebuild ann' = \case
+            ([], Let ann'' binds' body') →
+              rebuild ann'' (preserveLetBinds (toList binds') body')
+            ([], body') → body'
+            (b : bs, body') → Let ann' (b :| bs) body'
+
           -- Dropping a dead binder removes a slot from that name's De Bruijn
           -- namespace, so references in the rest of the Let (later grouping
           -- RHSs and the body) that skipped over it must be lowered, just as

--- a/lib/Language/PureScript/Backend/IR/FlattenDeepBinds.hs
+++ b/lib/Language/PureScript/Backend/IR/FlattenDeepBinds.hs
@@ -133,6 +133,7 @@ single table to cut the upvalue cost to one is a future upgrade.
 -}
 module Language.PureScript.Backend.IR.FlattenDeepBinds
   ( flattenDeepBinds
+  , flattenDeepBindsM
   ) where
 
 import Data.List qualified as List
@@ -141,9 +142,9 @@ import Data.Set qualified as Set
 import Language.PureScript.Backend.IR.Linker (UberModule (..))
 import Language.PureScript.Backend.IR.Names
   ( Name (..)
-  , QName
   , Qualified (Local)
   )
+import Language.PureScript.Backend.IR.Supply (SupplyM, freshName, runSupply)
 import Language.PureScript.Backend.IR.Types
   ( Ann
   , Exp
@@ -159,26 +160,21 @@ import Language.PureScript.Backend.IR.Types
   , rewriteExpTopDownM
   )
 
+-- | 'flattenDeepBindsM' with a private supply, for standalone use.
+flattenDeepBinds ∷ UberModule → UberModule
+flattenDeepBinds = runSupply . flattenDeepBindsM
+
 {- | Flatten deeply-nested expression trees in every binding and export of the
-module. A single counter is threaded across the whole module so the minted
+module. The supply counter is threaded across the whole module so the minted
 @$kontN@\/@$tmpN@ names are globally unique.
 -}
-flattenDeepBinds ∷ UberModule → UberModule
-flattenDeepBinds uber@UberModule {uberModuleBindings, uberModuleExports} =
-  uber
-    { uberModuleBindings = bindings'
-    , uberModuleExports = exports'
-    }
+flattenDeepBindsM ∷ UberModule → SupplyM UberModule
+flattenDeepBindsM uber@UberModule {uberModuleBindings, uberModuleExports} = do
+  bindings' ← traverse (traverse (traverse rewrite)) uberModuleBindings
+  exports' ← traverse (traverse rewrite) uberModuleExports
+  pure uber {uberModuleBindings = bindings', uberModuleExports = exports'}
  where
-  (bindings', exports') = evalState action 0
-
-  action ∷ State Int ([Grouping (QName, Exp)], [(Name, Exp)])
-  action =
-    (,)
-      <$> traverse (traverse (traverse rewrite)) uberModuleBindings
-      <*> traverse (traverse rewrite) uberModuleExports
-
-  rewrite ∷ Exp → State Int Exp
+  rewrite ∷ Exp → SupplyM Exp
   rewrite = rewriteExpTopDownM flattenRule
 
 --------------------------------------------------------------------------------
@@ -190,7 +186,7 @@ application-spine depth is tiny, so Strategy B only ever sees the remaining deep
 'App' spines. Either may leave the expression unchanged ('NoChange'), in which
 case 'Language.PureScript.Backend.Lua.NestingCheck' remains the backstop.
 -}
-flattenRule ∷ RewriteRuleM (State Int) Ann
+flattenRule ∷ RewriteRuleM SupplyM Ann
 flattenRule expr
   | (steps, finalAction) ← peelChain expr
   , length steps > threshold =
@@ -233,7 +229,7 @@ asStep expr = case spine expr of
 Returns 'Nothing' (bail, leave the chain nested) when the forwarded live set at
 some cut exceeds the upvalue budget.
 -}
-lambdaLift ∷ [Step] → Exp → State Int (Maybe Exp)
+lambdaLift ∷ [Step] → Exp → SupplyM (Maybe Exp)
 lambdaLift steps finalAction =
   -- Build bottom-up: the deepest segment carries the final action; each
   -- shallower segment ends by calling the helper wrapping the one below it.
@@ -282,7 +278,7 @@ lambdaLift steps finalAction =
   cut
     ∷ (Exp, [(Int, Grouping (Ann, Name, Exp))])
     → [Step]
-    → State Int (Exp, [(Int, Grouping (Ann, Name, Exp))])
+    → SupplyM (Exp, [(Int, Grouping (Ann, Name, Exp))])
   cut (deepBody, konts) seg = do
     kname ← freshKontName
     let params = liveVars deepBody
@@ -359,7 +355,7 @@ total operands (see the module header's soundness note). The off-path operands
 are kept verbatim; deep ones are flattened in turn by the top-down rewrite's
 descent. Returns 'Nothing' when the path is too short to need sealing.
 -}
-sequentialiseSpine ∷ Exp → State Int (Maybe Exp)
+sequentialiseSpine ∷ Exp → SupplyM (Maybe Exp)
 sequentialiseSpine expr =
   case decompose expr of
     (frames, base)
@@ -373,7 +369,7 @@ sequentialiseSpine expr =
   seal
     ∷ ([Grouping (Ann, Name, Exp)], Exp)
     → (Int, Frame)
-    → State Int ([Grouping (Ann, Name, Exp)], Exp)
+    → SupplyM ([Grouping (Ann, Name, Exp)], Exp)
   seal (binds, acc) (i, frame) = do
     let acc' = rebuildFrame frame acc
     if i `mod` segmentSize == 0
@@ -400,11 +396,11 @@ spine = go []
 refLocal0 ∷ Name → Exp
 refLocal0 name = Ref noAnn (Local name) (Index 0)
 
-freshKontName ∷ State Int Name
-freshKontName = state \n → (Name ("$kont" <> show n), n + 1)
+freshKontName ∷ SupplyM Name
+freshKontName = freshName "$kont"
 
-freshTmpName ∷ State Int Name
-freshTmpName = state \n → (Name ("$tmp" <> show n), n + 1)
+freshTmpName ∷ SupplyM Name
+freshTmpName = freshName "$tmp"
 
 chunksOf ∷ Int → [a] → [[a]]
 chunksOf _ [] = []

--- a/lib/Language/PureScript/Backend/IR/Linter.hs
+++ b/lib/Language/PureScript/Backend/IR/Linter.hs
@@ -1,0 +1,120 @@
+{- | Invariant checks over the IR, run at pass boundaries by the checked
+pipeline runner (see 'Language.PureScript.Backend.IR.Pass') — in the test
+suite always, in the CLI behind a debug flag. A violation names the exact
+top-level site, turning a silent miscompile into a loud failure that
+points at the offending pass.
+
+The linter only checks 'Local' references: after
+'Language.PureScript.Backend.IR.Linker.qualifyTopRefs' every top-level
+cross-reference is 'Language.PureScript.Backend.IR.Names.Imported', which
+this scope check deliberately ignores (mechanically checking those is
+part of the globally-unique-names redesign, issue #139).
+-}
+module Language.PureScript.Backend.IR.Linter
+  ( Violation (..)
+  , Site (..)
+  , lintUberModule
+  , unboundLocals
+  ) where
+
+import Control.Lens (toListOf)
+import Data.Map qualified as Map
+import Language.PureScript.Backend.IR.Linker (UberModule (..))
+import Language.PureScript.Backend.IR.Names
+  ( Name (..)
+  , QName
+  , Qualified (Local)
+  )
+import Language.PureScript.Backend.IR.Types
+  ( Exp
+  , Grouping (..)
+  , Index
+  , RawExp (..)
+  , paramName
+  , subexpressions
+  , unIndex
+  )
+import Language.PureScript.Names (runtimeLazyName)
+
+--------------------------------------------------------------------------------
+-- Violations ------------------------------------------------------------------
+
+-- | A broken IR invariant, located at a top-level site of the module.
+data Violation = UnboundLocal Site Name Index
+  deriving stock (Eq, Show)
+
+-- | The top-level entry of the module a violation was found in.
+data Site
+  = InBinding QName
+  | InForeign QName
+  | InExport Name
+  deriving stock (Eq, Show)
+
+--------------------------------------------------------------------------------
+-- Linting ---------------------------------------------------------------------
+
+{- | Check every top-level binding, foreign binding, and export of the
+module. An empty result means the module holds the linted invariants.
+-}
+lintUberModule ∷ UberModule → [Violation]
+lintUberModule UberModule {..} =
+  foldMap
+    (\(qname, e) → atSite (InBinding qname) e)
+    (listGrouping =<< uberModuleBindings)
+    <> foldMap (\(qname, e) → atSite (InForeign qname) e) uberModuleForeigns
+    <> foldMap (\(name, e) → atSite (InExport name) e) uberModuleExports
+ where
+  atSite ∷ Site → Exp → [Violation]
+  atSite site e = uncurry (UnboundLocal site) <$> unboundLocals e
+
+  listGrouping ∷ Grouping a → [a]
+  listGrouping = \case
+    Standalone a → [a]
+    RecursiveGroup as → toList as
+
+{- | Local references whose De Bruijn index points past every enclosing binder
+of that name: unbound locals, which the Lua backend rejects (see
+Note [Locals are uniquely named after renameShadowedNames]). An empty result
+means the expression is well-scoped. The binder bookkeeping mirrors
+'shift'/'unshift'; see Note [Sequential scoping of Let bindings] for 'Let'.
+
+The runtime lazy factory is the one deliberately free local reference:
+the laziness transform emits @Local (Name runtimeLazyName)@ refs whose
+definition is injected as a Lua fixture only at codegen (see
+Note [The PSLUA_runtime_lazy coupling] in "Language.PureScript.Names"),
+so the initial scope treats that name as bound by the runtime.
+-}
+unboundLocals ∷ Exp → [(Name, Index)]
+unboundLocals = go (Map.singleton (Name runtimeLazyName) 1)
+ where
+  go ∷ Map Name Natural → Exp → [(Name, Index)]
+  go scope = \case
+    Ref _ (Local nm) index
+      | unIndex index < Map.findWithDefault 0 nm scope → []
+      | otherwise → [(nm, index)]
+    Abs _ param body → go (bindName (paramName param) scope) body
+    Let _ binds body →
+      let (bodyScope, errs) = foldl' letGrouping (scope, []) (toList binds)
+       in errs <> go bodyScope body
+    other → foldMap (go scope) (toListOf subexpressions other)
+   where
+    bindName ∷ Maybe Name → Map Name Natural → Map Name Natural
+    bindName Nothing sc = sc
+    bindName (Just nm) sc = Map.insertWith (+) nm 1 sc
+
+    letGrouping
+      ∷ (Map Name Natural, [(Name, Index)])
+      → Grouping (a, Name, Exp)
+      → (Map Name Natural, [(Name, Index)])
+    letGrouping (sc, errs) = \case
+      Standalone (_ann, nm, e) →
+        ( Map.insertWith (+) nm 1 sc
+        , errs <> go sc e
+        )
+      RecursiveGroup recBinds →
+        ( sc'
+        , errs <> foldMap (\(_ann, _nm, e) → go sc' e) recBinds
+        )
+       where
+        sc' = foldr (\nm → Map.insertWith (+) nm 1) sc names
+        names = (\(_ann, nm, _e) → nm) <$> toList recBinds

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -4,7 +4,7 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Language.PureScript.Backend.IR.DCE (eliminateDeadCode)
-import Language.PureScript.Backend.IR.FlattenDeepBinds (flattenDeepBinds)
+import Language.PureScript.Backend.IR.FlattenDeepBinds (flattenDeepBindsM)
 import Language.PureScript.Backend.IR.Inliner (Annotation (..))
 import Language.PureScript.Backend.IR.Linker (UberModule (..))
 import Language.PureScript.Backend.IR.MagicDo (magicDo)
@@ -14,7 +14,16 @@ import Language.PureScript.Backend.IR.Names
   , Qualified (Local)
   , qualifiedQName
   )
+import Language.PureScript.Backend.IR.Pass
+  ( Invariant (..)
+  , Pass (..)
+  , PassCheckFailure
+  , Step (..)
+  , runSteps
+  , runStepsChecked
+  )
 import Language.PureScript.Backend.IR.Query (collectBoundNames)
+import Language.PureScript.Backend.IR.Supply (runSupply)
 import Language.PureScript.Backend.IR.Types
   ( Ann
   , Exp
@@ -39,32 +48,70 @@ import Language.PureScript.Backend.IR.Types
 
 optimizedUberModule ∷ UberModule → UberModule
 optimizedUberModule uber =
-  uber
-    & idempotently (eliminateDeadCode . optimizeModule neverNames)
-    -- by merging foreign bindings into the main bindings, we can
+  runSupply (runSteps (optimizerPipeline (neverInlineNames uber)) uber)
+
+{- | 'optimizedUberModule' with every pass's contract checked by the
+linter, failing with the name of the offending pass. Used by the test
+suite always, and by the CLI behind the @--lint-ir@ flag.
+-}
+optimizedUberModuleChecked ∷ UberModule → Either PassCheckFailure UberModule
+optimizedUberModuleChecked uber =
+  runSupply (runStepsChecked (optimizerPipeline (neverInlineNames uber)) uber)
+
+{- | The IR optimization pipeline. The argument is the set of @inline never@
+bindings, collected once from the pristine module before any pass runs:
+later rewrites may strip the annotation off a binding's root, so the veto
+keys off the name (see Note [Inline annotations and inlining heuristics]).
+-}
+optimizerPipeline ∷ Set QName → [Step]
+optimizerPipeline neverNames =
+  [ RunFixpoint "optimize+dce" (optimizePass :| [dcePass])
+  , -- by merging foreign bindings into the main bindings, we can
     -- unblock even more optimizations, e.g. inline foreign bindings.
-    & mergeForeignsIntoBindings
-    & idempotently (eliminateDeadCode . optimizeModule neverNames)
-    -- Must run last among the index-sensitive passes:
+    RunPass mergeForeignsPass
+  , RunFixpoint "optimize+dce" (optimizePass :| [dcePass])
+  , -- Must run last among the index-sensitive passes:
     -- see Note [Locals are uniquely named after renameShadowedNames]
-    & renameShadowedNames
-    -- Magic-do is the final lowering (issue #46): it relies on the unique
+    RunPass renameShadowedNamesPass
+  , -- Magic-do is the final lowering (issue #46): it relies on the unique
     -- naming established above and preserves it, and must run after dead-code
     -- elimination so the statements it introduces for `discard` are not
     -- dropped as dead. See Language.PureScript.Backend.IR.MagicDo.
-    & magicDo
-    -- Flatten the remaining deeply-nested expression trees (issues #104, #108):
-    -- continuation/bind chains of any monad (lambda-lifted into $kont helpers)
-    -- and applicative/flipped-bind application spines (A-normalised into $tmp
-    -- locals). Runs after magicDo (which consumes Effect/ST chains, leaving only
-    -- non-Effect/ST ones) and likewise consumes and preserves the unique naming.
+    RunPass magicDoPass
+  , -- Flatten the remaining deeply-nested expression trees (issues #104,
+    -- #108): continuation/bind chains of any monad (lambda-lifted
+    -- into $kont helpers) and applicative/flipped-bind application
+    -- spines (A-normalised into $tmp locals). Runs after magicDo (which
+    -- consumes Effect/ST chains, leaving only non-Effect/ST ones) and
+    -- likewise consumes and preserves the unique naming.
     -- See Language.PureScript.Backend.IR.FlattenDeepBinds.
-    & flattenDeepBinds
+    RunPass flattenDeepBindsPass
+  ]
  where
-  -- Collect @inline never bindings once from the pristine module: later
-  -- rewrites may strip the annotation off a binding's root, so the veto keys
-  -- off the name (see Note [Inline annotations and inlining heuristics]).
-  neverNames = neverInlineNames uber
+  optimizePass = purePass "optimize" (optimizeModule neverNames)
+  dcePass = purePass "dce" eliminateDeadCode
+  mergeForeignsPass = purePass "mergeForeigns" mergeForeignsIntoBindings
+  renameShadowedNamesPass = purePass "renameShadowedNames" renameShadowedNames
+  magicDoPass = purePass "magicDo" magicDo
+  flattenDeepBindsPass =
+    Pass
+      { passName = "flattenDeepBinds"
+      , passRun = flattenDeepBindsM
+      , passRequires = wellScoped
+      , passEnsures = wellScoped
+      }
+
+  purePass ∷ Text → (UberModule → UberModule) → Pass
+  purePass name run =
+    Pass
+      { passName = name
+      , passRun = pure . run
+      , passRequires = wellScoped
+      , passEnsures = wellScoped
+      }
+
+  wellScoped ∷ Set Invariant
+  wellScoped = Set.singleton WellScoped
 
 mergeForeignsIntoBindings ∷ UberModule → UberModule
 mergeForeignsIntoBindings uberModule@UberModule {..} =
@@ -240,18 +287,6 @@ renameShadowedNamesInExpr scope = go
        in if Set.member nextName usedNames
             then uniqueName usedNames n (i + 1)
             else nextName
-
-idempotently ∷ Eq a ⇒ (a → a) → a → a
-idempotently = fix $ \i f a →
-  let a' = f a
-   in if a' == a then a else i f a'
-
---         if a' == a
---           then tr "FIXPOINT" a a
---           else tr "RETRYING" a' (i f a')
---  where
---   tr ∷ Show x ⇒ String → x → y → y
---   tr l x y = trace ("\n\n" <> l <> "\n" <> (toString . pShow) x <> "\n") y
 
 {- | The top-level bindings annotated @inline never@, collected once from the
 pristine module. Later rewrites can drop the annotation off a binding's root

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -69,7 +69,7 @@ optimizerPipeline neverNames =
   , -- by merging foreign bindings into the main bindings, we can
     -- unblock even more optimizations, e.g. inline foreign bindings.
     RunPass mergeForeignsPass
-  , RunFixpoint "optimize+dce" (optimizePass :| [dcePass])
+  , RunFixpoint "optimize+dce-post-merge" (optimizePass :| [dcePass])
   , -- Must run last among the index-sensitive passes:
     -- see Note [Locals are uniquely named after renameShadowedNames]
     RunPass renameShadowedNamesPass

--- a/lib/Language/PureScript/Backend/IR/Pass.hs
+++ b/lib/Language/PureScript/Backend/IR/Pass.hs
@@ -1,0 +1,168 @@
+{- | First-class passes for the IR pipeline (issue #138).
+
+A pass is a value carrying its contract: the invariants it requires of
+its input and the invariants it ensures for its output. The pipeline is
+a list of 'Step's interpreted by one of three runners:
+
+  * 'runSteps' — plain execution, no checking (the production default);
+  * 'runStepsChecked' — lints 'passRequires' before and 'passEnsures'
+    after every pass (including every pass of every fixpoint iteration),
+    failing loudly with the offending pass's name. Used by the test
+    suite and, behind a debug flag, by the CLI;
+  * 'runStepsTraced' — like 'runSteps' but also records the module after
+    each pass, for debugging.
+
+'Step' exists (rather than a fixpoint /combinator/ returning an opaque
+'Pass') so the checked runner can see through a fixpoint and lint each
+iteration: a violation on an intermediate iteration that a later
+iteration masks would otherwise be invisible.
+-}
+module Language.PureScript.Backend.IR.Pass
+  ( Invariant (..)
+  , Pass (..)
+  , Step (..)
+  , Phase (..)
+  , PassCheckFailure (..)
+  , runSteps
+  , runStepsChecked
+  , runStepsTraced
+  , idempotently
+  ) where
+
+import Control.Monad.Error.Class (MonadError (throwError))
+import Data.Set qualified as Set
+import Language.PureScript.Backend.IR.Linker (UberModule)
+import Language.PureScript.Backend.IR.Linter (Violation, lintUberModule)
+import Language.PureScript.Backend.IR.Supply (SupplyM)
+
+--------------------------------------------------------------------------------
+-- Passes and their contracts --------------------------------------------------
+
+{- | A mechanically checkable property of the IR. Extended by the
+globally-unique-names redesign (issue #139).
+-}
+data Invariant = WellScoped
+  deriving stock (Eq, Ord, Show)
+
+data Pass = Pass
+  { passName ∷ Text
+  , passRun ∷ UberModule → SupplyM UberModule
+  , passRequires ∷ Set Invariant
+  , passEnsures ∷ Set Invariant
+  }
+
+{- | One step of a pipeline: a single pass, or a sequence of passes
+iterated until a whole-module 'Eq' fixpoint (same semantics as
+'idempotently' over their composition).
+-}
+data Step
+  = RunPass Pass
+  | RunFixpoint Text (NonEmpty Pass)
+
+data Phase = Before | After
+  deriving stock (Eq, Show)
+
+{- | A pass's contract did not hold: the named invariant set was violated
+either on the pass's input ('Before') or on its output ('After').
+-}
+data PassCheckFailure = PassCheckFailure
+  { failedPassName ∷ Text
+  , failedPhase ∷ Phase
+  , failedViolations ∷ NonEmpty Violation
+  }
+  deriving stock (Eq, Show)
+
+--------------------------------------------------------------------------------
+-- Runners ---------------------------------------------------------------------
+
+runSteps ∷ [Step] → UberModule → SupplyM UberModule
+runSteps steps uber0 = foldlM (flip runStep) uber0 steps
+ where
+  runStep ∷ Step → UberModule → SupplyM UberModule
+  runStep = \case
+    RunPass p → passRun p
+    RunFixpoint _name passes →
+      fixpointM \uber → foldlM (flip passRun) uber (toList passes)
+
+runStepsChecked
+  ∷ [Step] → UberModule → SupplyM (Either PassCheckFailure UberModule)
+runStepsChecked steps uber0 = runExceptT (foldlM (flip runStep) uber0 steps)
+ where
+  runStep ∷ Step → UberModule → ExceptT PassCheckFailure SupplyM UberModule
+  runStep = \case
+    RunPass p → checkedPass p
+    RunFixpoint _name passes →
+      fixpointM \uber → foldlM (flip checkedPass) uber (toList passes)
+
+  checkedPass
+    ∷ Pass → UberModule → ExceptT PassCheckFailure SupplyM UberModule
+  checkedPass Pass {passName, passRun, passRequires, passEnsures} uber = do
+    check Before passRequires uber
+    uber' ← lift (passRun uber)
+    uber' <$ check After passEnsures uber'
+   where
+    check
+      ∷ Phase
+      → Set Invariant
+      → UberModule
+      → ExceptT PassCheckFailure SupplyM ()
+    check phase invariants u =
+      whenJust
+        (nonEmpty (violations invariants u))
+        (throwError . PassCheckFailure passName phase)
+
+  violations ∷ Set Invariant → UberModule → [Violation]
+  violations invariants u
+    | WellScoped `Set.member` invariants = lintUberModule u
+    | otherwise = []
+
+{- | Like 'runSteps', but also record the module after each pass. Passes
+run by a fixpoint are recorded per iteration as @fixpointName#N/passName@.
+-}
+runStepsTraced
+  ∷ [Step] → UberModule → SupplyM (UberModule, [(Text, UberModule)])
+runStepsTraced steps uber0 =
+  second reverse <$> runStateT (foldlM (flip runStep) uber0 steps) []
+ where
+  -- The trace accumulates reversed (newest first) and is reversed once
+  -- at the end.
+  runStep ∷ Step → UberModule → StateT [(Text, UberModule)] SupplyM UberModule
+  runStep = \case
+    RunPass p → tracedPass (passName p) p
+    RunFixpoint name passes → loop (1 ∷ Natural)
+     where
+      loop i uber = do
+        uber' ←
+          foldlM
+            ( \u p →
+                tracedPass (name <> "#" <> show i <> "/" <> passName p) p u
+            )
+            uber
+            (toList passes)
+        if uber' == uber then pure uber else loop (i + 1) uber'
+
+  tracedPass
+    ∷ Text
+    → Pass
+    → UberModule
+    → StateT [(Text, UberModule)] SupplyM UberModule
+  tracedPass label p uber = do
+    uber' ← lift (passRun p uber)
+    uber' <$ modify ((label, uber') :)
+
+--------------------------------------------------------------------------------
+-- Fixpoints -------------------------------------------------------------------
+
+-- | Apply a function until it makes no change (by 'Eq').
+idempotently ∷ Eq a ⇒ (a → a) → a → a
+idempotently = fix $ \i f a →
+  let a' = f a
+   in if a' == a then a else i f a'
+
+-- | Monadic 'idempotently'.
+fixpointM ∷ (Monad m, Eq a) ⇒ (a → m a) → a → m a
+fixpointM f = loop
+ where
+  loop a = do
+    a' ← f a
+    if a' == a then pure a else loop a'

--- a/lib/Language/PureScript/Backend/IR/Supply.hs
+++ b/lib/Language/PureScript/Backend/IR/Supply.hs
@@ -1,0 +1,33 @@
+{- | A deterministic supply of fresh names for IR pipeline passes.
+
+The counter starts at 0 on every 'runSupply' and advances in traversal
+order, so the minted names are reproducible across runs — they end up
+verbatim in generated Lua (and thus in golden files), where any
+non-determinism would show up as spurious churn.
+
+Only passes that mint names appearing in the /output/ may draw from the
+shared supply ('Language.PureScript.Backend.IR.FlattenDeepBinds' is the
+only one today). Counters that are internal to a pass — the node-ID
+counter of 'Language.PureScript.Backend.IR.DCE', the collision-retry
+renaming of 'Language.PureScript.Backend.IR.Optimizer.renameShadowedNames'
+— must stay internal: routing them through the shared supply would shift
+the numbering of every name minted downstream.
+-}
+module Language.PureScript.Backend.IR.Supply
+  ( SupplyM
+  , runSupply
+  , freshName
+  ) where
+
+import Language.PureScript.Backend.IR.Names (Name (..))
+
+newtype SupplyM a = SupplyM (State Natural a)
+  deriving newtype (Functor, Applicative, Monad)
+
+-- | Run a supplied computation, starting the counter at 0.
+runSupply ∷ SupplyM a → a
+runSupply (SupplyM st) = evalState st 0
+
+-- | Mint a fresh name: the prefix followed by the next counter value.
+freshName ∷ Text → SupplyM Name
+freshName prefix = SupplyM $ state \n → (Name (prefix <> show n), n + 1)

--- a/lib/Language/PureScript/Names.hs
+++ b/lib/Language/PureScript/Names.hs
@@ -59,17 +59,21 @@ data InternalIdentData
 
 -- | Names for value identifiers
 data Ident
-  = -- |
-    -- An alphanumeric identifier
+  = {- |
+    An alphanumeric identifier
+    -}
     Ident Text
-  | -- |
-    -- A generated name for an identifier
+  | {- |
+    A generated name for an identifier
+    -}
     GenIdent (Maybe Text) Integer
-  | -- |
-    -- A generated name used only for type-checking
+  | {- |
+    A generated name used only for type-checking
+    -}
     UnusedIdent
-  | -- |
-    -- A generated name used only for internal transformations
+  | {- |
+    A generated name used only for internal transformations
+    -}
     InternalIdent !InternalIdentData
   deriving stock (Show, Eq, Ord, Generic)
 
@@ -88,7 +92,7 @@ runIdent = \case
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Lazy (self-recursive) bindings are compiled to a reference to a runtime
 helper, the "runtime lazy factory", carried by the bare name 'runtimeLazyName'
-below. That one string, "PSLUA_runtime_lazy", silently couples four sites;
+below. That one string, "PSLUA_runtime_lazy", silently couples five sites;
 they must stay in agreement.
 
   * Here ('runtimeLazyName'): the ident the laziness transform emits.
@@ -111,6 +115,10 @@ they must stay in agreement.
     'Language.PureScript.Backend.Lua.fromUberModule': emit the fixture iff it
     is both needed (the laziness transform ran) and used (the scan finds a
     reference).
+
+  * 'Language.PureScript.Backend.IR.Linter.unboundLocals': treats a free
+    @Local (Name runtimeLazyName)@ as bound by the runtime — the one
+    deliberate exemption from the well-scopedness invariant.
 
 Rename either side of the string and the halves stop matching: the fixture is
 judged unused and dropped, or the generated code calls a binding that was
@@ -298,7 +306,7 @@ instance FromJSONKey ModuleName where
   fromJSONKey = fmap moduleNameFromString fromJSONKey
 
 $( deriveJSON
-    (defaultOptions {sumEncoding = ObjectWithSingleField})
-    ''InternalIdentData
+     (defaultOptions {sumEncoding = ObjectWithSingleField})
+     ''InternalIdentData
  )
 $(deriveJSON (defaultOptions {sumEncoding = ObjectWithSingleField}) ''Ident)

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -132,10 +132,13 @@ library
     Language.PureScript.Backend.IR.FlattenDeepBinds
     Language.PureScript.Backend.IR.Inliner
     Language.PureScript.Backend.IR.Linker
+    Language.PureScript.Backend.IR.Linter
     Language.PureScript.Backend.IR.MagicDo
     Language.PureScript.Backend.IR.Names
     Language.PureScript.Backend.IR.Optimizer
+    Language.PureScript.Backend.IR.Pass
     Language.PureScript.Backend.IR.Query
+    Language.PureScript.Backend.IR.Supply
     Language.PureScript.Backend.IR.Types
     Language.PureScript.Backend.Lua
     Language.PureScript.Backend.Lua.Fixture
@@ -173,7 +176,9 @@ test-suite spec
     Language.PureScript.Backend.IR.Gen
     Language.PureScript.Backend.IR.Inliner.Spec
     Language.PureScript.Backend.IR.Linker.Spec
+    Language.PureScript.Backend.IR.Linter.Spec
     Language.PureScript.Backend.IR.Optimizer.Spec
+    Language.PureScript.Backend.IR.Pass.Spec
     Language.PureScript.Backend.IR.Spec
     Language.PureScript.Backend.IR.Types.Spec
     Language.PureScript.Backend.Lua.Golden.Spec

--- a/test/Language/PureScript/Backend/IR/DCE/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/DCE/Spec.hs
@@ -179,6 +179,28 @@ spec = describe "IR Dead Code Elimination" do
             )
     dceExpression expr === expected
 
+  -- 'Rewritten Recurse' descends into the result's children without
+  -- re-applying the rule to the result itself. When a Let whose bindings
+  -- are all dead collapses to its body, and the body is itself a Let,
+  -- that inner Let node must not escape dead-code elimination: its dead
+  -- bindings would be kept while the parameters of lambdas inside them
+  -- are blanked (their ids are unreachable), leaving unbound references.
+  it "eliminates dead bindings of a Let a collapsing Let exposes" $ hedgehog do
+    let x = Name "x"
+        k = Name "k"
+        a = Name "a"
+        expr =
+          lets
+            (Standalone (noAnn, a, literalInt 1) :| [])
+            ( lets
+                ( Standalone
+                    (noAnn, k, abstraction (paramNamed x) (refLocal x 0))
+                    :| []
+                )
+                (literalInt 3)
+            )
+    dceExpression expr === literalInt 3
+
   it "unshifts after dropping a dead recursive-group member" $ hedgehog do
     let x = Name "x"
         y = Name "y"

--- a/test/Language/PureScript/Backend/IR/Linter/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Linter/Spec.hs
@@ -1,0 +1,90 @@
+module Language.PureScript.Backend.IR.Linter.Spec where
+
+import Hedgehog (forAll, (===))
+import Language.PureScript.Backend.IR.Gen qualified as Gen
+import Language.PureScript.Backend.IR.Linker (UberModule (..))
+import Language.PureScript.Backend.IR.Linter
+  ( Site (..)
+  , Violation (..)
+  , lintUberModule
+  , unboundLocals
+  )
+import Language.PureScript.Backend.IR.Names
+  ( Name (..)
+  , QName (..)
+  , moduleNameFromString
+  )
+import Language.PureScript.Backend.IR.Types
+  ( Grouping (..)
+  , abstraction
+  , lets
+  , literalInt
+  , noAnn
+  , paramNamed
+  , refLocal
+  )
+import Language.PureScript.Names (runtimeLazyName)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec.Hedgehog.Extended (test)
+
+spec ∷ Spec
+spec = describe "IR Linter" do
+  test "generated well-scoped expressions lint clean" do
+    e ← forAll Gen.scopedExp
+    unboundLocals e === []
+
+  it "flags an unbound local at every module site" do
+    let y = Name "y"
+        unbound = refLocal y 0
+        qname = QName (moduleNameFromString "Main") (Name "it")
+    lintUberModule
+      UberModule
+        { uberModuleBindings = [Standalone (qname, unbound)]
+        , uberModuleForeigns = [(qname, unbound)]
+        , uberModuleExports = [(Name "it", unbound)]
+        }
+      `shouldBe` [ UnboundLocal (InBinding qname) y 0
+                 , UnboundLocal (InForeign qname) y 0
+                 , UnboundLocal (InExport (Name "it")) y 0
+                 ]
+
+  -- See Note [The PSLUA_runtime_lazy coupling] in Language.PureScript.Names:
+  -- the laziness transform emits free references to the runtime lazy factory
+  -- whose definition only appears as a Lua fixture at codegen.
+  it "treats the runtime lazy factory as bound by the runtime" do
+    let factory = Name runtimeLazyName
+    unboundLocals (refLocal factory 0) `shouldBe` []
+    -- …but only the runtime's own binder: deeper indices still dangle.
+    unboundLocals (refLocal factory 1) `shouldBe` [(factory, 1)]
+
+  it "counts binders of the referenced name only" do
+    let x = Name "x"
+        y = Name "y"
+    -- \x → \y → x@1 — the y binder must not satisfy x's index 1.
+    unboundLocals
+      (abstraction (paramNamed x) (abstraction (paramNamed y) (refLocal x 1)))
+      `shouldBe` [(x, 1)]
+
+  it "resolves Let references per Note [Sequential scoping of Let bindings]" do
+    let x = Name "x"
+    -- \x → let x = 1 in x@1: index 1 skips the Let binder onto the λ binder.
+    unboundLocals
+      ( abstraction (paramNamed x) $
+          lets (Standalone (noAnn, x, literalInt 1) :| []) (refLocal x 1)
+      )
+      `shouldBe` []
+    -- let x = 1 in x@1: nothing outside the Let binds x.
+    unboundLocals
+      (lets (Standalone (noAnn, x, literalInt 1) :| []) (refLocal x 1))
+      `shouldBe` [(x, 1)]
+    -- A Standalone RHS does not see its own binder…
+    unboundLocals
+      (lets (Standalone (noAnn, x, refLocal x 0) :| []) (literalInt 1))
+      `shouldBe` [(x, 0)]
+    -- …but a recursive-group member's RHS sees every member of its group.
+    unboundLocals
+      ( lets
+          (RecursiveGroup ((noAnn, x, refLocal x 0) :| []) :| [])
+          (literalInt 1)
+      )
+      `shouldBe` []

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Backend.IR.Optimizer.Spec where
 
-import Control.Lens (toListOf, universeOf)
+import Control.Lens (universeOf)
 import Data.Map qualified as Map
 import Hedgehog (PropertyT, annotateShow, forAll, (===))
 import Hedgehog.Gen qualified as Gen
@@ -8,6 +8,7 @@ import Language.PureScript.Backend.IR.Gen qualified as Gen
 import Language.PureScript.Backend.IR.Inliner (Annotation (Never))
 import Language.PureScript.Backend.IR.Linker (LinkMode (..))
 import Language.PureScript.Backend.IR.Linker qualified as Linker
+import Language.PureScript.Backend.IR.Linter (lintUberModule, unboundLocals)
 import Language.PureScript.Backend.IR.Names
   ( Name (..)
   , PropName (..)
@@ -23,7 +24,6 @@ import Language.PureScript.Backend.IR.Optimizer
 import Language.PureScript.Backend.IR.Types
   ( Exp
   , Grouping (..)
-  , Index
   , Module (..)
   , RawExp (..)
   , abstraction
@@ -37,14 +37,12 @@ import Language.PureScript.Backend.IR.Types
   , literalInt
   , literalObject
   , noAnn
-  , paramName
   , paramNamed
   , paramUnused
   , refImported
   , refLocal
   , refLocal0
   , subexpressions
-  , unIndex
   )
 import Test.Hspec (Spec, SpecWith, describe, it)
 import Test.Hspec.Hedgehog (hedgehog, modifyMaxShrinks, modifyMaxSuccess)
@@ -57,47 +55,6 @@ prop title =
     . modifyMaxSuccess (const 100)
     . it title
     . hedgehog
-
-{- | Local references whose De Bruijn index points past every enclosing binder
-of that name: unbound locals, which the Lua backend rejects (see
-Note [Locals are uniquely named after renameShadowedNames]). An empty result
-means the expression is well-scoped. The binder bookkeeping mirrors
-'shift'/'unshift'; see Note [Sequential scoping of Let bindings] for 'Let'.
--}
-unboundLocals ∷ Exp → [(Name, Index)]
-unboundLocals = go Map.empty
- where
-  go ∷ Map Name Natural → Exp → [(Name, Index)]
-  go scope = \case
-    Ref _ (Local nm) index
-      | unIndex index < Map.findWithDefault 0 nm scope → []
-      | otherwise → [(nm, index)]
-    Abs _ param body → go (bindName (paramName param) scope) body
-    Let _ binds body →
-      let (bodyScope, errs) = foldl' letGrouping (scope, []) (toList binds)
-       in errs <> go bodyScope body
-    other → foldMap (go scope) (toListOf subexpressions other)
-   where
-    bindName ∷ Maybe Name → Map Name Natural → Map Name Natural
-    bindName Nothing sc = sc
-    bindName (Just nm) sc = Map.insertWith (+) nm 1 sc
-
-    letGrouping
-      ∷ (Map Name Natural, [(Name, Index)])
-      → Grouping (a, Name, Exp)
-      → (Map Name Natural, [(Name, Index)])
-    letGrouping (sc, errs) = \case
-      Standalone (_ann, nm, e) →
-        ( Map.insertWith (+) nm 1 sc
-        , errs <> go sc e
-        )
-      RecursiveGroup recBinds →
-        ( sc'
-        , errs <> foldMap (\(_ann, _nm, e) → go sc' e) recBinds
-        )
-       where
-        sc' = foldr (\nm → Map.insertWith (+) nm 1) sc names
-        names = (\(_ann, nm, _e) → nm) <$> toList recBinds
 
 spec ∷ Spec
 spec = describe "IR Optimizer" do
@@ -388,7 +345,7 @@ spec = describe "IR Optimizer" do
                 , Linker.uberModuleBindings = []
                 , Linker.uberModuleExports = [(Name "root", e)]
                 }
-      foldMap (unboundLocals . snd) (Linker.uberModuleExports optimized) === []
+      lintUberModule optimized === []
 
   describe "renames shadowed names" do
     test "nested λ-abstractions" do

--- a/test/Language/PureScript/Backend/IR/Pass/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Pass/Spec.hs
@@ -1,0 +1,128 @@
+module Language.PureScript.Backend.IR.Pass.Spec where
+
+import Data.Set qualified as Set
+import Hedgehog (PropertyT, forAll, (===))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Language.PureScript.Backend.IR.Linker (UberModule (..))
+import Language.PureScript.Backend.IR.Linter (Site (..), Violation (..))
+import Language.PureScript.Backend.IR.Names (Name (..))
+import Language.PureScript.Backend.IR.Pass
+  ( Invariant (..)
+  , Pass (..)
+  , PassCheckFailure (..)
+  , Phase (..)
+  , Step (..)
+  , idempotently
+  , runSteps
+  , runStepsChecked
+  )
+import Language.PureScript.Backend.IR.Supply (runSupply)
+import Language.PureScript.Backend.IR.Types
+  ( Exp
+  , RawExp (..)
+  , literalInt
+  , refLocal
+  )
+import Test.Hspec (Spec, SpecWith, describe, it, shouldBe)
+import Test.Hspec.Hedgehog (hedgehog, modifyMaxSuccess)
+
+{- | Like 'Test.Hspec.Hedgehog.Extended.test', but runs the property over
+many generated inputs.
+-}
+prop ∷ String → PropertyT IO () → SpecWith ()
+prop title = modifyMaxSuccess (const 100) . it title . hedgehog
+
+spec ∷ Spec
+spec = describe "IR Pass runner" do
+  it "checked runner reports the pass that broke an invariant" do
+    let breakScope = purePass "break-scope" (constExports unboundRef)
+    runSupply (runStepsChecked [RunPass breakScope] (exporting (literalInt 0)))
+      `shouldBe` Left
+        PassCheckFailure
+          { failedPassName = "break-scope"
+          , failedPhase = After
+          , failedViolations = pure (UnboundLocal (InExport main) y 0)
+          }
+
+  it "checked runner reports a violated precondition" do
+    let keep = purePass "keep" id
+    runSupply (runStepsChecked [RunPass keep] (exporting unboundRef))
+      `shouldBe` Left
+        PassCheckFailure
+          { failedPassName = "keep"
+          , failedPhase = Before
+          , failedViolations = pure (UnboundLocal (InExport main) y 0)
+          }
+
+  it "checked runner sees intermediate fixpoint iterations" do
+    -- First iteration breaks scoping, second heals it and converges: the
+    -- final module is clean, so only per-iteration linting can catch it.
+    let step ∷ UberModule → UberModule
+        step uber = case uberModuleExports uber of
+          [(_name, LiteralInt _ 0)] → constExports unboundRef uber
+          [(_name, Ref {})] → constExports (literalInt 1) uber
+          _ → uber
+        fixpoint = RunFixpoint "toggle" (pure (purePass "step" step))
+        start = exporting (literalInt 0)
+    -- The unchecked runner happily converges on the healed module…
+    runSupply (runSteps [fixpoint] start)
+      `shouldBe` exporting (literalInt 1)
+    -- …the checked runner fails on the intermediate iteration.
+    runSupply (runStepsChecked [fixpoint] start)
+      `shouldBe` Left
+        PassCheckFailure
+          { failedPassName = "step"
+          , failedPhase = After
+          , failedViolations = pure (UnboundLocal (InExport main) y 0)
+          }
+
+  prop "fixpoint has 'idempotently' semantics" do
+    limit ← forAll $ Gen.integral (Range.linear 0 20)
+    start ← forAll $ Gen.integral (Range.linear 0 25)
+    let f ∷ UberModule → UberModule
+        f uber = case uberModuleExports uber of
+          [(_name, LiteralInt _ n)] | n < limit → exporting (literalInt (n + 1))
+          _ → uber
+    runSupply
+      ( runSteps
+          [RunFixpoint "f" (pure (purePass "f" f))]
+          (exporting (literalInt start))
+      )
+      === idempotently f (exporting (literalInt start))
+
+--------------------------------------------------------------------------------
+-- Fixture ---------------------------------------------------------------------
+
+main ∷ Name
+main = Name "main"
+
+y ∷ Name
+y = Name "y"
+
+unboundRef ∷ Exp
+unboundRef = refLocal y 0
+
+exporting ∷ Exp → UberModule
+exporting e =
+  UberModule
+    { uberModuleBindings = []
+    , uberModuleForeigns = []
+    , uberModuleExports = [(main, e)]
+    }
+
+constExports ∷ Exp → UberModule → UberModule
+constExports e uber =
+  uber
+    { uberModuleExports =
+        [(name, e) | (name, _prev) ← uberModuleExports uber]
+    }
+
+purePass ∷ Text → (UberModule → UberModule) → Pass
+purePass name run =
+  Pass
+    { passName = name
+    , passRun = pure . run
+    , passRequires = Set.singleton WellScoped
+    , passEnsures = Set.singleton WellScoped
+    }

--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -15,7 +15,7 @@ import Language.PureScript.Backend.IR.FlattenDeepBinds (flattenDeepBinds)
 import Language.PureScript.Backend.IR.Linker (LinkMode (..))
 import Language.PureScript.Backend.IR.Linker qualified as IR
 import Language.PureScript.Backend.IR.Linker qualified as Linker
-import Language.PureScript.Backend.IR.Optimizer (optimizedUberModule)
+import Language.PureScript.Backend.IR.Optimizer (optimizedUberModuleChecked)
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Optimizer (optimizeChunk)
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
@@ -300,7 +300,10 @@ compileCorefn outputDir uberModuleName = do
     forM (toList cfnModules) $
       either (fail . show) (pure . snd) . (`IR.mkModule` dataDecls)
   let uberModule = Linker.makeUberModule (LinkAsModule uberModuleName) modules
-  pure $ optimizedUberModule uberModule
+  -- The checked runner lints every pass boundary (including every fixpoint
+  -- iteration), so each golden module doubles as a scope-invariant test of
+  -- the whole pipeline.
+  either (fail . show) pure (optimizedUberModuleChecked uberModule)
 
 compileIr ∷ (MonadIO m, MonadMask m) ⇒ AppOrModule → IR.UberModule → m Text
 compileIr appOrModule uberModule = withCurrentDir [reldir|test/ps|] do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,7 +4,9 @@ import Language.PureScript.Backend.IR.DCE.Spec qualified as IrDce
 import Language.PureScript.Backend.IR.FlattenDeepBinds.Spec qualified as FlattenDeepBinds
 import Language.PureScript.Backend.IR.Inliner.Spec qualified as Inliner
 import Language.PureScript.Backend.IR.Linker.Spec qualified as IRLinker
+import Language.PureScript.Backend.IR.Linter.Spec qualified as IRLinter
 import Language.PureScript.Backend.IR.Optimizer.Spec qualified as IROptimizer
+import Language.PureScript.Backend.IR.Pass.Spec qualified as IRPass
 import Language.PureScript.Backend.IR.Spec qualified as IR
 import Language.PureScript.Backend.IR.Types.Spec qualified as Types
 import Language.PureScript.Backend.Lua.Golden.Spec qualified as Golden
@@ -24,7 +26,9 @@ main = hspec do
   IrDce.spec
   Types.spec
   IRLinker.spec
+  IRLinter.spec
   IROptimizer.spec
+  IRPass.spec
   LuaOptimizer.spec
   Printer.spec
   Run.spec


### PR DESCRIPTION
Closes #138.

## What

`optimizedUberModule` was plain function composition, with the pipeline's invariants living in comments and Notes. This PR makes the pipeline a list of interpreted steps, each pass a value carrying its contract:

- `IR.Pass`: `Pass` (name, `passRun :: UberModule -> SupplyM UberModule`, `passRequires`/`passEnsures :: Set Invariant`) and a `Step` layer (`RunPass | RunFixpoint`). Three runners interpret a `[Step]`: plain (`runSteps`), checked (`runStepsChecked`), and traced (`runStepsTraced`, per-pass IR snapshots for debugging). The `Step` layer exists so the checked runner can lint every pass of every fixpoint iteration: a violation on an intermediate iteration that a later iteration masks would be invisible to a fixpoint combinator returning an opaque `Pass`. That is not hypothetical, see below.
- `IR.Linter`: `lintUberModule` generalizes the `unboundLocals` reference implementation that lived in the Optimizer spec. It walks bindings, foreigns, and exports, and treats the runtime lazy factory as bound by the runtime (documented as a fifth site of the `PSLUA_runtime_lazy` coupling Note).
- `IR.Supply`: a deterministic counter-based name supply threaded through `passRun`. `flattenDeepBinds` ports its internal counter to it; minted `$kontN`/`$tmpN` names are bit-identical because nothing draws from the supply before that pass and the counter starts at 0. The module documents why the DCE node-id counter and `renameShadowedNames` must stay off the shared supply.
- The golden harness compiles through the checked runner, so every golden module now doubles as a scope-invariant test of the whole pipeline. The CLI gains a `--lint-ir` debug flag plumbed through `compileModules`.

Behavior-identical by construction: the fixpoint iterates the optimize/DCE composition and compares after the full sequence, exactly like the old `idempotently`. Zero golden churn, guarded by the `kont0`/`tmp0` names baked into the Long*Bind goldens.

## The bug the checked runner caught on day one

Turning on per-pass linting in the golden harness immediately went red on Golden.LongWriterBind: after the first `dce` pass, `Control.Monad.Writer.Trans.applyWriterT` contained unbound `v3`/`v4` references, healed by the next fixpoint iteration. Root cause: `Rewritten Recurse` descends into the rewritten node's children without re-applying the rule, so when a fully dead `Let` collapses to its body and the body is itself a `Let`, the inner `Let` escapes the DCE rule. Its dead bindings are kept while the parameters of lambdas inside them get blanked (their ids are unreachable), leaving dangling references. Latent only, because the fixpoint's next iteration always dropped the residue, but that is accidental robustness. Fixed in the first commit (red unit test first), so every commit of this branch keeps the suite green. The bug predates #134.

This is the motivation for the whole issue playing out on the spot: the 2026-07-02 audit traced six scoping bugs to invariants that lived in comments, and the first mechanical check of those invariants found a seventh within minutes of existing.

## Verification

- `cabal test all`: 330 examples, 0 failures; `git status` clean in `test/ps/output` (zero golden churn).
- New specs: `IR.Linter` (module sites, runtime-lazy exemption, sequential Let scoping cases, property over `Gen.scopedExp`) and `IR.Pass` (checked runner reports the offending pass and phase, catches an intermediate fixpoint violation that the plain runner converges past, fixpoint semantics property-tested against `idempotently`).
- CLI smoke: `pslua --lint-ir` compiles the test project and the produced Lua runs (`ok!`); `--help` shows the flag.
- `fourmolu` and `hlint` clean on the touched files.
