### PR TITLE
Guard reduceTableDefinitionAccessor against ambiguous table literals

### DIFF
--- a/changelog.d/20260704_120000_unisay_table_accessor_guard.md
+++ b/changelog.d/20260704_120000_unisay_table_accessor_guard.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The Lua optimizer rule that folds a field access into a table literal
+  (`{ foo = 1 }.foo` to `1`) now declines when the constructor has a
+  string-keyed row or a repeated field name, instead of silently folding to
+  `nil` or to the wrong (first) value. Neither shape is emitted by the
+  current codegen, so this closes a latent miscompile rather than a live one
+  (#140).

--- a/lib/Language/PureScript/Backend/Lua/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Optimizer.hs
@@ -10,7 +10,8 @@ import Language.PureScript.Backend.Lua.Traversal
   , everywhereStatM
   )
 import Language.PureScript.Backend.Lua.Types
-  ( Chunk
+  ( Annotated
+  , Chunk
   , Exp
   , ExpF (..)
   , Statement
@@ -69,14 +70,34 @@ removeScopeWhenInsideEmptyFunction = \case
       Function outerArgs body
   e → e
 
--- | Rewrites '{ foo = 1, bar = 2 }.foo' to '1'
+{- | Rewrites '{ foo = 1, bar = 2 }.foo' to '1'.
+
+Only fires when the constructor is unambiguous: every row is a name-value
+row and no field name repeats. A 'TableRowKV' row could carry a string key
+equal to the accessed field (e.g. @["foo"] = …@) that this name-keyed lookup
+cannot see, and on a repeated name Lua's constructor keeps the last
+assignment while a first-match lookup returns the earliest; in either case
+the fold could pick the wrong value, so the rule declines. See issue #140.
+-}
 reduceTableDefinitionAccessor ∷ RewriteRule
 reduceTableDefinitionAccessor = \case
-  Var (Ann (VarField (Ann (TableCtor rows)) accessedField)) →
-    fromMaybe Nil $
-      listToMaybe
-        [ fieldValue
-        | (_ann, TableRowNV tableField (Ann fieldValue)) ← rows
-        , tableField == accessedField
-        ]
+  original@(Var (Ann (VarField (Ann (TableCtor rows)) accessedField)))
+    | all isNameValue rows
+    , not (hasDuplicateNames rows) →
+        fromMaybe Nil $
+          listToMaybe
+            [ fieldValue
+            | (_ann, TableRowNV tableField (Ann fieldValue)) ← rows
+            , tableField == accessedField
+            ]
+    | otherwise → original
   e → e
+ where
+  isNameValue ∷ Annotated () TableRowF → Bool
+  isNameValue (_ann, row) = case row of
+    TableRowNV {} → True
+    TableRowKV {} → False
+  hasDuplicateNames ∷ [Annotated () TableRowF] → Bool
+  hasDuplicateNames rows =
+    let names = [n | (_ann, TableRowNV n _) ← rows]
+     in length names /= length (ordNub names)

--- a/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
@@ -4,7 +4,8 @@ module Language.PureScript.Backend.Lua.Optimizer.Spec where
 
 import Language.PureScript.Backend.Lua.Name (name)
 import Language.PureScript.Backend.Lua.Optimizer
-  ( removeScopeWhenInsideEmptyFunction
+  ( reduceTableDefinitionAccessor
+  , removeScopeWhenInsideEmptyFunction
   , rewriteExpWithRule
   )
 import Language.PureScript.Backend.Lua.Types (ParamF (..))
@@ -37,3 +38,40 @@ spec = describe "Lua AST Optimizer" do
               ]
       assertEqual (toString $ pShow original) expected $
         rewriteExpWithRule removeScopeWhenInsideEmptyFunction original
+
+  describe "reduceTableDefinitionAccessor" do
+    it "folds a field access into an unambiguous name-value definition" do
+      let original ∷ Lua.Exp =
+            Lua.varField
+              ( Lua.table
+                  [ Lua.tableRowNV [name|foo|] (Lua.Integer 1)
+                  , Lua.tableRowNV [name|bar|] (Lua.Integer 2)
+                  ]
+              )
+              [name|foo|]
+      assertEqual (toString $ pShow original) (Lua.Integer 1) $
+        rewriteExpWithRule reduceTableDefinitionAccessor original
+
+    it "declines when a key-value row could shadow the accessed field" do
+      -- The accessed field is present only as a string-keyed row, which the
+      -- name lookup cannot see, so folding to Nil would drop the real value.
+      let original ∷ Lua.Exp =
+            Lua.varField
+              (Lua.table [Lua.tableRowKV (Lua.String "foo") (Lua.Integer 1)])
+              [name|foo|]
+      assertEqual (toString $ pShow original) original $
+        rewriteExpWithRule reduceTableDefinitionAccessor original
+
+    it "declines on duplicate field names, where Lua keeps the last" do
+      -- Lua's table constructor keeps the last assignment (2); a first-match
+      -- fold would wrongly return the first (1).
+      let original ∷ Lua.Exp =
+            Lua.varField
+              ( Lua.table
+                  [ Lua.tableRowNV [name|foo|] (Lua.Integer 1)
+                  , Lua.tableRowNV [name|foo|] (Lua.Integer 2)
+                  ]
+              )
+              [name|foo|]
+      assertEqual (toString $ pShow original) original $
+        rewriteExpWithRule reduceTableDefinitionAccessor original


### PR DESCRIPTION
Closes #140.

## Summary

The Lua optimizer rule `reduceTableDefinitionAccessor` folds a field access into a table literal, rewriting `{ foo = 1, bar = 2 }.foo` to `1`. It searched only name-value rows (`TableRowNV`) and took the first match, falling back to `Nil`.

Two shapes broke that:

- A string-keyed row (`["foo"] = 1`, a `TableRowKV`) for the accessed field is invisible to the name lookup, so the rule folded the access to `Nil` and dropped the real value.
- On a duplicate field name, Lua's constructor keeps the last assignment while the first-match lookup returns the earliest, so the rule could fold to the wrong value.

Neither shape is produced by the current codegen, so this is a latent miscompile rather than a live one. The rule now fires only when the constructor is unambiguous: every row is a name-value row and no field name repeats. Otherwise it leaves the expression untouched.

## Changes

- `lib/Language/PureScript/Backend/Lua/Optimizer.hs`: guard the rewrite with an all-name-value check and a duplicate-name check; the Haddock explains both hazards.
- `test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs`: the rule had no test before. Three cases now pin it: the fold still fires on an unambiguous literal, and it declines on a key-value row and on duplicate names (both were red against the old rule).

## Test plan

- [x] `cabal test all --test-show-details=direct` passes
- [x] The two decline tests fail against the pre-fix rule (confirmed red) and pass after
- [x] `fourmolu` and `hlint` clean on the touched files, warning-free build
