### PR TITLE
refactor: consolidate IR traversals onto the subexpressions plate

### DIFF
--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -3,6 +3,7 @@ module Language.PureScript.Backend.IR.DCE
   , eliminateDeadCode
   ) where
 
+import Control.Lens (foldMapOf, toListOf)
 import Data.DList (DList)
 import Data.DList qualified as DL
 import Data.Graph (Graph, Vertex, graphFromEdges, reachable)
@@ -25,10 +26,10 @@ import Language.PureScript.Backend.IR.Types
   , RawExp (..)
   , RewriteMod (..)
   , Rewritten (..)
-  , annotateExpM
   , getAnn
   , listGrouping
   , rewriteExpTopDown
+  , subexpressions
   )
 
 data EntryPoint = EntryPoint ModuleName [Name]
@@ -294,39 +295,6 @@ eliminateDeadCode uber@UberModule {..} =
   adjacencyListForExpr scope expr =
     mkNode (nodeId expr) (expressionDependsOnIds scope expr)
       `DL.cons` case expr of
-        LiteralInt {} → mempty
-        LiteralFloat {} → mempty
-        LiteralString {} → mempty
-        LiteralChar {} → mempty
-        LiteralBool {} → mempty
-        LiteralArray _ann as → foldMap (adjacencyListForExpr scope) as
-        LiteralObject _ann ps → foldMap (adjacencyListForExpr scope . snd) ps
-        Exception {} → mempty
-        ForeignImport {} → mempty
-        Ctor {} → mempty
-        ReflectCtor _ann a →
-          adjacencyListForExpr scope a
-        Eq _ann a b →
-          adjacencyListForExpr scope a <> adjacencyListForExpr scope b
-        DataArgumentByIndex _ann _index a →
-          adjacencyListForExpr scope a
-        ArrayLength _ann a →
-          adjacencyListForExpr scope a
-        ArrayIndex _ann a _index →
-          adjacencyListForExpr scope a
-        ObjectProp _ann a _prop →
-          adjacencyListForExpr scope a
-        ObjectUpdate _ann o patches →
-          adjacencyListForExpr scope o
-            <> foldMap (adjacencyListForExpr scope . snd) patches
-        IfThenElse _ann i t e →
-          adjacencyListForExpr scope i
-            <> adjacencyListForExpr scope t
-            <> adjacencyListForExpr scope e
-        App _ann a b →
-          adjacencyListForExpr scope a <> adjacencyListForExpr scope b
-        Ref _ann _qname →
-          mempty
         Abs _ann param b →
           case param of
             ParamUnused _ann' → adjacencyListForExpr scope b
@@ -342,6 +310,8 @@ eliminateDeadCode uber@UberModule {..} =
           -- binding (see Note [Sequential scoping of Let bindings]).
           (bodyScope, groupingsAdjacency) =
             foldl' adjacencyListForGrouping (scope, mempty) groupings
+        -- No other constructor binds names, so the scope passes through:
+        other → foldMapOf subexpressions (adjacencyListForExpr scope) other
    where
     -- See Note [Sequential scoping of Let bindings]
     adjacencyListForGrouping
@@ -370,28 +340,11 @@ eliminateDeadCode uber@UberModule {..} =
 
 expressionDependsOnIds ∷ Scope → AExp → [Id]
 expressionDependsOnIds exprScope = \case
-  LiteralArray _ann as → nodeId <$> as
-  LiteralObject _ann ps → nodeId . snd <$> ps
-  LiteralInt {} → []
-  LiteralFloat {} → []
-  LiteralString {} → []
-  LiteralChar {} → []
-  LiteralBool {} → []
-  Exception {} → []
-  ForeignImport {} → []
-  Ctor {} → []
-  ReflectCtor _ann a → [nodeId a]
-  Eq _ann a b → [nodeId a, nodeId b]
-  DataArgumentByIndex _ann _idx a → [nodeId a]
-  ArrayLength _ann as → [nodeId as]
-  ArrayIndex _ann a _idx → [nodeId a]
-  ObjectProp _ann a _prp → [nodeId a]
-  ObjectUpdate _ann o patches → nodeId o : toList (nodeId . snd <$> patches)
-  Abs _ann _ b → [nodeId b]
-  App _ann a b → [nodeId a, nodeId b]
-  IfThenElse _ann i t e → [nodeId i, nodeId t, nodeId e]
   Ref _ann qname → maybeToList $ Map.lookup qname exprScope
+  -- A Let node depends only on its body: the groupings are pulled in
+  -- via the per-binder nodes built by 'adjacencyListForGrouping'.
   Let _ann _groupings body → [nodeId body]
+  other → nodeId <$> toListOf subexpressions other
 
 {- | Under GUC (@UniqueBinders@) no two live binders at one site share a
 name, so a fresh local binder can never collide with one already in
@@ -419,36 +372,13 @@ nextId = AnnM (get >>= \i → i <$ put (i + 1))
 runAnnM ∷ AnnM a → a
 runAnnM = (`evalState` 0) . unAnnM
 
+{- | Pair every annotation position of the expression — node, parameter,
+Let-binding name, foreign-import name — with a fresh 'Id', via the
+derived 'Traversable' of 'RawExp'.
+-}
 assignUniqueIds ∷ Exp → AnnM AExp
-assignUniqueIds =
-  annotateExpM identity annotateExp annotateParam annotateName
- where
-  annotateExp ∷ RawExp Ann → AnnM (Id, Ann)
-  annotateExp e = (,getAnn e) <$> nextId
+assignUniqueIds = traverse \ann → (,ann) <$> nextId
 
-  annotateParam ∷ Parameter Ann → AnnM (Parameter (Id, Ann))
-  annotateParam = \case
-    ParamNamed ann name → do
-      id' ← nextId
-      pure $ ParamNamed (id', ann) name
-    ParamUnused ann → do
-      id' ← nextId
-      pure $ ParamUnused (id', ann)
-
-  annotateName ∷ Ann → Name → AnnM (Id, Ann)
-  annotateName a _name = (,a) <$> nextId
-
+-- | Strip the 'Id's back off, via the derived 'Functor' of 'RawExp'.
 deannotateExp ∷ AExp → Exp
-deannotateExp expr = runIdentity do
-  annotateExpM identity deannotateExp' deannotateParam deannotateName expr
- where
-  deannotateExp' ∷ Applicative f ⇒ RawExp (Id, Ann) → f Ann
-  deannotateExp' = pure . snd . getAnn
-
-  deannotateParam ∷ Applicative f ⇒ Parameter (Id, Ann) → f (Parameter Ann)
-  deannotateParam = \case
-    ParamNamed (_id, ann) name → pure $ ParamNamed ann name
-    ParamUnused (_id, ann) → pure $ ParamUnused ann
-
-  deannotateName ∷ Applicative f ⇒ (Id, Ann) → Name → f Ann
-  deannotateName (_id, ann) _name = pure ann
+deannotateExp = fmap snd

--- a/lib/Language/PureScript/Backend/IR/Linker.hs
+++ b/lib/Language/PureScript/Backend/IR/Linker.hs
@@ -2,6 +2,7 @@
 
 module Language.PureScript.Backend.IR.Linker where
 
+import Control.Lens (over)
 import Data.Graph (graphFromEdges', reverseTopSort)
 import Data.Set qualified as Set
 import Language.PureScript.Backend.IR.Inliner qualified as Inline
@@ -23,6 +24,7 @@ import Language.PureScript.Backend.IR.Types
   , bindingNames
   , noAnn
   , refImported
+  , subexpressions
   )
 
 data LinkMode
@@ -152,31 +154,14 @@ qualifyTopRefs moduleName = go
              where
               names' =
                 foldr Set.delete names (bindingNames grouping)
-      App ann argument function →
-        App ann (go' argument) (go' function)
-      LiteralArray ann as →
-        LiteralArray ann (go' <$> as)
-      LiteralObject ann props →
-        LiteralObject ann (go' <<$>> props)
-      ReflectCtor ann a →
-        ReflectCtor ann (go' a)
-      DataArgumentByIndex ann idx a →
-        DataArgumentByIndex ann idx (go' a)
-      Eq ann a b →
-        Eq ann (go' a) (go' b)
-      ArrayLength ann a →
-        ArrayLength ann (go' a)
-      ArrayIndex ann a indx →
-        ArrayIndex ann (go' a) indx
-      ObjectProp ann a prop →
-        ObjectProp ann (go' a) prop
-      ObjectUpdate ann a patches →
-        ObjectUpdate ann (go' a) (go' <<$>> patches)
-      IfThenElse ann p th el →
-        IfThenElse ann (go' p) (go' th) (go' el)
-      _ → expression
+      -- No other constructor binds names, so the top-name set passes
+      -- through:
+      _ → over subexpressions go' expression
    where
+    isTopLevel ∷ Name → Bool
     isTopLevel name = Set.member name topNames
+
+    go' ∷ Exp → Exp
     go' = go topNames
 
 --------------------------------------------------------------------------------

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -2,7 +2,14 @@
 
 module Language.PureScript.Backend.IR.Types where
 
-import Control.Lens (Prism', Traversal', makePrisms, prism')
+import Control.Lens
+  ( Prism'
+  , Traversal'
+  , foldMapOf
+  , makePrisms
+  , prism'
+  , traverseOf
+  )
 import Data.Deriving (deriveEq1, deriveOrd1)
 import Data.Map qualified as Map
 import Data.MonoidMap (MonoidMap)
@@ -67,7 +74,7 @@ data AlgebraicType = SumType | ProductType
   deriving stock (Generic, Eq, Ord, Show, Enum, Bounded)
 
 data Parameter ann = ParamUnused ann | ParamNamed ann Name
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 paramName ∷ Parameter ann → Maybe Name
 paramName (ParamUnused _ann) = Nothing
@@ -165,6 +172,15 @@ scoping" tests pin the convention.
 deriving stock instance Show ann ⇒ Show (RawExp ann)
 deriving stock instance Eq ann ⇒ Eq (RawExp ann)
 deriving stock instance Ord ann ⇒ Ord (RawExp ann)
+
+{- | Map/fold/traverse over every annotation of the expression: the
+per-node @ann@s, the 'Parameter' annotations, the name annotations of
+'Let' bindings, and the name annotations of a 'ForeignImport'.
+-}
+deriving stock instance Functor RawExp
+
+deriving stock instance Foldable RawExp
+deriving stock instance Traversable RawExp
 
 getAnn ∷ RawExp ann → ann
 getAnn = \case
@@ -341,90 +357,6 @@ literalObject = LiteralObject noAnn
 --------------------------------------------------------------------------------
 -- Traversals ------------------------------------------------------------------
 
-annotateExpM
-  ∷ ∀ ann ann' m
-   . Monad m
-  ⇒ (∀ x. m x → m x)
-  → (RawExp ann → m ann')
-  → (Parameter ann → m (Parameter ann'))
-  → (ann → Name → m ann')
-  → (RawExp ann → m (RawExp ann'))
-annotateExpM around annotateExp annotateParam annotateName =
-  around . \expr → do
-    ann ← annotateExp expr
-    case expr of
-      LiteralInt _ann i →
-        pure $ LiteralInt ann i
-      LiteralFloat _ann f →
-        pure $ LiteralFloat ann f
-      LiteralString _ann s →
-        pure $ LiteralString ann s
-      LiteralChar _ann c →
-        pure $ LiteralChar ann c
-      LiteralBool _ann b →
-        pure $ LiteralBool ann b
-      LiteralArray _ann elems → do
-        elems' ← traverse mkAnn elems
-        pure $ LiteralArray ann elems'
-      LiteralObject _ann props → do
-        props' ← traverse (traverse mkAnn) props
-        pure $ LiteralObject ann props'
-      ReflectCtor _ann a → do
-        a' ← mkAnn a
-        pure $ ReflectCtor ann a'
-      Eq _ann a b → do
-        a' ← mkAnn a
-        b' ← mkAnn b
-        pure $ Eq ann a' b'
-      DataArgumentByIndex _ann index a → do
-        a' ← mkAnn a
-        pure $ DataArgumentByIndex ann index a'
-      ArrayLength _ann a → do
-        a' ← mkAnn a
-        pure $ ArrayLength ann a'
-      ArrayIndex _ann a index → do
-        a' ← mkAnn a
-        pure $ ArrayIndex ann a' index
-      ObjectProp _ann a prop → do
-        a' ← mkAnn a
-        pure $ ObjectProp ann a' prop
-      ObjectUpdate _ann a props → do
-        a' ← mkAnn a
-        props' ← traverse (traverse mkAnn) props
-        pure $ ObjectUpdate ann a' props'
-      Abs _ann param body → do
-        body' ← mkAnn body
-        param' ← annotateParam param
-        pure $ Abs ann param' body'
-      App _ann a b → do
-        a' ← mkAnn a
-        b' ← mkAnn b
-        pure $ App ann a' b'
-      Ref _ann qname → pure $ Ref ann qname
-      Let _ann binds body → do
-        binds' ←
-          forM binds $
-            traverse \(a, n, e) → do
-              n' ← annotateName a n
-              e' ← mkAnn e
-              pure (n', n, e')
-        body' ← mkAnn body
-        pure $ Let ann binds' body'
-      IfThenElse _ann i t e → do
-        i' ← mkAnn i
-        t' ← mkAnn t
-        e' ← mkAnn e
-        pure $ IfThenElse ann i' t' e'
-      Ctor _ann mn aty ty ctr fs → pure $ Ctor ann mn aty ty ctr fs
-      Exception _ann m → pure $ Exception ann m
-      ForeignImport _ann m p ns → do
-        anns ← traverse (uncurry annotateName) ns
-        let ns' = zip anns (fmap snd ns)
-        pure $ ForeignImport ann m p ns'
- where
-  mkAnn ∷ RawExp ann → m (RawExp ann')
-  mkAnn = annotateExpM around annotateExp annotateParam annotateName
-
 {-# INLINE subexpressions #-}
 
 -- | Get all the direct child 'RawExp's of the given 'RawExp'
@@ -516,36 +448,7 @@ rewriteExpTopDownM rewrite = visit
       Rewritten Stop expression' → pure expression'
       Rewritten Recurse expression' → descendInto expression'
 
-  descendInto e = case e of
-    LiteralArray ann as →
-      LiteralArray ann <$> traverse visit as
-    LiteralObject ann props →
-      LiteralObject ann <$> traverse (traverse visit) props
-    ReflectCtor ann a →
-      ReflectCtor ann <$> visit a
-    DataArgumentByIndex ann idx a →
-      DataArgumentByIndex ann idx <$> visit a
-    Eq ann a b →
-      Eq ann <$> visit a <*> visit b
-    ArrayLength ann a →
-      ArrayLength ann <$> visit a
-    ArrayIndex ann a indx →
-      visit a <&> \expr → ArrayIndex ann expr indx
-    ObjectProp ann a prop →
-      visit a <&> \expr → ObjectProp ann expr prop
-    ObjectUpdate ann a patches →
-      ObjectUpdate ann <$> visit a <*> traverse (traverse visit) patches
-    App ann a b →
-      App ann <$> visit a <*> visit b
-    Abs ann param expr →
-      Abs ann param <$> visit expr
-    Let ann binds body →
-      Let ann
-        <$> forM binds (traverse \(a, n, expr) → (a,n,) <$> visit expr)
-        <*> visit body
-    IfThenElse ann p th el →
-      IfThenElse ann <$> visit p <*> visit th <*> visit el
-    _ → pure e
+  descendInto = traverseOf subexpressions visit
 
 countFreeRefs ∷ RawExp ann → Map (Qualified Name) Natural
 countFreeRefs = fmap getSum . MMap.toMap . countFreeRefs' mempty
@@ -593,39 +496,8 @@ countFreeRefs = fmap getSum . MMap.toMap . countFreeRefs' mempty
               (\(_nameAnn, boundName, _expr) → Set.insert boundName)
               names
               recBinds
-    App _ann argument function →
-      go argument <> go function
-    LiteralArray _ann as →
-      foldMap go as
-    LiteralObject _ann props →
-      foldMap (go . snd) props
-    ReflectCtor _ann a →
-      go a
-    DataArgumentByIndex _ann _idx a →
-      go a
-    Eq _ann a b →
-      go a <> go b
-    ArrayLength _ann a →
-      go a
-    ArrayIndex _ann a _indx →
-      go a
-    ObjectProp _ann a _prop →
-      go a
-    ObjectUpdate _ann a patches →
-      go a <> foldMap (go . snd) patches
-    IfThenElse _ann p th el →
-      go p <> go th <> go el
-    -- Terminals:
-    LiteralInt {} → mempty
-    LiteralBool {} → mempty
-    LiteralFloat {} → mempty
-    LiteralString {} → mempty
-    LiteralChar {} → mempty
-    Ctor {} → mempty
-    Exception {} → mempty
-    ForeignImport {} → mempty
-   where
-    go = countFreeRefs' bound
+    -- No other constructor binds names, so the scope passes through:
+    other → foldMapOf subexpressions (countFreeRefs' bound) other
 
 countFreeRef ∷ Qualified Name → RawExp ann → Natural
 countFreeRef name = Map.findWithDefault 0 name . countFreeRefs
@@ -827,30 +699,9 @@ freshenBinders = go Map.empty
             (bindAnn,Map.findWithDefault name name renames',)
               <$> go renames' expr
       Let ann <$> traverse (traverse renameBound) binds <*> go renames' body
-    LiteralArray ann as →
-      LiteralArray ann <$> traverse (go renames) as
-    LiteralObject ann props →
-      LiteralObject ann <$> traverse (traverse (go renames)) props
-    ReflectCtor ann a →
-      ReflectCtor ann <$> go renames a
-    DataArgumentByIndex ann idx a →
-      DataArgumentByIndex ann idx <$> go renames a
-    Eq ann a b →
-      Eq ann <$> go renames a <*> go renames b
-    ArrayLength ann a →
-      ArrayLength ann <$> go renames a
-    ArrayIndex ann a idx →
-      ArrayIndex ann <$> go renames a <*> pure idx
-    ObjectProp ann a prop →
-      ObjectProp ann <$> go renames a <*> pure prop
-    ObjectUpdate ann a patches →
-      ObjectUpdate ann <$> go renames a <*> traverse (traverse (go renames)) patches
-    App ann a b →
-      App ann <$> go renames a <*> go renames b
-    IfThenElse ann p th el →
-      IfThenElse ann <$> go renames p <*> go renames th <*> go renames el
-    -- Terminals:
-    terminal → pure terminal
+    -- No other constructor binds or references names ('ForeignImport'
+    -- included: its name list holds export keys, not binders):
+    other → traverseOf subexpressions (go renames) other
 
   freshNameFor ∷ Name → SupplyM Name
   freshNameFor name = freshName (nameToText name <> "$")
@@ -902,44 +753,16 @@ substituteFreshening freshenFirst name replacement target =
   evalStateT (go target) freshenFirst
  where
   -- The state is whether the next inserted occurrence must be freshened.
+  -- Under GUC no scope is threaded (see the haddock above): binders are
+  -- descended through blindly, so only 'Ref' needs a dedicated case.
   go ∷ RawExp ann → StateT Bool SupplyM (RawExp ann)
   go = \case
-    r@(Ref _ann name')
+    Ref _ann name'
       | name' == name → do
           freshen ← get
           put True
           if freshen then lift (freshenBinders replacement) else pure replacement
-      | otherwise → pure r
-    Abs ann param body →
-      Abs ann param <$> go body
-    Let ann binds body →
-      Let ann
-        <$> traverse (traverse \(a, n, expr) → (a,n,) <$> go expr) binds
-        <*> go body
-    LiteralArray ann as →
-      LiteralArray ann <$> traverse go as
-    LiteralObject ann props →
-      LiteralObject ann <$> traverse (traverse go) props
-    ReflectCtor ann a →
-      ReflectCtor ann <$> go a
-    DataArgumentByIndex ann idx a →
-      DataArgumentByIndex ann idx <$> go a
-    Eq ann a b →
-      Eq ann <$> go a <*> go b
-    ArrayLength ann a →
-      ArrayLength ann <$> go a
-    ArrayIndex ann a idx →
-      ArrayIndex ann <$> go a <*> pure idx
-    ObjectProp ann a prop →
-      ObjectProp ann <$> go a <*> pure prop
-    ObjectUpdate ann a patches →
-      ObjectUpdate ann <$> go a <*> traverse (traverse go) patches
-    App ann a b →
-      App ann <$> go a <*> go b
-    IfThenElse ann p th el →
-      IfThenElse ann <$> go p <*> go th <*> go el
-    -- Terminals:
-    terminal → pure terminal
+    other → traverseOf subexpressions go other
 
 $(makePrisms ''AlgebraicType)
 $(makePrisms ''Parameter)

--- a/lib/Language/PureScript/Backend/IR/Uniquify.hs
+++ b/lib/Language/PureScript/Backend/IR/Uniquify.hs
@@ -24,6 +24,7 @@ module Language.PureScript.Backend.IR.Uniquify
   , uniquifyNamesInExpr
   ) where
 
+import Control.Lens (traverseOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -38,6 +39,7 @@ import Language.PureScript.Backend.IR.Types
   , Grouping (..)
   , Parameter (..)
   , RawExp (..)
+  , subexpressions
   )
 import Language.PureScript.Names (runtimeLazyName)
 
@@ -70,28 +72,6 @@ uniquifyNamesInExpr e =
  where
   go ∷ RenamesInScope → Exp → State (Set Name) Exp
   go scope = \case
-    LiteralArray ann as →
-      LiteralArray ann <$> traverse (go scope) as
-    LiteralObject ann ps →
-      LiteralObject ann <$> traverse (traverse (go scope)) ps
-    ReflectCtor ann a →
-      ReflectCtor ann <$> go scope a
-    Eq ann a b →
-      Eq ann <$> go scope a <*> go scope b
-    DataArgumentByIndex ann index a →
-      DataArgumentByIndex ann index <$> go scope a
-    ArrayLength ann a →
-      ArrayLength ann <$> go scope a
-    ArrayIndex ann a index →
-      ArrayIndex ann <$> go scope a <*> pure index
-    ObjectProp ann a prop →
-      ObjectProp ann <$> go scope a <*> pure prop
-    ObjectUpdate ann a ps →
-      ObjectUpdate ann <$> go scope a <*> traverse (traverse (go scope)) ps
-    App ann a b →
-      App ann <$> go scope a <*> go scope b
-    IfThenElse ann i t f →
-      IfThenElse ann <$> go scope i <*> go scope t <*> go scope f
     Abs ann param body →
       case param of
         ParamUnused _ann → Abs ann param <$> go scope body
@@ -107,17 +87,11 @@ uniquifyNamesInExpr e =
     Let ann binds body → do
       (scope', binds') ← foldlM withGrouping (scope, []) (toList binds)
       Let ann (NE.fromList (reverse binds')) <$> go scope' body
-    -- Terminals:
-    terminal@LiteralInt {} → pure terminal
-    terminal@LiteralFloat {} → pure terminal
-    terminal@LiteralString {} → pure terminal
-    terminal@LiteralChar {} → pure terminal
-    terminal@LiteralBool {} → pure terminal
-    terminal@Ctor {} → pure terminal
-    terminal@Exception {} → pure terminal
-    -- The names of a foreign import are the export keys of the foreign
-    -- source file, not binders — they must not be renamed.
-    terminal@ForeignImport {} → pure terminal
+    -- No other constructor binds or references names, so the scope
+    -- passes through ('ForeignImport' included: its name list holds the
+    -- export keys of the foreign source file, not binders — they must
+    -- not be renamed):
+    other → traverseOf subexpressions (go scope) other
 
   withGrouping
     ∷ (RenamesInScope, [Grouping (Ann, Name, Exp)])


### PR DESCRIPTION
Preparatory refactor for the rewrite-driver modernization (#144, #145): the IR layer had about a dozen hand-written structural recursions over `RawExp`, each spelling out every constructor. This PR consolidates them onto the existing `subexpressions` traversal and lens combinators, so the upcoming driver change only has to touch one traversal spine.

What changed:

- `RawExp` and `Parameter` now derive `Functor`/`Foldable`/`Traversable` over the annotation. This subsumes the bespoke `annotateExpM` (deleted): DCE's `assignUniqueIds` is now a plain `traverse`, and `deannotateExp` is `fmap snd`.
- Traversals that thread context (the bound-name scope in `countFreeRefs`, rename maps in `freshenBinders`, sequential Let scoping everywhere per Note [Sequential scoping of Let bindings]) keep their explicit `Ref`/`Abs`/`Let` cases and delegate the structural remainder to `traverseOf`/`foldMapOf`/`over subexpressions`. Forcing those onto a plain plate would lose the scope threading, so they stay hand-written on purpose.
- Same treatment in `DCE.adjacencyListForExpr`, `DCE.expressionDependsOnIds`, `Uniquify.uniquifyNamesInExpr`, and `Linker.qualifyTopRefs`.
- The old driver's `descendInto` collapsed to `traverseOf subexpressions` (it was a manual copy of the plate).

No behavior change intended, and none observed: the full suite passes with every golden file byte-for-byte unchanged. Net -288 lines.

First of a three-PR stack: this one, then the bottom-up rewrite driver (#145), then the fixpoint oracle switch (#144).
