### PR TITLE
perf: drive optimizer fixpoints by change flags instead of whole-module Eq

### DIFF
--- a/changelog.d/20260704_140000_unisay_fixpoint_change_flag.md
+++ b/changelog.d/20260704_140000_unisay_fixpoint_change_flag.md
@@ -1,0 +1,12 @@
+### Changed
+
+- The optimizer's fixpoint oracle no longer compares whole `UberModule`s for
+  structural equality (#144). Every pass now returns a change flag (precise for
+  the fixpoint members — optimize and DCE — whose rewrite rules report honestly
+  since the bottom-up driver change); a fixpoint stops on the first round that
+  reports no change, bounded by a generous iteration cap. The production runner
+  accepts the module reached at the cap (an early stop only costs optimization,
+  never correctness), while the checked runner — used by the test suite and
+  `--lint-ir` — fails loudly in both dishonesty directions: a pass that changes
+  the module while reporting no change (`PassUnreportedChange`), and a fixpoint
+  that fails to converge within the cap (`FixpointDivergence`).

--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -24,9 +24,11 @@ import Language.PureScript.Backend.IR.Types
   , Grouping (..)
   , Parameter (..)
   , RawExp (..)
+  , WasRewritten (..)
   , getAnn
   , listGrouping
   , rewriteExpBottomUp
+  , rewrittenIf
   , subexpressions
   )
 
@@ -40,7 +42,13 @@ type Scope = Map (Qualified Name) Id
 
 type Node = ((), Id, [Id])
 
-eliminateDeadCode ∷ UberModule → UberModule
+{- | Drop the unreachable bindings of the module. The 'WasRewritten'
+result (see 'Language.PureScript.Backend.IR.Pass.passRun') reports
+precisely whether anything was dropped, blanked, or pruned — an
+expression rewrite fired ('dceAnnotatedExp'), a top-level binding or
+foreign was dropped, or a 'ForeignImport' name list was pruned.
+-}
+eliminateDeadCode ∷ UberModule → (UberModule, WasRewritten)
 eliminateDeadCode uber@UberModule {..} =
   -- traceIt "annotatedForeigns" annotatedForeigns $
   --   traceIt "annotatedBindings" annotatedBindings $
@@ -48,12 +56,24 @@ eliminateDeadCode uber@UberModule {..} =
   --       traceIt "topLevelScope" topLevelScope $
   --         traceIt "adjacencyList" adjacencyList $
   --           traceIt "reachableIds" reachableIds $
-  uber
-    { uberModuleForeigns = preservedForeigns
-    , uberModuleBindings = preservedBindings
-    , uberModuleExports = preservedExports
-    }
+  ( uber
+      { uberModuleForeigns = preservedForeigns
+      , uberModuleBindings = preservedBindings
+      , uberModuleExports = preservedExports
+      }
+  , mconcat
+      [ exprRewrites
+      , rewrittenIf (length preservedForeigns /= length annotatedForeigns)
+      , rewrittenIf
+          (groupingMembers preservedBindings /= groupingMembers annotatedBindings)
+      ]
+  )
  where
+  exprRewrites ∷ WasRewritten
+  exprRewrites = foreignExprRewrites <> bindingExprRewrites <> exportExprRewrites
+
+  groupingMembers ∷ [Grouping a] → Int
+  groupingMembers = length . (listGrouping =<<)
   -- traceIt ∷ ∀ a b. Show a ⇒ String → a → b → b
   -- traceIt label it =
   --   trace ("\n\n" <> label <> ":\n" <> pp it <> "\n")
@@ -66,39 +86,43 @@ eliminateDeadCode uber@UberModule {..} =
   --           }
 
   -- See Note [Foreign bindings structure emitted by the Linker]
-  preservedForeigns ∷ [(QName, Exp)]
-  preservedForeigns = do
-    (name, expr) ← annotatedForeigns
-    guard $ nodeId expr `member` reachableIds
-    pure . (name,) $ case expr of
-      ForeignImport (_id, ann) modname path names →
-        ForeignImport
-          ann
-          modname
-          path
-          [(a, n) | ((i, a), n) ← names, i `member` reachableIds]
-      other → dceAnnotatedExp other
-
-  preservedBindings ∷ [Grouping (QName, Exp)] =
-    annotatedBindings >>= \case
-      Standalone (qname, expr) → do
-        guard $ nodeId expr `member` reachableIds
-        [Standalone (qname, dceAnnotatedExp expr)]
-      RecursiveGroup recBinds →
-        case NE.nonEmpty (preservedRecBinds (toList recBinds)) of
-          Nothing → []
-          Just pb → [RecursiveGroup pb]
-   where
-    preservedRecBinds ∷ [(QName, AExp)] → [(QName, Exp)]
-    preservedRecBinds recBinds = do
-      (qname, expr) ← recBinds
+  ( preservedForeigns ∷ [(QName, Exp)]
+    , foreignExprRewrites ∷ WasRewritten
+    ) = second fold $ unzip do
+      (name, expr) ← annotatedForeigns
       guard $ nodeId expr `member` reachableIds
-      pure (qname, dceAnnotatedExp expr)
+      pure case expr of
+        ForeignImport (_id, ann) modname path names →
+          let keptNames = [(a, n) | ((i, a), n) ← names, i `member` reachableIds]
+           in ( (name, ForeignImport ann modname path keptNames)
+              , rewrittenIf (length keptNames /= length names)
+              )
+        other → first (name,) (dceAnnotatedExp other)
 
-  preservedExports ∷ [(Name, Exp)]
-  preservedExports = do
-    (name, annotatedExp) ← annotatedExports
-    pure (name, dceAnnotatedExp annotatedExp)
+  ( preservedBindings ∷ [Grouping (QName, Exp)]
+    , bindingExprRewrites ∷ WasRewritten
+    ) = second fold $ unzip do
+      annotatedBindings >>= \case
+        Standalone (qname, expr) → do
+          guard $ nodeId expr `member` reachableIds
+          let (e, rewritten) = dceAnnotatedExp expr
+          [(Standalone (qname, e), rewritten)]
+        RecursiveGroup recBinds →
+          case NE.nonEmpty (preservedRecBinds (toList recBinds)) of
+            Nothing → []
+            Just pb → [(RecursiveGroup (fst <$> pb), foldMap snd pb)]
+     where
+      preservedRecBinds ∷ [(QName, AExp)] → [((QName, Exp), WasRewritten)]
+      preservedRecBinds recBinds = do
+        (qname, expr) ← recBinds
+        guard $ nodeId expr `member` reachableIds
+        pure (first (qname,) (dceAnnotatedExp expr))
+
+  ( preservedExports ∷ [(Name, Exp)]
+    , exportExprRewrites ∷ WasRewritten
+    ) = second fold $ unzip do
+      (name, annotatedExp) ← annotatedExports
+      pure (first (name,) (dceAnnotatedExp annotatedExp))
 
   -- run these computations in the same monad
   -- so that we can share the state of the ID counter
@@ -124,16 +148,16 @@ eliminateDeadCode uber@UberModule {..} =
   -- the node collapses to its body, a body that is itself a Let has
   -- already had its own dead bindings dropped — the Recurse-escape bug
   -- class (issue #149) cannot arise, and no rebuild cascade is needed.
-  -- Both rules observe the honesty contract of 'RewriteRule': they fire
-  -- only when a binder is actually blanked or dropped (issue #145), so
-  -- the driver's 'WasRewritten' signal is sound.
-  dceAnnotatedExp ∷ AExp → Exp
+  -- Both rules fire only when a binder is actually blanked or dropped
+  -- (the 'RewriteRule' contract, issue #145), so the driver's
+  -- 'WasRewritten' signal is precise.
+  dceAnnotatedExp ∷ AExp → (Exp, WasRewritten)
   dceAnnotatedExp =
-    deannotateExp . fst . rewriteExpBottomUp \case
+    first deannotateExp . rewriteExpBottomUp \case
       -- Under GUC a dead binder is unreferenced by definition, so
       -- blanking its name touches no reference elsewhere (the hazard
       -- behind issue #56). Requiring 'ParamNamed' keeps the rule
-      -- honest: an already-blank parameter is left alone.
+      -- precise: an already-blank parameter is left alone.
       Abs ann (ParamNamed pann@(paramId, _) _name) b
         | not (paramId `member` reachableIds) →
             Just (Abs ann (ParamUnused pann) b)

--- a/lib/Language/PureScript/Backend/IR/DCE.hs
+++ b/lib/Language/PureScript/Backend/IR/DCE.hs
@@ -126,14 +126,14 @@ eliminateDeadCode uber@UberModule {..} =
   -- class (issue #149) cannot arise, and no rebuild cascade is needed.
   -- Both rules observe the honesty contract of 'RewriteRule': they fire
   -- only when a binder is actually blanked or dropped (issue #145), so
-  -- the driver's change flag is a sound fixpoint signal (issue #144).
+  -- the driver's 'WasRewritten' signal is sound.
   dceAnnotatedExp ∷ AExp → Exp
   dceAnnotatedExp =
     deannotateExp . fst . rewriteExpBottomUp \case
       -- Under GUC a dead binder is unreferenced by definition, so
       -- blanking its name touches no reference elsewhere (the hazard
       -- behind issue #56). Requiring 'ParamNamed' keeps the rule
-      -- honest: an already-blank parameter is left alone (issue #145).
+      -- honest: an already-blank parameter is left alone.
       Abs ann (ParamNamed pann@(paramId, _) _name) b
         | not (paramId `member` reachableIds) →
             Just (Abs ann (ParamUnused pann) b)

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -1,5 +1,6 @@
 module Language.PureScript.Backend.IR.Optimizer where
 
+import Control.Monad.Writer.CPS (WriterT, runWriterT, tell)
 import Data.Foldable (foldrM)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
@@ -105,7 +106,7 @@ optimizerPipeline neverNames =
   uniquifyPass =
     Pass
       { passName = "uniquify"
-      , passRun = pure . uniquifyNames
+      , passRun = conservatively . pure . uniquifyNames
       , passRequires = wellScoped
       , passEnsures = guc
       }
@@ -116,20 +117,26 @@ optimizerPipeline neverNames =
       , passRequires = guc
       , passEnsures = guc
       }
-  dcePass = gucPass "dce" eliminateDeadCode
+  dcePass =
+    Pass
+      { passName = "dce"
+      , passRun = pure . eliminateDeadCode
+      , passRequires = guc
+      , passEnsures = guc
+      }
   mergeForeignsPass = gucPass "mergeForeigns" mergeForeignsIntoBindings
   floatInPass = gucPass "float-in" floatIn
   magicDoPass =
     Pass
       { passName = "magicDo"
-      , passRun = magicDo
+      , passRun = conservatively . magicDo
       , passRequires = guc
       , passEnsures = guc
       }
   flattenDeepBindsPass =
     Pass
       { passName = "flattenDeepBinds"
-      , passRun = flattenDeepBindsM
+      , passRun = conservatively . flattenDeepBindsM
       , passRequires = guc
       , passEnsures = guc
       }
@@ -138,10 +145,15 @@ optimizerPipeline neverNames =
   gucPass name run =
     Pass
       { passName = name
-      , passRun = pure . run
+      , passRun = conservatively . pure . run
       , passRequires = guc
       , passEnsures = guc
       }
+
+  -- Run-once passes report a conservative 'Rewritten' — only fixpoint
+  -- members (optimize, dce) need a precise signal (see 'passRun').
+  conservatively ∷ SupplyM UberModule → SupplyM (UberModule, WasRewritten)
+  conservatively = fmap (,Rewritten)
 
   wellScoped ∷ Set Invariant
   wellScoped = Set.singleton WellScoped
@@ -171,13 +183,13 @@ neverInlineNames UberModule {uberModuleBindings} =
     , getAnn expr == Just Never
     ]
 
-optimizeModule ∷ Set QName → UberModule → SupplyM UberModule
-optimizeModule neverNames UberModule {..} = do
+optimizeModule ∷ Set QName → UberModule → SupplyM (UberModule, WasRewritten)
+optimizeModule neverNames UberModule {..} = runWriterT do
   (bindings, exports) ←
     foldrM withBinding ([], uberModuleExports) uberModuleBindings
   uberModuleBindings' ←
-    traverse (traverse (traverse optimizedExpressionM)) bindings
-  uberModuleExports' ← traverse (traverse optimizedExpressionM) exports
+    traverse (traverse (traverse optimizeExp)) bindings
+  uberModuleExports' ← traverse (traverse optimizeExp) exports
   pure
     UberModule
       { uberModuleForeigns
@@ -185,14 +197,22 @@ optimizeModule neverNames UberModule {..} = do
       , uberModuleExports = uberModuleExports'
       }
  where
+  -- Every expression rewrite and every top-level inlining reports into
+  -- the pass's 'WasRewritten' result; nothing else in this pass changes
+  -- the module, so a converged module reports 'Unmodified'.
+  optimizeExp ∷ Exp → WriterT WasRewritten SupplyM Exp
+  optimizeExp e = do
+    (e', rewritten) ← lift (optimizedExpressionM e)
+    e' <$ tell rewritten
+
   withBinding
     ∷ Grouping (QName, Exp)
     → ([Grouping (QName, Exp)], [(Name, Exp)])
-    → SupplyM ([Grouping (QName, Exp)], [(Name, Exp)])
+    → WriterT WasRewritten SupplyM ([Grouping (QName, Exp)], [(Name, Exp)])
   withBinding binding (bindings, exports) =
     case binding of
       Standalone (qname, expr0) → do
-        expr ← optimizedExpressionM expr0
+        expr ← optimizeExp expr0
         -- See Note [Inline annotations and inlining heuristics]
         let isUsedOnce name =
               1 == Map.findWithDefault 0 (qualifiedQName name) uberModuleFreeRefs
@@ -205,13 +225,18 @@ optimizeModule neverNames UberModule {..} = do
               (bindingExprs =<< uberModuleBindings) <> map snd exports
         if qname `Set.notMember` neverNames
           && (isInlinableExpr expr || isUsedOnce qname)
-          then
-            (,)
-              <$> substituteInBindings qname expr bindings
-              <*> substituteInExports qname expr exports
+          then do
+            -- The binding is dropped from the module in favor of the
+            -- substituted copies: a rewrite even when it had no
+            -- occurrences left to substitute.
+            tell Rewritten
+            lift $
+              (,)
+                <$> substituteInBindings qname expr bindings
+                <*> substituteInExports qname expr exports
           else pure (Standalone (qname, expr) : bindings, exports)
       RecursiveGroup recGroup → do
-        recGroup' ← traverse (traverse optimizedExpressionM) recGroup
+        recGroup' ← traverse (traverse optimizeExp) recGroup
         pure (RecursiveGroup recGroup' : bindings, exports)
 
 -- Cross-entry substitution: the host entry's binders give no uniqueness
@@ -245,21 +270,20 @@ its own supply. Production code uses 'optimizedExpressionM' so all
 passes share one supply.
 -}
 optimizedExpression ∷ Exp → Exp
-optimizedExpression = runSupply . optimizedExpressionM
+optimizedExpression = runSupply . fmap fst . optimizedExpressionM
 
-optimizedExpressionM ∷ Exp → SupplyM Exp
+optimizedExpressionM ∷ Exp → SupplyM (Exp, WasRewritten)
 optimizedExpressionM =
   -- See Note [Eta reduction is unsound]
-  fmap fst
-    . rewriteExpBottomUpM
-      ( constantFolding
-          `thenRewrite` betaReduce
-          `thenRewrite` betaReduceUnusedParams
-          `thenRewrite` removeUnreachableThenBranch
-          `thenRewrite` removeUnreachableElseBranch
-          `thenRewrite` removeIfWithEqualBranches
-          `thenRewrite` inlineLocalBindings
-      )
+  rewriteExpBottomUpM
+    ( constantFolding
+        `thenRewrite` betaReduce
+        `thenRewrite` betaReduceUnusedParams
+        `thenRewrite` removeUnreachableThenBranch
+        `thenRewrite` removeUnreachableElseBranch
+        `thenRewrite` removeIfWithEqualBranches
+        `thenRewrite` inlineLocalBindings
+    )
 
 {- Note [IR is assumed well-typed]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -386,8 +410,8 @@ inlineLocalBindings = \case
 
 {- | Inline one binding into the Let's body when the heuristic wants it
 /and/ the body actually references it — a zero-occurrence substitution
-is a no-op and must not report a change (the honesty contract of
-'RewriteRuleM'), or the optimize fixpoint would never converge.
+is a no-op and must not report a rewrite (the 'RewriteRule' contract),
+or the optimize fixpoint would never converge.
 
 The inlinee must not reference the binding's own name: substitution
 never descends into its insertions, so a self-reference would keep the

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -31,6 +31,7 @@ import Language.PureScript.Backend.IR.Types
   , Parameter (..)
   , RawExp (..)
   , RewriteRuleM
+  , WasRewritten (..)
   , alphaEq
   , bindingExprs
   , countFreeRef
@@ -377,8 +378,10 @@ removeUnreachableElseBranch e = pure case e of
 inlineLocalBindings ∷ RewriteRuleM SupplyM Ann
 inlineLocalBindings = \case
   Let ann groupings body → do
-    (body', Any inlined) ← foldrM inlineLocalBinding (body, Any False) groupings
-    pure $ if inlined then Just (Let ann groupings body') else Nothing
+    (body', inlined) ← foldrM inlineLocalBinding (body, Unmodified) groupings
+    pure case inlined of
+      Rewritten → Just (Let ann groupings body')
+      Unmodified → Nothing
   _ → pure Nothing
 
 {- | Inline one binding into the Let's body when the heuristic wants it
@@ -398,7 +401,10 @@ a same-named reference in the RHS would be a duplicate binder upstream
 — but 'optimizedExpression' is also exercised directly on non-GUC
 input, where the rule must decline rather than loop or capture.
 -}
-inlineLocalBinding ∷ Grouping (Ann, Name, Exp) → (Exp, Any) → SupplyM (Exp, Any)
+inlineLocalBinding
+  ∷ Grouping (Ann, Name, Exp)
+  → (Exp, WasRewritten)
+  → SupplyM (Exp, WasRewritten)
 inlineLocalBinding grouping (body, inlined) =
   case grouping of
     RecursiveGroup _grp → pure (body, inlined) -- Not inlining recursive bindings
@@ -408,7 +414,7 @@ inlineLocalBinding grouping (body, inlined) =
       , isInlinableExpr inlinee || occurrences == 1 →
           -- The binding survives until DCE drops it, so the inserted copy
           -- must not reuse its binder names ('substituteCopyM').
-          (,Any True) <$> substituteCopyM name inlinee body
+          (,Rewritten) <$> substituteCopyM name inlinee body
       | otherwise → pure (body, inlined)
      where
       occurrences ∷ Natural

--- a/lib/Language/PureScript/Backend/IR/Pass.hs
+++ b/lib/Language/PureScript/Backend/IR/Pass.hs
@@ -1,8 +1,9 @@
 {- | First-class passes for the IR pipeline (issue #138).
 
 A pass is a value carrying its contract: the invariants it requires of
-its input and the invariants it ensures for its output. The pipeline is
-a list of 'Step's interpreted by one of three runners:
+its input, the invariants it ensures for its output, and a
+'WasRewritten' signal on its result. The pipeline is a list of 'Step's
+interpreted by one of three runners:
 
   * 'runSteps' — plain execution, no checking (the production default);
   * 'runStepsChecked' — lints 'passRequires' before and 'passEnsures'
@@ -16,6 +17,22 @@ a list of 'Step's interpreted by one of three runners:
 'Pass') so the checked runner can see through a fixpoint and lint each
 iteration: a violation on an intermediate iteration that a later
 iteration masks would otherwise be invisible.
+
+A fixpoint iterates its passes until a whole round reports
+'Unmodified', bounded by 'maxFixpointIterations' — no runner compares
+whole modules for structural equality. The two ways the signal can be
+imprecise are each caught in the direction that matters:
+
+  * /under-reporting/ (changed the module, said it didn't) would stop a
+    fixpoint early and silently under-optimize — the checked runner
+    compares the one module a pass claims unchanged against its input
+    and fails with 'PassUnreportedChange';
+  * /over-reporting/ (said it changed, didn't) would spin a fixpoint
+    forever — both runners stop at 'maxFixpointIterations', where the
+    checked runner fails with 'FixpointDivergence' while the production
+    runner accepts the module reached so far (every pass is
+    semantics-preserving, so an early stop only costs optimization,
+    never correctness).
 -}
 module Language.PureScript.Backend.IR.Pass
   ( Invariant (..)
@@ -28,6 +45,7 @@ module Language.PureScript.Backend.IR.Pass
   , runStepsChecked
   , runStepsTraced
   , idempotently
+  , maxFixpointIterations
   ) where
 
 import Control.Monad.Error.Class (MonadError (throwError))
@@ -39,6 +57,7 @@ import Language.PureScript.Backend.IR.Linter
   , lintWellScoped
   )
 import Language.PureScript.Backend.IR.Supply (SupplyM)
+import Language.PureScript.Backend.IR.Types (WasRewritten (..))
 
 --------------------------------------------------------------------------------
 -- Passes and their contracts --------------------------------------------------
@@ -57,14 +76,20 @@ data Invariant = WellScoped | UniqueBinders
 
 data Pass = Pass
   { passName ∷ Text
-  , passRun ∷ UberModule → SupplyM UberModule
+  , passRun ∷ UberModule → SupplyM (UberModule, WasRewritten)
+  {- ^ Run the pass. 'Unmodified' asserts the returned module is
+  structurally identical to the input, 'Rewritten' says it may differ.
+  Passes iterated by a 'RunFixpoint' must report precisely — the
+  fixpoint stops on the first 'Unmodified' round — while a pass that
+  only ever runs once may report a conservative 'Rewritten'.
+  -}
   , passRequires ∷ Set Invariant
   , passEnsures ∷ Set Invariant
   }
 
 {- | One step of a pipeline: a single pass, or a sequence of passes
-iterated until a whole-module 'Eq' fixpoint (same semantics as
-'idempotently' over their composition).
+iterated until a round reports no change (see 'passRun'), bounded by
+'maxFixpointIterations'.
 -}
 data Step
   = RunPass Pass
@@ -73,23 +98,29 @@ data Step
 data Phase = Before | After
   deriving stock (Eq, Show)
 
-{- | A pass's contract did not hold: the named invariant set was violated
-either on the pass's input ('Before') or on its output ('After').
--}
-data PassCheckFailure = PassCheckFailure
-  { failedPassName ∷ Text
-  , failedPhase ∷ Phase
-  , failedViolations ∷ NonEmpty Violation
-  }
+-- | A pass broke its contract; thrown by 'runStepsChecked' only.
+data PassCheckFailure
+  = {- | The named pass violated the given invariant set either on its
+    input ('Before') or on its output ('After').
+    -}
+    PassCheckFailure Text Phase (NonEmpty Violation)
+  | {- | The named pass returned a module that differs from its input
+    while reporting no change — the fixpoint oracle cannot trust it.
+    -}
+    PassUnreportedChange Text
+  | {- | The named fixpoint did not converge within the given number of
+    iterations ('maxFixpointIterations'): some pass over-reports
+    changes or genuinely loops.
+    -}
+    FixpointDivergence Text Natural
   deriving stock (Eq, Show)
 
 {- | The user-facing rendering of a contract violation (used by the CLI
-behind @--lint-ir@): a headline naming the offending pass and phase,
-then one line per violation.
+behind @--lint-ir@).
 -}
 renderPassCheckFailure ∷ PassCheckFailure → Text
-renderPassCheckFailure
-  PassCheckFailure {failedPassName, failedPhase, failedViolations} =
+renderPassCheckFailure = \case
+  PassCheckFailure failedPassName failedPhase failedViolations →
     unlines $
       [ "IR invariants violated "
           <> show failedPhase
@@ -98,6 +129,25 @@ renderPassCheckFailure
           <> ":"
       ]
         <> (show <$> toList failedViolations)
+  PassUnreportedChange passName →
+    "Optimizer pass "
+      <> passName
+      <> " changed the module while reporting no change."
+  FixpointDivergence fixpointName iterations →
+    "Optimizer fixpoint "
+      <> fixpointName
+      <> " did not converge within "
+      <> show iterations
+      <> " iterations."
+
+{- | Iteration backstop for 'RunFixpoint'. Convergence normally takes a
+handful of rounds, so this is far above anything legitimate: hitting it
+means a pass over-reports changes or genuinely loops — a bug, which the
+checked runner turns into a 'FixpointDivergence' while the production
+runner accepts the (correct, possibly under-optimized) module reached.
+-}
+maxFixpointIterations ∷ Natural
+maxFixpointIterations = 100
 
 --------------------------------------------------------------------------------
 -- Runners ---------------------------------------------------------------------
@@ -107,9 +157,15 @@ runSteps steps uber0 = foldlM (flip runStep) uber0 steps
  where
   runStep ∷ Step → UberModule → SupplyM UberModule
   runStep = \case
-    RunPass p → passRun p
-    RunFixpoint _name passes →
-      fixpointM \uber → foldlM (flip passRun) uber (toList passes)
+    RunPass p → fmap fst . passRun p
+    RunFixpoint _name passes → loop maxFixpointIterations
+     where
+      loop ∷ Natural → UberModule → SupplyM UberModule
+      loop 0 uber = pure uber -- cap reached: accept (see the module doc)
+      loop n uber =
+        runRound passRun uber (toList passes) >>= \case
+          (uber', Rewritten) → loop (n - 1) uber'
+          (uber', Unmodified) → pure uber'
 
 runStepsChecked
   ∷ [Step] → UberModule → SupplyM (Either PassCheckFailure UberModule)
@@ -117,16 +173,32 @@ runStepsChecked steps uber0 = runExceptT (foldlM (flip runStep) uber0 steps)
  where
   runStep ∷ Step → UberModule → ExceptT PassCheckFailure SupplyM UberModule
   runStep = \case
-    RunPass p → checkedPass p
-    RunFixpoint _name passes →
-      fixpointM \uber → foldlM (flip checkedPass) uber (toList passes)
+    RunPass p → fmap fst . checkedPass p
+    RunFixpoint name passes → loop maxFixpointIterations
+     where
+      loop
+        ∷ Natural → UberModule → ExceptT PassCheckFailure SupplyM UberModule
+      loop 0 _uber = throwError (FixpointDivergence name maxFixpointIterations)
+      loop n uber =
+        runRound checkedPass uber (toList passes) >>= \case
+          (uber', Rewritten) → loop (n - 1) uber'
+          (uber', Unmodified) → pure uber'
 
   checkedPass
-    ∷ Pass → UberModule → ExceptT PassCheckFailure SupplyM UberModule
+    ∷ Pass
+    → UberModule
+    → ExceptT PassCheckFailure SupplyM (UberModule, WasRewritten)
   checkedPass Pass {passName, passRun, passRequires, passEnsures} uber = do
     check Before passRequires uber
-    uber' ← lift (passRun uber)
-    uber' <$ check After passEnsures uber'
+    result@(uber', rewritten) ← lift (passRun uber)
+    check After passEnsures uber'
+    -- The under-reporting direction: 'Unmodified' must mean
+    -- structurally identical output. This is the one surviving use of
+    -- whole-module equality, paid only in the checked runner and only
+    -- when a pass claims 'Unmodified'.
+    when (rewritten == Unmodified && uber' /= uber) $
+      throwError (PassUnreportedChange passName)
+    pure result
    where
     check
       ∷ Phase
@@ -159,41 +231,53 @@ runStepsTraced steps uber0 =
   -- at the end.
   runStep ∷ Step → UberModule → StateT [(Text, UberModule)] SupplyM UberModule
   runStep = \case
-    RunPass p → tracedPass (passName p) p
+    RunPass p → fmap fst . tracedPass (passName p) p
     RunFixpoint name passes → loop (1 ∷ Natural)
      where
+      loop
+        ∷ Natural
+        → UberModule
+        → StateT [(Text, UberModule)] SupplyM UberModule
       loop i uber = do
-        uber' ←
-          foldlM
-            ( \u p →
-                tracedPass (name <> "#" <> show i <> "/" <> passName p) p u
-            )
+        (uber', rewritten) ←
+          runRound
+            (\p → tracedPass (name <> "#" <> show i <> "/" <> passName p) p)
             uber
             (toList passes)
-        if uber' == uber then pure uber else loop (i + 1) uber'
+        if rewritten == Rewritten && i < maxFixpointIterations
+          then loop (i + 1) uber'
+          else pure uber'
 
   tracedPass
     ∷ Text
     → Pass
     → UberModule
-    → StateT [(Text, UberModule)] SupplyM UberModule
+    → StateT [(Text, UberModule)] SupplyM (UberModule, WasRewritten)
   tracedPass label p uber = do
-    uber' ← lift (passRun p uber)
-    uber' <$ modify ((label, uber') :)
+    result@(uber', _rewritten) ← lift (passRun p uber)
+    result <$ modify ((label, uber') :)
+
+-- | One fixpoint round: every pass once, 'WasRewritten' accumulated.
+runRound
+  ∷ Monad m
+  ⇒ (Pass → UberModule → m (UberModule, WasRewritten))
+  → UberModule
+  → [Pass]
+  → m (UberModule, WasRewritten)
+runRound runPass uber0 =
+  foldlM
+    (\(uber, rewritten) p → second (rewritten <>) <$> runPass p uber)
+    (uber0, mempty)
 
 --------------------------------------------------------------------------------
 -- Fixpoints -------------------------------------------------------------------
 
--- | Apply a function until it makes no change (by 'Eq').
+{- | Apply a function until it makes no change (by 'Eq') — the semantic
+reference for what a 'WasRewritten'-driven 'RunFixpoint' computes when
+its passes report precisely; the test suite checks the two against
+each other.
+-}
 idempotently ∷ Eq a ⇒ (a → a) → a → a
 idempotently = fix $ \i f a →
   let a' = f a
    in if a' == a then a else i f a'
-
--- | Monadic 'idempotently'.
-fixpointM ∷ (Monad m, Eq a) ⇒ (a → m a) → a → m a
-fixpointM f = loop
- where
-  loop a = do
-    a' ← f a
-    if a' == a then pure a else loop a'

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -399,7 +399,7 @@ subexpressions go = \case
 
 The honesty contract: a rule must return 'Just' only when it actually
 changed something. The drivers below surface "did any rule fire" as the
-change signal the optimizer fixpoint trusts (issue #144): a rule that
+'WasRewritten' signal the optimizer fixpoint trusts: a rule that
 reports 'Just' with an unchanged result spins the fixpoint until its
 iteration cap, and one that changes something under 'Nothing' stops it
 early — both are caught loudly by the checked pipeline runner
@@ -409,6 +409,25 @@ type RewriteRule ann = RawExp ann → Maybe (RawExp ann)
 
 -- | Effectful 'RewriteRule'.
 type RewriteRuleM m ann = RawExp ann → m (Maybe (RawExp ann))
+
+{- | Did rewriting change anything? The '(<>)' answers "did either":
+'Rewritten' wins, 'Unmodified' is 'mempty'. 'Unmodified' asserts the
+result is structurally identical to the input; 'Rewritten' says it may
+differ.
+-}
+data WasRewritten = Rewritten | Unmodified
+  deriving stock (Show, Eq)
+
+instance Semigroup WasRewritten where
+  Unmodified <> Unmodified = Unmodified
+  _ <> _ = Rewritten
+
+instance Monoid WasRewritten where
+  mempty = Unmodified
+
+-- | 'Rewritten' iff the condition holds.
+rewrittenIf ∷ Bool → WasRewritten
+rewrittenIf b = if b then Rewritten else Unmodified
 
 {- | Sequential composition: apply the second rule to the first rule's
 result (or to the original expression when the first did not fire).
@@ -428,19 +447,19 @@ thenRewrite rewrite1 rewrite2 e =
 the rule sees the node, and the rule is re-applied to its own result
 until it no longer fires ('rewriteMOf' semantics). One pass is
 therefore complete and idempotent — the result contains no node the
-rule still fires on — which is what makes the returned 'Any' a precise
-change flag (issue #144), and what closes the Recurse-escape bug class
-(issue #149) structurally: a node exposed by a collapsing parent has
-already been fully rewritten.
+rule still fires on — which is what makes the returned 'WasRewritten'
+precise, and what closes the Recurse-escape bug class (issue #149)
+structurally: a node exposed by a collapsing parent has already been
+fully rewritten.
 -}
 rewriteExpBottomUpM
-  ∷ Monad m ⇒ RewriteRuleM m ann → RawExp ann → m (RawExp ann, Any)
+  ∷ Monad m ⇒ RewriteRuleM m ann → RawExp ann → m (RawExp ann, WasRewritten)
 rewriteExpBottomUpM rule expr =
   runWriterT $ flip (rewriteMOf subexpressions) expr \e →
-    lift (rule e) >>= traverse \e' → e' <$ tell (Any True)
+    lift (rule e) >>= traverse \e' → e' <$ tell Rewritten
 
 -- | Pure 'rewriteExpBottomUpM'.
-rewriteExpBottomUp ∷ RewriteRule ann → RawExp ann → (RawExp ann, Any)
+rewriteExpBottomUp ∷ RewriteRule ann → RawExp ann → (RawExp ann, WasRewritten)
 rewriteExpBottomUp rule = runIdentity . rewriteExpBottomUpM (pure . rule)
 
 {- | Rewrite top-down: re-apply the rule at the node until it no longer

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -397,8 +397,8 @@ subexpressions go = \case
 {- | A rewrite rule: 'Nothing' when the rule does not apply to the node,
 'Just' the rewritten node when it fired.
 
-The honesty contract: a rule must return 'Just' only when it actually
-changed something. The drivers below surface "did any rule fire" as the
+The contract: a rule must return 'Just' only when it actually changed
+something. The drivers below surface "did any rule fire" as the
 'WasRewritten' signal the optimizer fixpoint trusts: a rule that
 reports 'Just' with an unchanged result spins the fixpoint until its
 iteration cap, and one that changes something under 'Nothing' stops it

--- a/test/Language/PureScript/Backend/IR/DCE/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/DCE/Spec.hs
@@ -28,6 +28,7 @@ import Language.PureScript.Backend.IR.Types
   ( Ann
   , Exp
   , Grouping (..)
+  , WasRewritten (..)
   , abstraction
   , application
   , countFreeRefs
@@ -60,7 +61,9 @@ spec = describe "IR Dead Code Elimination" do
 
   test "doesn't eliminate an exported entry point" do
     optimalModule ← forAll singletonModule
-    optimalModule === eliminateDeadCode optimalModule
+    -- Nothing to drop, and the result must say so (the precision the
+    -- fixpoint oracle relies on).
+    (optimalModule, Unmodified) === eliminateDeadCode optimalModule
 
   test "eliminates unused non-exported binding" do
     expected@UberModule {uberModuleBindings} ← forAll singletonModule
@@ -69,7 +72,7 @@ spec = describe "IR Dead Code Elimination" do
             { uberModuleBindings = topBinding_ "unused" : uberModuleBindings
             }
     annotate . toString $ pShow unoptimized
-    eliminateDeadCode unoptimized === expected
+    eliminateDeadCode unoptimized === (expected, Rewritten)
 
   -- The unit-level twin of the 'dcePass' ensures-contract: on GUC input
   -- (which the pipeline guarantees via the uniquify entry pass), DCE
@@ -80,7 +83,7 @@ spec = describe "IR Dead Code Elimination" do
           emptyUberModule
             { uberModuleExports = [(Name "main", uniquifyNamesInExpr e)]
             }
-        optimized = eliminateDeadCode uber
+        optimized = fst (eliminateDeadCode uber)
     annotateShow optimized
     lintWellScoped optimized === []
     lintUniqueBinders optimized === []
@@ -195,7 +198,7 @@ spec = describe "IR Dead Code Elimination" do
 -- Helpers ---------------------------------------------------------------------
 
 dceExpression ∷ HasCallStack ⇒ Exp → Exp
-dceExpression = applyPassToExpression "dceExpression" eliminateDeadCode
+dceExpression = applyPassToExpression "dceExpression" (fst . eliminateDeadCode)
 
 --------------------------------------------------------------------------------
 -- Fixture ---------------------------------------------------------------------

--- a/test/Language/PureScript/Backend/IR/Pass/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Pass/Spec.hs
@@ -14,6 +14,7 @@ import Language.PureScript.Backend.IR.Pass
   , Phase (..)
   , Step (..)
   , idempotently
+  , maxFixpointIterations
   , renderPassCheckFailure
   , runSteps
   , runStepsChecked
@@ -22,10 +23,12 @@ import Language.PureScript.Backend.IR.Supply (runSupply)
 import Language.PureScript.Backend.IR.Types
   ( Exp
   , RawExp (..)
+  , WasRewritten (..)
   , abstraction
   , literalInt
   , paramNamed
   , refLocal
+  , rewrittenIf
   )
 import Test.Hspec (Spec, SpecWith, describe, it, shouldBe)
 import Test.Hspec.Hedgehog (hedgehog, modifyMaxSuccess)
@@ -42,21 +45,17 @@ spec = describe "IR Pass runner" do
     let breakScope = purePass "break-scope" (constExports unboundRef)
     runSupply (runStepsChecked [RunPass breakScope] (exporting (literalInt 0)))
       `shouldBe` Left
-        PassCheckFailure
-          { failedPassName = "break-scope"
-          , failedPhase = After
-          , failedViolations = pure (UnboundLocal (InExport main) y)
-          }
+        ( PassCheckFailure
+            "break-scope"
+            After
+            (pure (UnboundLocal (InExport main) y))
+        )
 
   it "checked runner reports a violated precondition" do
     let keep = purePass "keep" id
     runSupply (runStepsChecked [RunPass keep] (exporting unboundRef))
       `shouldBe` Left
-        PassCheckFailure
-          { failedPassName = "keep"
-          , failedPhase = Before
-          , failedViolations = pure (UnboundLocal (InExport main) y)
-          }
+        (PassCheckFailure "keep" Before (pure (UnboundLocal (InExport main) y)))
 
   it "checked runner sees intermediate fixpoint iterations" do
     -- First iteration breaks scoping, second heals it and converges: the
@@ -74,11 +73,7 @@ spec = describe "IR Pass runner" do
     -- …the checked runner fails on the intermediate iteration.
     runSupply (runStepsChecked [fixpoint] start)
       `shouldBe` Left
-        PassCheckFailure
-          { failedPassName = "step"
-          , failedPhase = After
-          , failedViolations = pure (UnboundLocal (InExport main) y)
-          }
+        (PassCheckFailure "step" After (pure (UnboundLocal (InExport main) y)))
 
   it "checked runner lints exactly the declared invariants" do
     -- λx. λx. x is well-scoped, but breaks UniqueBinders (shadowing).
@@ -90,7 +85,7 @@ spec = describe "IR Pass runner" do
         produce invariants =
           Pass
             { passName = "produce"
-            , passRun = pure . constExports shadowing
+            , passRun = pure . (,Rewritten) . constExports shadowing
             , passRequires = Set.singleton WellScoped
             , passEnsures = invariants
             }
@@ -106,29 +101,61 @@ spec = describe "IR Pass runner" do
     -- …while promising the GUC invariant dispatches its linter.
     run (Set.fromList [WellScoped, UniqueBinders])
       `shouldBe` Left
-        PassCheckFailure
-          { failedPassName = "produce"
-          , failedPhase = After
-          , failedViolations = pure (DuplicateBinder (InExport main) x)
-          }
+        ( PassCheckFailure
+            "produce"
+            After
+            (pure (DuplicateBinder (InExport main) x))
+        )
 
   it "renders a check failure for the CLI (--lint-ir)" do
     -- The exact wording is user-facing: the CLI dies with this text.
     renderPassCheckFailure
-      PassCheckFailure
-        { failedPassName = "break-scope"
-        , failedPhase = After
-        , failedViolations =
-            UnboundLocal (InExport main) y
+      ( PassCheckFailure
+          "break-scope"
+          After
+          ( UnboundLocal (InExport main) y
               :| [DuplicateBinder (InExport main) y]
-        }
+          )
+      )
       `shouldBe` unlines
         [ "IR invariants violated After optimizer pass break-scope:"
         , "UnboundLocal (InExport (Name \"main\")) (Name \"y\")"
         , "DuplicateBinder (InExport (Name \"main\")) (Name \"y\")"
         ]
+    renderPassCheckFailure (PassUnreportedChange "opt")
+      `shouldBe` "Optimizer pass opt changed the module while reporting no change."
+    renderPassCheckFailure (FixpointDivergence "loop" 100)
+      `shouldBe` "Optimizer fixpoint loop did not converge within 100 iterations."
+
+  it "fixpoint trusts the 'WasRewritten' signal, not structural equality" do
+    -- The pass mutates the module on every run but reports
+    -- 'Unmodified'. The signal-driven fixpoint stops after one round —
+    -- the old Eq-driven one would have kept iterating…
+    let sneaky = reportingPass "sneaky" \uber → (bump uber, Unmodified)
+        start = exporting (literalInt 0)
+    runSupply (runSteps [RunFixpoint "f" (pure sneaky)] start)
+      `shouldBe` exporting (literalInt 1)
+    -- …and the checked runner rejects the misreport, comparing the
+    -- modules a pass claims are identical.
+    runSupply (runStepsChecked [RunFixpoint "f" (pure sneaky)] start)
+      `shouldBe` Left (PassUnreportedChange "sneaky")
+    -- The under-report check guards plain passes too:
+    runSupply (runStepsChecked [RunPass sneaky] start)
+      `shouldBe` Left (PassUnreportedChange "sneaky")
+
+  it "a diverging fixpoint stops at the cap: production accepts, checked fails" do
+    -- Truthfully reports a rewrite every round, forever.
+    let diverging = reportingPass "diverging" \uber → (bump uber, Rewritten)
+        start = exporting (literalInt 0)
+    runSupply (runSteps [RunFixpoint "d" (pure diverging)] start)
+      `shouldBe` exporting (literalInt (fromIntegral maxFixpointIterations))
+    runSupply (runStepsChecked [RunFixpoint "d" (pure diverging)] start)
+      `shouldBe` Left (FixpointDivergence "d" maxFixpointIterations)
 
   prop "fixpoint has 'idempotently' semantics" do
+    -- With a precise signal (the 'purePass' fixture derives it by Eq),
+    -- the signal-driven fixpoint computes exactly what the structural
+    -- Eq-driven reference computes.
     limit ← forAll $ Gen.integral (Range.linear 0 20)
     start ← forAll $ Gen.integral (Range.linear 0 25)
     let f ∷ UberModule → UberModule
@@ -169,11 +196,24 @@ constExports e uber =
         [(name, e) | (name, _prev) ← uberModuleExports uber]
     }
 
+-- | A pure pass with a precise, Eq-derived 'WasRewritten' signal.
 purePass ∷ Text → (UberModule → UberModule) → Pass
-purePass name run =
+purePass name run = reportingPass name \uber →
+  let uber' = run uber in (uber', rewrittenIf (uber' /= uber))
+
+-- | A pure pass reporting whatever signal its function computes.
+reportingPass ∷ Text → (UberModule → (UberModule, WasRewritten)) → Pass
+reportingPass name run =
   Pass
     { passName = name
     , passRun = pure . run
     , passRequires = Set.singleton WellScoped
     , passEnsures = Set.singleton WellScoped
     }
+
+-- | Increment the module's sole exported integer literal.
+bump ∷ UberModule → UberModule
+bump uber = case uberModuleExports uber of
+  [(name, LiteralInt ann n)] →
+    uber {uberModuleExports = [(name, LiteralInt ann (n + 1))]}
+  _ → uber

--- a/test/Language/PureScript/Backend/IR/Types/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Types/Spec.hs
@@ -167,7 +167,7 @@ spec = describe "Types" do
 
     describe "rewriteExpBottomUp" do
       it "reports no change when no rule fires" do
-        -- The honesty contract end-to-end: the result must say
+        -- The 'RewriteRule' contract end-to-end: the result must say
         -- 'Unmodified' for an expression the rule set cannot rewrite
         -- (the optimize fixpoint relies on this to stop).
         let e = abstraction (paramNamed x) (eq (refLocal x) (literalInt 1))

--- a/test/Language/PureScript/Backend/IR/Types/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Types/Spec.hs
@@ -15,6 +15,7 @@ import Language.PureScript.Backend.IR.Types
   , Grouping (..)
   , RawExp (..)
   , RewriteRule
+  , WasRewritten (..)
   , abstraction
   , alphaEq
   , application
@@ -166,17 +167,17 @@ spec = describe "Types" do
 
     describe "rewriteExpBottomUp" do
       it "reports no change when no rule fires" do
-        -- The honesty contract end-to-end: the flag must be False on an
-        -- expression the rule set cannot rewrite (issue #144 relies on
-        -- this to stop the optimize fixpoint).
+        -- The honesty contract end-to-end: the result must say
+        -- 'Unmodified' for an expression the rule set cannot rewrite
+        -- (the optimize fixpoint relies on this to stop).
         let e = abstraction (paramNamed x) (eq (refLocal x) (literalInt 1))
-        rewriteExpBottomUp foldEq e `shouldBe` (e, Any False)
+        rewriteExpBottomUp foldEq e `shouldBe` (e, Unmodified)
 
       it "folds children before their parent sees them" do
         -- The outer Eq only matches because the inner Eq was folded
         -- first: bottom-up order, one pass.
         let e = eq (eq (literalInt 1) (literalInt 1)) (refLocal x)
-        rewriteExpBottomUp foldEq e `shouldBe` (refLocal x, Any True)
+        rewriteExpBottomUp foldEq e `shouldBe` (refLocal x, Rewritten)
 
       it "one pass is complete: a second pass reports no change" do
         let e =
@@ -184,9 +185,9 @@ spec = describe "Types" do
                 eq
                   (eq (literalInt 1) (literalInt 2))
                   (eq (literalInt 3) (literalInt 3))
-            (once, Any changed) = rewriteExpBottomUp foldEq e
-        changed `shouldBe` True
-        rewriteExpBottomUp foldEq once `shouldBe` (once, Any False)
+            (once, rewritten) = rewriteExpBottomUp foldEq e
+        rewritten `shouldBe` Rewritten
+        rewriteExpBottomUp foldEq once `shouldBe` (once, Unmodified)
 
     describe "rewriteExpTopDownM" do
       let topDown ∷ RewriteRule Ann → Exp → Exp


### PR DESCRIPTION
Closes #144. Builds on the bottom-up driver (#155, merged).

`fixpointM` detected convergence by deep `Eq` on the whole `UberModule` every round. Now that the rewrite driver reports precisely whether it rewrote anything, the passes can just say so:

- Per review feedback, the signal is a dedicated domain type instead of `Any`: `data WasRewritten = Rewritten | Unmodified` with a "Rewritten wins" Semigroup, so use sites read `tell Rewritten` and signatures read `SupplyM (Exp, WasRewritten)`.
- `passRun` returns `(UberModule, WasRewritten)`. `Unmodified` asserts the output is structurally identical to the input; `Rewritten` says it may differ. The fixpoint members report precisely: optimize aggregates the driver signal across all expressions plus every top-level inlining, and dce combines its driver signal with top-level binding/foreign drops and `ForeignImport` name-list pruning. Run-once passes report a conservative `Rewritten`, which nothing consumes.
- A fixpoint stops on the first round that reports `Unmodified`, bounded by `maxFixpointIterations` (100). No runner compares whole modules anymore.
- The two failure directions land in different runners. Under-reporting (changed but said it didn't) would silently under-optimize, so the checked runner (the whole test suite and `--lint-ir`) compares the one module a pass claims unchanged against its input and fails with `PassUnreportedChange`. Over-reporting (said it changed but didn't) would spin the loop, so at the cap the checked runner fails with `FixpointDivergence` while the production runner accepts the module reached so far. Every pass is semantics-preserving, so an early stop costs optimization, never correctness, and production can no longer hang.
- `idempotently` stays as the semantic reference: a property test checks that the signal-driven fixpoint computes exactly what the Eq-driven reference computes when the signal is precise. `fixpointM` is gone.

Since the golden harness runs the checked pipeline, every fixpoint round of every golden test now asserts the signal's precision for free. No golden moved: the fixpoint stops at exactly the round the Eq oracle did, drawing the same supply names.

To be honest about the payoff: the raw perf win is modest, since `Eq` short-circuits on the first difference and only pays a full traversal on the final converged round. The real gains are a precise per-pass signal, loud failures when it misreports, and the per-pass delta that #142/#143 can build on.
