### PR TITLE
fix: classify data types independently of constructor order (#168)

### DIFF
--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -7,7 +7,6 @@ module Language.PureScript.Backend.IR
 import Control.Monad.Error.Class (MonadError (throwError))
 import Control.Monad.Writer.Class (MonadWriter (..))
 import Data.IntCast (intCast)
-import Data.List qualified as List
 import Data.List.NonEmpty ((<|))
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Lazy qualified as Map
@@ -177,21 +176,24 @@ mkForeigns = do
 collectDataDeclarations
   ∷ Map ModuleName (Cfn.Module Cfn.Ann)
   → Map (ModuleName, TyName) (AlgebraicType, Map CtorName [FieldName])
-collectDataDeclarations cfnModules = Map.unions do
-  Map.toList cfnModules <&> \(modName, cfnModule) →
-    Map.fromList
-      [ ((modName, ty), (algebraicType, Map.fromList (snd <$> ctors)))
-      | ctors ←
-          List.groupBy
-            ((==) `on` fst)
-            [ (mkTyName tyName, (mkCtorName ctorName, mkFieldName <$> fields))
-            | bind ← Cfn.moduleBindings cfnModule
-            , Cfn.Constructor _ann tyName ctorName fields ← boundExp bind
-            ]
-      , let ty = fst (head (NE.fromList ctors)) -- groupBy never makes an empty group
-      , let algebraicType = if length ctors == 1 then ProductType else SumType
+collectDataDeclarations cfnModules =
+  classify
+    <$> Map.fromListWith
+      (<>)
+      [ ( (modName, mkTyName tyName)
+        , Map.singleton (mkCtorName ctorName) (mkFieldName <$> fields)
+        )
+      | (modName, cfnModule) ← Map.toList cfnModules
+      , bind ← Cfn.moduleBindings cfnModule
+      , Cfn.Constructor _ann tyName ctorName fields ← boundExp bind
       ]
  where
+  -- A type is a product type iff it has exactly one constructor. Grouping the
+  -- constructors by type first makes this independent of the order in which
+  -- they appear in the module bindings.
+  classify ctors =
+    (if Map.size ctors == 1 then ProductType else SumType, ctors)
+
   boundExp ∷ Cfn.Bind a → [Cfn.Expr a]
   boundExp = \case
     Cfn.Rec bindingGroup → snd <$> bindingGroup

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -181,11 +181,17 @@ fromIR foreigns topLevelNames modname ir = case ir of
     Right . (`Lua.varField` Lua.unsafeName ("value" <> show i)) <$> goExp e
   IR.Eq _ann l r →
     Right <$> liftA2 Lua.equalTo (goExp l) (goExp r)
-  IR.Ctor _ann _algebraicTy ctorModName ctorTyName ctorName fieldNames →
+  IR.Ctor _ann algebraicTy ctorModName ctorTyName ctorName fieldNames →
     pure . Right $ foldr wrap value args
    where
     wrap name expr = Lua.functionDef [ParamNamed name] [Lua.return expr]
-    value = Lua.table $ ctorRow : attributes
+    -- Only sum-type constructors need the tag row: the pattern matcher emits a
+    -- ReflectCtor read (the reflectCtor == ctorId test) exclusively for sum
+    -- types, so on a product value the row would never be read.
+    -- See Note [Compiling case expressions to decision trees].
+    value = Lua.table case algebraicTy of
+      IR.SumType → ctorRow : attributes
+      IR.ProductType → attributes
     ctorId = IR.ctorId ctorModName ctorTyName ctorName
     ctorRow = Lua.tableRowKV keyCtor (Lua.String ctorId)
     args = Name.unsafeName . IR.renderFieldName <$> fieldNames

--- a/lib/Language/PureScript/Backend/Lua/Name.hs
+++ b/lib/Language/PureScript/Backend/Lua/Name.hs
@@ -9,7 +9,6 @@ module Language.PureScript.Backend.Lua.Name
   , unsafeName
   , makeSafe
   , specialNameType
-  , specialNameCtor
   , join2
   , reserved
   ) where
@@ -90,9 +89,6 @@ unsafeName n =
 
 specialNameType ∷ Name
 specialNameType = Name "$type"
-
-specialNameCtor ∷ Name
-specialNameCtor = Name "$ctor"
 
 -- See Note [Lua reserved words as foreign export keys] in ...Backend.Lua.Key
 reserved ∷ Set Text

--- a/test/Language/PureScript/Backend/IR/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Spec.hs
@@ -3,8 +3,20 @@
 module Language.PureScript.Backend.IR.Spec where
 
 import Data.List.NonEmpty qualified as NE
-import Language.PureScript.Backend.IR (Context (..), RepM, mkCase, runRepM)
-import Language.PureScript.Backend.IR.Names (Name (..), PropName (..))
+import Data.Map.Strict qualified as Map
+import Language.PureScript.Backend.IR
+  ( Context (..)
+  , RepM
+  , collectDataDeclarations
+  , mkCase
+  , runRepM
+  )
+import Language.PureScript.Backend.IR.Names
+  ( CtorName (..)
+  , Name (..)
+  , PropName (..)
+  , TyName (..)
+  )
 import Language.PureScript.Backend.IR.Types
 import Language.PureScript.CoreFn qualified as Cfn
 import Language.PureScript.Names qualified as PS
@@ -464,6 +476,38 @@ spec = describe "IR representation" do
                         )
                     )
               )
+
+  describe "collectDataDeclarations" do
+    it "classifies data types regardless of constructor order" do
+      let ctor tyName ctorName =
+            Cfn.Constructor
+              ann
+              (PS.ProperName tyName)
+              (PS.ProperName ctorName)
+              []
+          bind ident = Cfn.NonRec ann (PS.Ident ident)
+          -- Constructor C of type U is interleaved between T's two
+          -- constructors, so adjacency-based grouping would split T into
+          -- singleton groups and misclassify it as a product type.
+          cfnMod =
+            cfnModule
+              { Cfn.moduleBindings =
+                  [ bind "A" (ctor "T" "A")
+                  , bind "C" (ctor "U" "C")
+                  , bind "B" (ctor "T" "B")
+                  ]
+              }
+      collectDataDeclarations (Map.singleton (PS.ModuleName "M") cfnMod)
+        `shouldBe` Map.fromList
+          [
+            ( (PS.ModuleName "M", TyName "T")
+            , (SumType, Map.fromList [(CtorName "A", []), (CtorName "B", [])])
+            )
+          ,
+            ( (PS.ModuleName "M", TyName "U")
+            , (ProductType, Map.fromList [(CtorName "C", [])])
+            )
+          ]
 
 --------------------------------------------------------------------------------
 -- Helper functions ------------------------------------------------------------

--- a/test/Language/PureScript/Backend/Lua/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Spec.hs
@@ -25,6 +25,14 @@ spec = describe "Lua.fromUberModule" do
     rendered ← compileExportedExpr absWithIfBody
     rendered `shouldSatisfy` (not . Text.isInfixOf "(function()")
 
+  it "omits the $ctor row for a product-type constructor" do
+    rendered ← compileExportedExpr (ctorExpr IR.ProductType)
+    rendered `shouldSatisfy` (not . Text.isInfixOf "$ctor")
+
+  it "keeps the $ctor row for a sum-type constructor" do
+    rendered ← compileExportedExpr (ctorExpr IR.SumType)
+    rendered `shouldSatisfy` Text.isInfixOf "[\"$ctor\"]"
+
 compileExportedExpr ∷ IR.Exp → IO Text
 compileExportedExpr expr = do
   foreignPath ← Tagged <$> getCurrentDir
@@ -82,3 +90,12 @@ absWithIfBody =
         (IR.Ref IR.noAnn (IR.Local (IR.Name "x")))
         (IR.LiteralInt IR.noAnn 0)
     )
+
+ctorExpr ∷ IR.AlgebraicType → IR.Exp
+ctorExpr algebraicTy =
+  IR.ctor
+    algebraicTy
+    (IR.ModuleName "M")
+    (IR.TyName "T")
+    (IR.CtorName "C")
+    [IR.FieldName "value0"]

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -28,7 +28,7 @@ M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
   bindE = function(a) return function(f) return function() return f(a())() end end end
 }
-M.Type_Proxy_Proxy = { ["$ctor"] = "Type.Proxy∷Proxy.Proxy" }
+M.Type_Proxy_Proxy = {}
 M.Data_HeytingAlgebra_heytingAlgebraBoolean = {
   ff = false,
   tt = true,
@@ -151,7 +151,7 @@ M.Golden_BugListGenericEq_Test_genericList = {
     if "Golden.BugListGenericEq.Test∷List.Nil" == x0["$ctor"] then
       return (function(value0)
         return { ["$ctor"] = "Data.Generic.Rep∷Sum.Inl", value0 = value0 }
-      end)({ ["$ctor"] = "Data.Generic.Rep∷NoArguments.NoArguments" })
+      end)({})
     else
       if "Golden.BugListGenericEq.Test∷List.Cons" == x0["$ctor"] then
         return (function(value0)

--- a/test/ps/output/Golden.DataDeclarations.Test1/golden.lua
+++ b/test/ps/output/Golden.DataDeclarations.Test1/golden.lua
@@ -1,23 +1,13 @@
 return {
-  U = { ["$ctor"] = "Golden.DataDeclarations.Test1∷Unit.U" },
+  U = {},
   P3 = function(value0)
     return function(value1)
       return function(value2)
-        return {
-          ["$ctor"] = "Golden.DataDeclarations.Test1∷TProduct.P3",
-          value0 = value0,
-          value1 = value1,
-          value2 = value2
-        }
+        return { value0 = value0, value1 = value1, value2 = value2 }
       end
     end
   end,
-  PF = function(value0)
-    return {
-      ["$ctor"] = "Golden.DataDeclarations.Test1∷TProductWithFields.PF",
-      value0 = value0
-    }
-  end,
+  PF = function(value0) return { value0 = value0 } end,
   S0 = { ["$ctor"] = "Golden.DataDeclarations.Test1∷TSum.S0" },
   S1 = function(value0)
     return {
@@ -41,7 +31,5 @@ return {
       value0 = value0
     }
   end,
-  CtorSameName = {
-    ["$ctor"] = "Golden.DataDeclarations.Test1∷TySameName.CtorSameName"
-  }
+  CtorSameName = {}
 }

--- a/test/ps/output/Golden.DataDeclarations.Test2/golden.lua
+++ b/test/ps/output/Golden.DataDeclarations.Test2/golden.lua
@@ -1,6 +1,4 @@
 return {
-  CtorSameName = {
-    ["$ctor"] = "Golden.DataDeclarations.Test2∷TySameName.CtorSameName"
-  },
+  CtorSameName = {},
   test = function() return function() return true end end
 }

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -28,7 +28,7 @@ M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
   bindE = function(a) return function(f) return function() return f(a())() end end end
 }
-M.Type_Proxy_Proxy = { ["$ctor"] = "Type.Proxy∷Proxy.Proxy" }
+M.Type_Proxy_Proxy = {}
 M.Data_HeytingAlgebra_heytingAlgebraBoolean = {
   ff = false,
   tt = true,
@@ -76,9 +76,7 @@ end
 M.Data_Generic_Rep_Inr = function(value0)
   return { ["$ctor"] = "Data.Generic.Rep∷Sum.Inr", value0 = value0 }
 end
-M.Data_Generic_Rep_NoArguments = {
-  ["$ctor"] = "Data.Generic.Rep∷NoArguments.NoArguments"
-}
+M.Data_Generic_Rep_NoArguments = {}
 M.Data_Eq_Generic_genericEqArgument = function(dictEq)
   return {
     genericEqPrime = function(v)

--- a/test/ps/output/Golden.LongStackBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongStackBind.Test/golden.lua
@@ -76,13 +76,7 @@ M.Data_Either_Right = function(value0)
   return { ["$ctor"] = "Data.Either∷Either.Right", value0 = value0 }
 end
 M.Data_Tuple_Tuple = function(value0)
-  return function(value1)
-    return {
-      ["$ctor"] = "Data.Tuple∷Tuple.Tuple",
-      value0 = value0,
-      value1 = value1
-    }
-  end
+  return function(value1) return { value0 = value0, value1 = value1 } end
 end
 M.Data_Identity_functorIdentity = {
   map = function(f) return function(m) return f(m) end end

--- a/test/ps/output/Golden.LongStateBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongStateBind.Test/golden.lua
@@ -5,13 +5,7 @@ M.Data_Semiring_foreign = {
 M.Control_Applicative_pure = function(dict) return dict.pure end
 M.Control_Bind_bind = function(dict) return dict.bind end
 M.Data_Tuple_Tuple = function(value0)
-  return function(value1)
-    return {
-      ["$ctor"] = "Data.Tuple∷Tuple.Tuple",
-      value0 = value0,
-      value1 = value1
-    }
-  end
+  return function(value1) return { value0 = value0, value1 = value1 } end
 end
 M.Data_Identity_applyIdentity = {
   apply = function(v) return function(v1) return v(v1) end end,

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.lua
@@ -27,13 +27,7 @@ M.Data_Monoid_monoidArray = {
   Semigroup0 = function() return M.Data_Semigroup_semigroupArray end
 }
 M.Data_Tuple_Tuple = function(value0)
-  return function(value1)
-    return {
-      ["$ctor"] = "Data.Tuple∷Tuple.Tuple",
-      value0 = value0,
-      value1 = value1
-    }
-  end
+  return function(value1) return { value0 = value0, value1 = value1 } end
 end
 M.Data_Identity_applyIdentity = {
   apply = function(v) return function(v1) return v(v1) end end,

--- a/test/ps/output/Golden.PatternMatching.Test1/golden.lua
+++ b/test/ps/output/Golden.PatternMatching.Test1/golden.lua
@@ -52,13 +52,7 @@ return {
     end
   end,
   T = function(value0)
-    return function(value1)
-      return {
-        ["$ctor"] = "Golden.PatternMatching.Test1∷Tuple.T",
-        value0 = value0,
-        value1 = value1
-      }
-    end
+    return function(value1) return { value0 = value0, value1 = value1 } end
   end,
   fst = function(v_S_0) return v_S_0.value0 end,
   snd = function(v_S_3) return v_S_3.value1 end

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -631,13 +631,7 @@ M.Data_String_CodePoints_toCodePointArray = M.Data_String_CodePoints_foreign._to
   end)(function(s_S_11)
     return M.Data_Functor_map(M.Data_Maybe_functorMaybe)(function(v_S_12)
       return (function(value0)
-        return function(value1)
-          return {
-            ["$ctor"] = "Data.Tuple∷Tuple.Tuple",
-            value0 = value0,
-            value1 = value1
-          }
-        end
+        return function(value1) return { value0 = value0, value1 = value1 } end
       end)(v_S_12.head)(v_S_12.tail)
     end)(M.Data_String_CodePoints_uncons(s_S_11))
   end)(s_S_10)


### PR DESCRIPTION
Fixes #168.

## Problem

`collectDataDeclarations` decided whether a data type is a product or a sum by grouping a module's constructors with `List.groupBy`, keyed on the type name. `groupBy` only merges *adjacent* elements, so it silently relied on purs emitting all constructors of one type consecutively in the module bindings. pslua does not control that order (it comes straight from the `decls` array in `corefn.json`) and never checked it.

When a reordering interleaves constructors of different types, a sum type falls apart into singleton groups. Two things then go wrong at once: each singleton is classified as a `ProductType`, and the same-key records collide in `Map.fromList`, so only the last constructor of the type survives.

The damage lands in the pattern matcher. The one live consumer of `AlgebraicType` is `mkClause`, which emits the `reflectCtor == ctorId` tag test for a `SumType` and an unconditional match for a `ProductType`. A sum type misclassified as a product therefore compiles and loads without error, but the first clause always wins: wrong answers, no crash.

## Fix

Group the constructors by `(module, type)` with `Map.fromListWith (<>)` across all modules first, then classify by the size of the merged constructor map (one constructor means a product type, more than one means a sum type). The result no longer depends on the order constructors appear in. For an already-consecutive input the classification is identical, so this half moves no goldens.

## Dead `$ctor` on product values

The second half of the issue: the Lua codegen ignored the `AlgebraicType` of a `Ctor` and wrote a `["$ctor"] = "..."` tag row into *every* constructed table. That row is only ever read by `ReflectCtor`, which `mkClause` emits solely for sum types (a product type has one constructor and needs no tag test). On a product value the row is dead weight allocated on every construction.

The codegen now emits the tag row only for sum-type constructors. Product constructors allocate one fewer field.

### FFI sweep

Since `$ctor` is a runtime table key, dropping it from product values could in principle break hand-written Lua FFI that reads it. It does not: a sweep found zero occurrences of `$ctor` across the 278 `.lua` files under `test/ps/.spago` and the 309 FFI files in the local fork clones (`src/` + `test/`; the hits under `dist/` are generated bundles, not FFI). In this repo the key lives only in `Backend.Lua` (`keyCtor`, written by `Ctor` and read by `ReflectCtor`) and in the golden files. There is no FFI contract on `$ctor`.

## Tests

TDD, red before each fix and green after:

- `collectDataDeclarations` on a module whose constructors are interleaved (`T.A`, `U.C`, `T.B`). Before the fix `T` came back as `(ProductType, {B})` with `A` clobbered; it now comes back as `(SumType, {A, B})`.
- Two codegen pins in `Lua/Spec.hs`: a product-type `Ctor` renders without `$ctor` (red before the fix), and a sum-type `Ctor` still renders `["$ctor"]` (green throughout).

## Golden churn

Structural `golden.lua` files lose the `["$ctor"]` row on product constructors; sum constructors are unchanged. The hand-verified `eval/golden.txt` oracles are untouched, so runtime behaviour is preserved.

## Also

Dropped `specialNameCtor`, a dead exported `Name "$ctor"` constant with no consumer (the live tag key is `keyCtor`).
