### PR TITLE
Keep the projection's annotation when folding a record projection

### DIFF
--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -42,6 +42,7 @@ import Language.PureScript.Backend.IR.Types
   , lets
   , literalBool
   , rewriteExpBottomUpM
+  , setAnn
   , substituteCopyM
   , substituteMoveM
   , thenRewrite
@@ -385,15 +386,23 @@ rule declines.
 
 The discarded fields are never evaluated — the same call DCE makes when
 it drops an unused binding unconditionally.
+
+The folded value takes the projection's own root annotation, not the
+field's: the result occupies the projection's position in the tree. A
+field can hold a foreign accessor annotated @Just Always@ (see
+Note [Foreign bindings structure emitted by the Linker]), and passing
+that annotation along would make whatever binding receives the fold
+unconditionally inlinable, duplicating it at every use site.
 -}
 reduceObjectProp ∷ Applicative m ⇒ RewriteRuleM m Ann
 reduceObjectProp =
   pure . \case
-    ObjectProp _ann (LiteralObject _ props) prop →
-      List.lookup prop props
+    ObjectProp ann (LiteralObject _ props) prop →
+      setAnn ann <$> List.lookup prop props
     ObjectProp ann (ObjectUpdate _ obj patches) prop →
-      Just $
-        fromMaybe (ObjectProp ann obj prop) (List.lookup prop (toList patches))
+      Just case List.lookup prop (toList patches) of
+        Just patched → setAnn ann patched
+        Nothing → ObjectProp ann obj prop
     _ → Nothing
 
 {- Note [Beta reduction and local inlining share an inlining guard]

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -209,6 +209,36 @@ getAnn = \case
   Exception ann _ → ann
   ForeignImport ann _ _ _ → ann
 
+{- | Replace the root annotation, leaving every other node's annotation
+(children, 'Parameter's, 'Let' binder names, 'ForeignImport' names)
+untouched. The symmetric setter to 'getAnn'.
+-}
+setAnn ∷ ann → RawExp ann → RawExp ann
+setAnn ann = \case
+  LiteralInt _ n → LiteralInt ann n
+  LiteralFloat _ n → LiteralFloat ann n
+  LiteralString _ s → LiteralString ann s
+  LiteralChar _ c → LiteralChar ann c
+  LiteralBool _ b → LiteralBool ann b
+  LiteralArray _ es → LiteralArray ann es
+  LiteralObject _ props → LiteralObject ann props
+  Ctor _ algTy modName tyName ctorName fields →
+    Ctor ann algTy modName tyName ctorName fields
+  ReflectCtor _ e → ReflectCtor ann e
+  Eq _ l r → Eq ann l r
+  DataArgumentByIndex _ i e → DataArgumentByIndex ann i e
+  ArrayLength _ e → ArrayLength ann e
+  ArrayIndex _ e i → ArrayIndex ann e i
+  ObjectProp _ e prop → ObjectProp ann e prop
+  ObjectUpdate _ e patches → ObjectUpdate ann e patches
+  Abs _ param body → Abs ann param body
+  App _ f arg → App ann f arg
+  Ref _ qname → Ref ann qname
+  Let _ binds body → Let ann binds body
+  IfThenElse _ cond th el → IfThenElse ann cond th el
+  Exception _ msg → Exception ann msg
+  ForeignImport _ modName path names → ForeignImport ann modName path names
+
 isLiteral ∷ RawExp ann → Bool
 isLiteral = (||) <$> isNonRecursiveLiteral <*> isRecursiveLiteral
 

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -4,7 +4,7 @@ import Data.Map qualified as Map
 import Hedgehog (PropertyT, annotateShow, diff, forAll, (===))
 import Hedgehog.Gen qualified as Gen
 import Language.PureScript.Backend.IR.Gen qualified as Gen
-import Language.PureScript.Backend.IR.Inliner (Annotation (Never))
+import Language.PureScript.Backend.IR.Inliner (Annotation (Always, Never))
 import Language.PureScript.Backend.IR.Linker (LinkMode (..))
 import Language.PureScript.Backend.IR.Linker qualified as Linker
 import Language.PureScript.Backend.IR.Linter
@@ -35,6 +35,7 @@ import Language.PureScript.Backend.IR.Types
   , application
   , countFreeRef
   , eq
+  , getAnn
   , ifThenElse
   , isLiteral
   , lets
@@ -183,6 +184,60 @@ spec = describe "IR Optimizer" do
               )
               foo
       optimizedExpression original `shouldBe` literalInt 1
+
+    -- A record field can hold an expression whose root annotation is
+    -- `Just Always` — the shape the Linker gives foreign accessors (see
+    -- Note [Foreign bindings structure emitted by the Linker]). The fold
+    -- must not hand that annotation to its result: the result occupies
+    -- the projection's position, so it carries the projection's
+    -- annotation.
+    let dictModule = moduleNameFromString "Dict"
+        accessor =
+          ObjectProp
+            (Just Always)
+            (refImported dictModule (Name "foreign"))
+            foo
+
+    it "does not leak the field's annotation out of a record literal" do
+      let original = objectProp (literalObject [(foo, accessor)]) foo
+      getAnn (optimizedExpression original) `shouldBe` Nothing
+
+    it "does not leak the patch's annotation out of a record update" do
+      let original =
+            objectProp
+              (objectUpdate (refLocal (Name "r")) ((foo, accessor) :| []))
+              foo
+      getAnn (optimizedExpression original) `shouldBe` Nothing
+
+    it "keeps the projection's own annotation on the folded value" do
+      let original =
+            ObjectProp (Just Never) (literalObject [(foo, accessor)]) foo
+      getAnn (optimizedExpression original) `shouldBe` Just Never
+
+    -- The end-to-end manifestation: a leaked `Just Always` makes an
+    -- unrelated top-level binding unconditionally inlinable, so it gets
+    -- duplicated into every use site and dropped from the bindings.
+    test "keeps a binding whose RHS folds to an annotated field" do
+      let mainModule = moduleNameFromString "Main"
+          addExp = objectProp (literalObject [(foo, accessor)]) foo
+          original =
+            Linker.UberModule
+              { uberModuleForeigns = []
+              , uberModuleBindings =
+                  [Standalone (QName mainModule (Name "add"), addExp)]
+              , uberModuleExports =
+                  [ (Name "main1", refImported mainModule (Name "add"))
+                  , (Name "main2", refImported mainModule (Name "add"))
+                  ]
+              }
+          optimized = optimizedUberModule original
+          addKept =
+            [ qn
+            | Standalone (qn, _) ← Linker.uberModuleBindings optimized
+            , qn == QName mainModule (Name "add")
+            ]
+      annotateShow optimized
+      addKept === [QName mainModule (Name "add")]
 
   describe "inlines expressions" do
     test "inlines literals" do


### PR DESCRIPTION
Fixes #169.

## The leak

`reduceObjectProp` folded `{ foo: v }.foo` to `v` verbatim, root annotation included. The Linker marks exactly one shape with `Just Always`: a foreign accessor alias, `ObjectProp (Just Always) (Ref foreign) (PropName name)` (see Note [Foreign bindings structure emitted by the Linker]). The leak takes three hops: the inliner copies such an accessor into a record literal's field (a typeclass dictionary), something projects that field back out, and the fold hands the field's `Just Always` to the result. That annotation then becomes the root annotation of whatever binding received the fold, so `isInlinableExpr` passes unconditionally: the binding gets duplicated at every use site and dropped from the uber-module bindings, regardless of its use count.

## The fix

The fold result now carries the projection node's own annotation. This needed a new `setAnn` in `IR.Types` (the symmetric setter to `getAnn`; nothing on main could replace a root annotation without touching the rest of the tree), applied on both the `LiteralObject` and `ObjectUpdate` paths.

Why the projection's annotation and not a plain reset to `noAnn`: the rewrite result occupies the projection's position in the tree, and the fall-through `ObjectUpdate` branch already keeps `ann`. A reset would also silently swallow an explicit user `@inline` pragma placed on the projection. A test pins this choice: a field annotated `Just Always` projected by a node annotated `Just Never` folds to a `Just Never` result, which distinguishes the fix both from the bug (`Just Always`) and from the reset variant (`Nothing`).

## Tests, demonstrated red first

Three rule-level tests (leak out of a record literal, leak out of an update patch, the semantics pin above) and one UberModule-level test: a binding referenced twice whose RHS folds to an Always-annotated field must survive `optimizedUberModule`. All four failed before the fix (the first two returned `Just Always`) and pass after it.

## Goldens

No golden changed. The issue predicted that `Golden.TailRecM2Shadow.Test` would get its shared `add` binding back, but on current main that chain no longer routes the leaked annotation through a shared binding: optimizer changes merged since the issue was filed reshaped it. I verified this directly by running the golden on a pre-fix build; its output is identical to the fixed build's. The leak is latent on the committed test programs, which is why the regression tests pin it at the rule and pipeline level instead. The `eval/golden.txt` oracles are untouched.

## Relations

Related to #171, which concerns the same Linker `Just Always` annotation but a different interaction (the bare `Ref` alias), and stays open.
