### PR TITLE
Parse foreign Lua files with the compiler's own Lua 5.1 parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ The test suite includes:
 - **Golden tests**: Compiles PureScript test modules from `test/ps/src/Golden/*/Test.purs` to Lua and compares against golden files
 - **Evaluation tests**: Runs generated Lua code and verifies output
 - **Luacheck tests**: Validates generated Lua code syntax
+- **Differential tests**: Anchors the Lua printer/parser pair to the reference
+  implementation (`Differential.Spec` via `Test.Lua`): `luac -p` must accept
+  everything the printer emits, and a semantic differential evaluates the
+  printer's precedence/associativity against the `lua` interpreter itself
 
 ### Testing PureScript Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,12 +223,15 @@ PureScript Source → CoreFn → IR → Lua → Optimized Lua
 - `IR.Query`: Queries over IR expressions
 
 **Lua Backend** (`Language.PureScript.Backend.Lua.*`):
-- `Lua.Types`: Lua AST types (`Chunk`, `Statement`, `Exp`)
+- `Lua.Types`: Lua AST types (`Chunk`, `Statement`, `Exp`), annotated with
+  `Comments`
 - `Lua.Name`: Safe Lua identifier generation
+- `Lua.Parser`: Full Lua 5.1 parser producing the Lua AST (used for FFI files
+  and runtime fixtures; preserves comments in annotation slots)
 - `Lua.Printer`: Pretty-printing Lua code
 - `Lua.Optimizer`: Lua-level optimizations
-- `Lua.DCE`: Lua-specific DCE
-- `Lua.Linker.Foreign`: FFI support for Lua foreign modules
+- `Lua.Linker.Foreign`: FFI support for Lua foreign modules (file resolution +
+  foreign-module shape on top of `Lua.Parser`)
 - `Lua.Fixture`: Runtime support code injected into output
 - `Lua.Key`, `Lua.Traversal`: Table keys and AST traversal helpers
 

--- a/bench/goldens/fnew_Bench.ArrayFoldl.txt
+++ b/bench/goldens/fnew_Bench.ArrayFoldl.txt
@@ -10,10 +10,10 @@ function-body FNEW sites:
   Bench.ArrayFoldl.lua:13
   Bench.ArrayFoldl.lua:24
   Bench.ArrayFoldl.lua:23
-  Bench.ArrayFoldl.lua:28
-  Bench.ArrayFoldl.lua:28
-  Bench.ArrayFoldl.lua:54
-  Bench.ArrayFoldl.lua:53
+  Bench.ArrayFoldl.lua:29
+  Bench.ArrayFoldl.lua:29
   Bench.ArrayFoldl.lua:52
-  Bench.ArrayFoldl.lua:63
-  Bench.ArrayFoldl.lua:62
+  Bench.ArrayFoldl.lua:51
+  Bench.ArrayFoldl.lua:50
+  Bench.ArrayFoldl.lua:61
+  Bench.ArrayFoldl.lua:60

--- a/bench/goldens/fnew_Bench.BindChain.txt
+++ b/bench/goldens/fnew_Bench.BindChain.txt
@@ -6,6 +6,6 @@ total FNEW: 8
 prototypes: 9
 function-body FNEW sites:
   Bench.BindChain.lua:3
-  Bench.BindChain.lua:19
-  Bench.BindChain.lua:27
-  Bench.BindChain.lua:26
+  Bench.BindChain.lua:17
+  Bench.BindChain.lua:25
+  Bench.BindChain.lua:24

--- a/bench/goldens/trace_array_foldl.txt
+++ b/bench/goldens/trace_array_foldl.txt
@@ -3,14 +3,14 @@ runtime: LuaJIT 2.1.1741730670
 workload: n=5000000 reps=2 result=12500002500000
 aborts (distinct site -- reason):
   Bench.ArrayFoldl.lua:3 -- NYI: bytecode FNEW
-  Bench.ArrayFoldl.lua:62 -- NYI: bytecode FNEW
+  Bench.ArrayFoldl.lua:60 -- NYI: bytecode FNEW
 bytecode end state (J*=compiled, I*=blacklisted):
   Bench.ArrayFoldl.lua:21 IFORL
   Bench.ArrayFoldl.lua:3 IFUNCF
   Bench.ArrayFoldl.lua:3 JFUNCF
-  Bench.ArrayFoldl.lua:35 JLOOP
-  Bench.ArrayFoldl.lua:59 IFUNCF
-  Bench.ArrayFoldl.lua:60 IFUNCF
+  Bench.ArrayFoldl.lua:37 JLOOP
+  Bench.ArrayFoldl.lua:57 IFUNCF
+  Bench.ArrayFoldl.lua:58 IFUNCF
   array_foldl.lua:13 JFORI
   array_foldl.lua:13 JFORL
   array_foldl.lua:17 JFORI

--- a/bench/goldens/trace_bind_chain.txt
+++ b/bench/goldens/trace_bind_chain.txt
@@ -2,12 +2,12 @@ spec: bind_chain
 runtime: LuaJIT 2.1.1741730670
 workload: n=1000000 reps=2 result=3000000
 aborts (distinct site -- reason):
-  Bench.BindChain.lua:19 -- NYI: bytecode FNEW
+  Bench.BindChain.lua:17 -- NYI: bytecode FNEW
   Bench.BindChain.lua:3 -- NYI: bytecode FNEW
 bytecode end state (J*=compiled, I*=blacklisted):
+  Bench.BindChain.lua:20 IFUNCF
+  Bench.BindChain.lua:21 IFUNCF
   Bench.BindChain.lua:22 IFUNCF
-  Bench.BindChain.lua:23 IFUNCF
-  Bench.BindChain.lua:24 IFUNCF
   Bench.BindChain.lua:3 IFUNCF
   Bench.BindChain.lua:3 JFUNCF
   Bench.BindChain.lua:5 JFUNCF

--- a/changelog.d/20260707_130000_unisay_foreign_lua_parser.md
+++ b/changelog.d/20260707_130000_unisay_foreign_lua_parser.md
@@ -1,0 +1,39 @@
+### Changed
+
+- Foreign `.lua` files are now read by the compiler's own Lua 5.1 parser
+  (megaparsec, `Language.PureScript.Backend.Lua.Parser`) instead of the lexical
+  splitter that extracted export values as opaque text blobs by counting
+  balanced parentheses. Export values and header statements land in the real
+  Lua AST, so Lua-level optimizations no longer stop at a foreign boundary, and
+  a syntax error anywhere in an FFI file is a compile-time error rather than a
+  luacheck/runtime one. The FFI format contract is relaxed accordingly: export
+  values no longer need to be wrapped in parentheses, and comments — which are
+  preserved into the generated output via AST annotation slots — may appear
+  anywhere, including between export fields (#173).
+
+- The FFI parser matches the reference implementation's rejections: an
+  argument-list `(` on a different line than its callee is "ambiguous syntax
+  (function call x new statement)" exactly as under `luac` (terminate the
+  previous statement with `;` or keep the `(` on the callee's line), and `...`
+  outside a vararg function is an error. Syntactic nesting is capped at 500
+  levels — far beyond real FFI, the cap only turns adversarially nested input
+  into a clean parse error instead of a compiler stack overflow (#173).
+
+- The Lua AST covers the full Lua 5.1 statement/expression grammar (loops,
+  `local function`, multiple assignment, method calls, varargs, array-part
+  table rows, multi-value `return`). The printer renders nested
+  `if`/`else`-of-`if` chains as `elseif`, which also compacts generated
+  pattern-matching code; runtime fixtures (`PSLUA_runtime_lazy`,
+  `PSLUA_object_update`) are parsed into the AST instead of being emitted as
+  verbatim text. Generated-code semantics are unchanged (eval goldens are
+  untouched).
+
+### Fixed
+
+- Two printer correctness gaps surfaced by the new `parse . print ≡ id`
+  round-trip property (checked over generated chunks, and — parseability-wise
+  — over every golden module): a negative numeric literal now carries unary
+  precedence, so `(-2) ^ 2` no longer prints as `-2 ^ 2` (which Lua reads as
+  `-(2 ^ 2)`), and a statement whose printed form starts with `(` is now
+  separated from the preceding statement with `;`, avoiding Lua 5.1's
+  "ambiguous syntax" fusion with a preceding expression.

--- a/docs/QUIRKS.md
+++ b/docs/QUIRKS.md
@@ -55,27 +55,35 @@ Notes that bite in practice:
 
 ## Writing FFI: the foreign module shape
 
-A foreign `.lua` file is split into a **header** and an **exports table**:
+A foreign `.lua` file is an ordinary Lua 5.1 module: an optional **header** of
+shared helpers followed by a single `return` of an **exports table**. The
+compiler parses the whole file with its own Lua 5.1 parser, so a syntax error
+anywhere in the file is a compile-time error.
 
-- Everything **before the first line that starts with `return` at column 0** is
-  a header of shared top-level `local` helpers, in scope for the exported
-  values. `return`s *inside* header functions must be indented (only the
-  exports `return` sits at column 0).
-- The exports are a single returned table of fields. **Each export value must be
-  wrapped in parentheses** — `key = (<lua expression>)`. The FFI parser requires
-  the `(...)`; a bare `key = function … end` will not parse.
-- **Do not put `--` comments between table fields** — the parser does not accept
-  them there. Put comments inside function bodies or in the header.
+- The header is any sequence of Lua statements (typically `local` helpers), in
+  scope for the exported values. Lua's own grammar guarantees the exports
+  `return` is the last top-level statement.
+- The exports are a single returned table of fields. Each field must be keyed
+  by an identifier (`key = <lua expression>`) or, for an export named after a
+  Lua keyword, by a bracketed string (`["if"] = …`). Values need no special
+  wrapping.
+- Comments are allowed anywhere, including between table fields, and are
+  preserved in the generated output.
+- Lua 5.1's "ambiguous syntax" rule applies, as it does under `luac`: a line
+  that starts with `(` right after an expression is rejected as an ambiguous
+  function call — end the previous statement with `;` or keep the `(` on the
+  same line as the callee.
 
 ```lua
--- header: shared helpers (this comment is fine — it's in the header)
+-- header: shared helpers
 local function helper(x)
-  return x + 1   -- indented: ok
+  return x + 1
 end
 
 return {
-  foo = (function(a) return helper(a) end),
-  bar = (function(a) return function(b) return a + b end end),
+  foo = function(a) return helper(a) end,
+  -- comments between fields are fine
+  bar = function(a) return function(b) return a + b end end,
 }
 ```
 

--- a/docs/QUIRKS.md
+++ b/docs/QUIRKS.md
@@ -73,6 +73,10 @@ anywhere in the file is a compile-time error.
   that starts with `(` right after an expression is rejected as an ambiguous
   function call — end the previous statement with `;` or keep the `(` on the
   same line as the callee.
+- Top-level `...` is rejected: the file is embedded into a function scope in
+  the generated output, so chunk varargs (e.g. the `local name = ...`
+  module-name idiom) cannot work there. `...` inside the file's own vararg
+  functions is fine.
 
 ```lua
 -- header: shared helpers

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -106,7 +106,7 @@ fromUberModule foreigns needsRuntimeLazy appOrModule uber = (`evalStateT` 0) do
 
     pure
       ( DList.fromList foreignBindings <> bindings
-      , Lua.Return (Lua.ann returnExp)
+      , Lua.Return [Lua.ann returnExp]
       )
 
   pure . mconcat $
@@ -257,12 +257,11 @@ fromIR foreigns topLevelNames modname ir = case ir of
         IR.RecursiveGroup grp → do
           let binds =
                 toList grp <&> \(_ann, fromName → name, _) →
-                  Lua.Local
+                  Lua.local0
                     ( if Set.member (qualifyName modname name) topLevelNames
                         then qualifyName modname name
                         else name
                     )
-                    Nothing
           assignments ← forM (toList grp) \(_ann, fromName → name, expr) →
             goExp expr
               <&> Lua.assign
@@ -288,23 +287,33 @@ fromIR foreigns topLevelNames modname ir = case ir of
   IR.ForeignImport _ann _moduleName path annotatedNames → do
     let foreignNames = fromName <<$>> annotatedNames
     -- See Note [Foreign module source format] in ...Lua.Linker.Foreign
-    Foreign.Source {header, exports} ←
+    Foreign.Source {header, returnComments, exports} ←
       Oops.hoistEither =<< liftIO do
         left LinkerErrorForeign
           <$> Foreign.parseForeignSource (untag foreigns) path
-    let foreignExports ∷ Lua.Exp =
-          Lua.table
-            [ Lua.tableRowNV name (Lua.ForeignSourceExp src)
-            | (key, src) ← toList exports
-            , -- See Note [Lua reserved words as foreign export keys]
-            -- Export tables can contain Lua-reserved words as keys, for
-            -- example `{ ["for"] = 42 }`; toSafeName mangles them.
-            let name = Key.toSafeName key
-            , name `elem` fmap snd foreignNames
-            ]
+    let keptRows =
+          [ (comments, Lua.TableRowNV name (Lua.ann value))
+          | (key, (comments, value)) ← toList exports
+          , -- See Note [Lua reserved words as foreign export keys]
+          -- Export tables can contain Lua-reserved words as keys, for
+          -- example `{ ["for"] = 42 }`; toSafeName mangles them.
+          let name = Key.toSafeName key
+          , name `elem` fmap snd foreignNames
+          ]
+        -- Comments preceding the exports return (e.g. the module-level
+        -- commentary of a header-less FFI file) stay with the first kept row.
+        foreignExports = Lua.TableCtor case keptRows of
+          (comments, row) : rest → (returnComments <> comments, row) : rest
+          [] → []
     pure case header of
-      Nothing → Right foreignExports
-      Just fh → Left $ Lua.ForeignSourceStat fh : [Lua.return foreignExports]
+      [] → Right foreignExports
+      stats →
+        -- The parsed header statements keep their comment annotations, so
+        -- they are embedded directly rather than re-annotated via smart
+        -- constructors.
+        Right . Lua.FunctionCall (Lua.ann (Lua.Function [] scopeBody)) $ []
+       where
+        scopeBody = stats <> [Lua.ann (Lua.Return [Lua.ann foreignExports])]
  where
   go ∷ IR.Exp → LuaM e (Either Lua.Chunk Lua.Exp)
   go = fromIR foreigns topLevelNames modname

--- a/lib/Language/PureScript/Backend/Lua/Fixture.hs
+++ b/lib/Language/PureScript/Backend/Lua/Fixture.hs
@@ -5,7 +5,8 @@ module Language.PureScript.Backend.Lua.Fixture where
 import Data.String.Interpolate (__i)
 import Language.PureScript.Backend.Lua.Name (Name, name, unsafeName)
 import Language.PureScript.Backend.Lua.Name qualified as Name
-import Language.PureScript.Backend.Lua.Types hiding (var)
+import Language.PureScript.Backend.Lua.Parser (unsafeParseStatements)
+import Language.PureScript.Backend.Lua.Types hiding (error, var)
 
 --------------------------------------------------------------------------------
 -- Hard-coded Lua pieces -------------------------------------------------------
@@ -58,7 +59,7 @@ function; the Lua port is curried and omits @moduleName@.
 -}
 runtimeLazy ∷ Statement
 runtimeLazy =
-  ForeignSourceStat
+  fixtureStatement
     [__i|
     local function #{Name.toText runtimeLazyName}(name)
       return function(init)
@@ -87,7 +88,7 @@ objectUpdateName = psluaName [name|object_update|]
 
 objectUpdate ∷ Statement
 objectUpdate =
-  ForeignSourceStat
+  fixtureStatement
     [__i|
     local function #{Name.toText objectUpdateName}(o, patches)
       local o_copy = {}
@@ -102,3 +103,17 @@ objectUpdate =
       return o_copy
     end
     |]
+
+{- | The runtime fixtures above are written as Lua source for readability and
+parsed into the AST once, at first use (each fixture is a single statement).
+A syntax error in a fixture is a compiler bug, hence the unsafe parse.
+-}
+fixtureStatement ∷ HasCallStack ⇒ Text → Statement
+fixtureStatement src = case unsafeParseStatements src of
+  [statement] → statement
+  statements →
+    error . unwords $
+      [ "Language.PureScript.Backend.Lua.Fixture.fixtureStatement:"
+      , "expected exactly one statement, got"
+      , show (length statements)
+      ]

--- a/lib/Language/PureScript/Backend/Lua/Key.hs
+++ b/lib/Language/PureScript/Backend/Lua/Key.hs
@@ -3,14 +3,11 @@ keys of a Lua table.
 -}
 module Language.PureScript.Backend.Lua.Key
   ( Key (..)
-  , parser
   , toSafeName
   ) where
 
 import Language.PureScript.Backend.Lua.Name (Name)
 import Language.PureScript.Backend.Lua.Name qualified as Name
-import Text.Megaparsec qualified as Mega
-import Text.Megaparsec.Char qualified as M
 
 {- Note [Lua reserved words as foreign export keys]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -23,11 +20,15 @@ keyword read from @["..."]@ syntax.
 The round-trip spans three modules, which must agree on the keyword set:
 
   * 'Language.PureScript.Backend.Lua.Name.reserved' is the reserved-word set the
-    backend escapes against -- the Lua keywords, kept conservative (it also
-    lists later additions like @goto@, harmless on the Lua 5.1 target) -- and
-    'Name.makeSafe' mangles one (e.g. @if@ becomes @_if_@).
-  * 'parser' below reads a bracketed-quoted key as 'KeyReserved' by matching
-    against that set, and a bare identifier as 'KeyName'.
+    backend escapes against -- the Lua 5.1 keywords plus @goto@, which Lua
+    5.2+ and LuaJIT reserve: generated names and parsed FFI names share one
+    output chunk, and mangling @goto@ keeps that chunk loadable there (the
+    compiler's Lua parser rejects it as an identifier for the same reason) --
+    and 'Name.makeSafe' mangles one (e.g. @if@ becomes @_if_@).
+  * 'Language.PureScript.Backend.Lua.Linker.Foreign.interpretForeignModule'
+    reads a parsed export-table row with a bracketed string key as
+    'KeyReserved' by matching against that set, and a bare identifier row as
+    'KeyName'.
   * 'toSafeName' maps a 'Key' back to a safe 'Name': 'KeyName' passes through,
     'KeyReserved' goes through 'Name.makeSafe'. The Lua backend uses the result
     as the export's table field name, so a reserved key reaches the generated
@@ -39,27 +40,3 @@ data Key = KeyName Name | KeyReserved Text
 toSafeName ∷ Key → Name
 toSafeName (KeyName n) = n
 toSafeName (KeyReserved t) = Name.makeSafe t
-
-type Parser = Mega.Parsec Void Text
-
-parser ∷ Parser Key
-parser = (nameParser <|> reservedParser) <* M.space
- where
-  nameParser ∷ Parser Key
-  nameParser = KeyName <$> Name.parser
-
-  reservedParser ∷ Parser Key
-  reservedParser = brackets $ quotes do
-    KeyReserved <$> Mega.choice (M.string <$> toList Name.reserved)
-
-  brackets ∷ Parser a → Parser a
-  brackets = between '[' ']'
-
-  quotes ∷ Parser a → Parser a
-  quotes = between '\"' '\"'
-
-  between ∷ Char → Char → Parser c → Parser c
-  between open close p = char open *> p <* char close
-
-  char ∷ Char → Parser ()
-  char c = M.char c *> M.space

--- a/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
+++ b/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
@@ -17,6 +17,7 @@ import Language.PureScript.Backend.Lua.Types
   , ExpF (..)
   , StatementF (..)
   , TableRowF (..)
+  , VarF (..)
   )
 import Path (Abs, Dir, File, Path, toFilePath, (</>))
 import Path qualified
@@ -44,6 +45,13 @@ the optimizer can see into them.
     — the latter is how an export named after a Lua keyword appears; see
     Note [Lua reserved words as foreign export keys] in
     'Language.PureScript.Backend.Lua.Key'.
+
+  * The chunk's top-level scope must not use @...@ ('chunkScopeUsesVararg').
+    The parser accepts it — a main chunk is a vararg function in Lua — but
+    the file is embedded into a function scope in the generated output
+    (a header becomes an IIFE body, export values land in expression
+    positions), where chunk varargs are either a syntax error or silently
+    rebound. @...@ inside the file's own vararg functions is unaffected.
 
 The result is a 'Source': header statements, per-export annotated
 expressions (a comment written above an export sticks with its value), and
@@ -102,7 +110,9 @@ interpretForeignModule
   ∷ FilePath
   → [Annotated Comments StatementF]
   → Either Error Source
-interpretForeignModule filePath statements =
+interpretForeignModule filePath statements = do
+  when (chunkScopeUsesVararg statements) $
+    Left (ForeignChunkVararg filePath)
   case reverse statements of
     (retComments, Return [(tableComments, TableCtor rows)]) : reversedHeader → do
       exports ←
@@ -130,6 +140,67 @@ interpretForeignModule filePath statements =
           Right (KeyName name, (rowComments <> valueComments, value))
     _ → Left (ForeignUnsupportedExportKey filePath)
 
+{- | Whether @...@ occurs in the chunk's own top-level scope: reachable from
+a statement or expression without entering a nested function, whose varargs
+are its own. Top-level @...@ is legal Lua (the main chunk is vararg) and the
+parser accepts it, but an FFI file is embedded into a function scope in the
+generated output, where chunk varargs cannot mean anything — so the foreign
+/shape/ rejects it (see Note [Foreign module source format]).
+-}
+chunkScopeUsesVararg ∷ [Annotated Comments StatementF] → Bool
+chunkScopeUsesVararg = any statUses
+ where
+  statUses ∷ Annotated Comments StatementF → Bool
+  statUses (_, stat) = case stat of
+    Assign vars vals →
+      any varUses (toList vars) || any expUses (toList vals)
+    Local _names vals → any expUses vals
+    IfThenElse p thenBlock elseBlock →
+      expUses p || any statUses thenBlock || any statUses elseBlock
+    Return es → any expUses es
+    CallStatement e → expUses e
+    Do body → any statUses body
+    While p body → expUses p || any statUses body
+    Repeat body p → any statUses body || expUses p
+    ForNum _name start limit step body →
+      expUses start
+        || expUses limit
+        || any expUses step
+        || any statUses body
+    ForIn _names es body → any expUses (toList es) || any statUses body
+    -- A (local) function's body is its own vararg scope.
+    LocalFunction {} → False
+    Break → False
+
+  expUses ∷ Annotated Comments ExpF → Bool
+  expUses (_, e) = case e of
+    Vararg → True
+    Nil → False
+    Boolean _ → False
+    Integer _ → False
+    Float _ → False
+    String _ → False
+    Function _params _body → False
+    TableCtor rows → any rowUses rows
+    UnOp _op a → expUses a
+    BinOp _op l r → expUses l || expUses r
+    Var v → varUses v
+    FunctionCall f args → expUses f || any expUses args
+    MethodCall o _name args → expUses o || any expUses args
+    Paren a → expUses a
+
+  varUses ∷ Annotated Comments VarF → Bool
+  varUses (_, v) = case v of
+    VarName _ → False
+    VarIndex e i → expUses e || expUses i
+    VarField e _name → expUses e
+
+  rowUses ∷ Annotated Comments TableRowF → Bool
+  rowUses (_, r) = case r of
+    TableRowKV k v → expUses k || expUses v
+    TableRowNV _name v → expUses v
+    TableRowV v → expUses v
+
 --------------------------------------------------------------------------------
 -- Errors ----------------------------------------------------------------------
 
@@ -139,6 +210,7 @@ data Error
   | ForeignNoExportsReturn FilePath
   | ForeignNoExports FilePath
   | ForeignUnsupportedExportKey FilePath
+  | ForeignChunkVararg FilePath
   deriving stock (Eq)
 
 instance Show Error where
@@ -164,3 +236,10 @@ instance Show Error where
       <> " has an export with an unsupported key; every export must be\n"
       <> "keyed by an identifier (name = ...) or a quoted Lua keyword\n"
       <> "([\"if\"] = ...)."
+  show (ForeignChunkVararg filePath) =
+    "Foreign file "
+      <> show filePath
+      <> " uses '...' in its top-level scope. The file is embedded into a\n"
+      <> "function scope in the generated output, so chunk varargs (e.g. the\n"
+      <> "`local name = ...` module-name idiom) cannot mean anything there;\n"
+      <> "'...' works only inside the file's own vararg functions."

--- a/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
+++ b/lib/Language/PureScript/Backend/Lua/Linker/Foreign.hs
@@ -1,84 +1,80 @@
 module Language.PureScript.Backend.Lua.Linker.Foreign
   ( Source (..)
-  , Parser
   , parseForeignSource
+  , interpretForeignModule
   , Error (..)
-
-    -- * Internal
-  , moduleParser
-  , valueParser
   ) where
 
-import Control.Monad.Combinators.NonEmpty qualified as NE
-import Control.Monad.Trans.Except (except, throwE)
-import Data.DList (DList)
-import Data.DList qualified as DL
+import Control.Monad.Trans.Except (except)
+import Data.Set qualified as Set
 import Data.String qualified as String
-import Data.Text qualified as Text
-import Language.PureScript.Backend.Lua.Key (Key)
-import Language.PureScript.Backend.Lua.Key qualified as Key
+import Language.PureScript.Backend.Lua.Key (Key (..))
+import Language.PureScript.Backend.Lua.Name qualified as Name
+import Language.PureScript.Backend.Lua.Parser qualified as Parser
+import Language.PureScript.Backend.Lua.Types
+  ( Annotated
+  , Comments
+  , ExpF (..)
+  , StatementF (..)
+  , TableRowF (..)
+  )
 import Path (Abs, Dir, File, Path, toFilePath, (</>))
 import Path qualified
 import Path.IO qualified as Path
-import Text.Megaparsec (Parsec)
-import Text.Megaparsec qualified as MP
-import Text.Megaparsec qualified as Megaparsec
-import Text.Megaparsec.Char qualified as MP
 import Text.Show (Show (..))
 import Prelude hiding (show)
 
-data Source = Source {header ∷ Maybe Text, exports ∷ NonEmpty (Key, Text)}
-  deriving stock (Eq, Show)
-
 {- Note [Foreign module source format]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The FFI file contract (see the Haddock on 'parseForeignSource' below) has two
-constraints that are easy to miss and each is load-bearing:
+An FFI file is an ordinary Lua 5.1 module: any statements (the shared
+header), closed by @return { name = <value>, ... }@. It is parsed with the
+full Lua parser (see Note [Parsing foreign Lua sources] in
+'Language.PureScript.Backend.Lua.Parser'), so a syntax error anywhere in the
+file is a compile-time error, and export values land in the Lua AST where
+the optimizer can see into them.
 
-  * Every export value is wrapped in parentheses: @name = (<value>)@. The
-    parens delimit the value so 'valueParser' can extract a balanced Lua
-    expression by counting nested @()@; without them it cannot tell where one
-    export ends and the next begins.
-  * The optional header must contain no @return@. 'parseForeignSource' splits
-    the file at the first line beginning with @return@ ('break isReturn'),
-    taking everything before it as the shared header and the rest as the export
-    table; a @return@ in the header would truncate it.
+'interpretForeignModule' imposes the module shape on the parsed chunk:
 
-The result is a two-part 'Source' (optional 'header', non-empty 'exports'),
-which 'Language.PureScript.Backend.Lua' consumes: the header becomes a
-'ForeignSourceStat' and each export a table row keyed by 'Key.toSafeName'.
+  * The chunk's last statement must be a @return@ of exactly one table
+    constructor. The Lua grammar permits @return@ only as the final statement
+    of a block, so a well-formed file cannot hide an early top-level return
+    inside the header.
+  * Every row of that table must be keyed by a plain identifier
+    (@name = <value>@) or by a bracketed string literal (@["if"] = <value>@)
+    — the latter is how an export named after a Lua keyword appears; see
+    Note [Lua reserved words as foreign export keys] in
+    'Language.PureScript.Backend.Lua.Key'.
+
+The result is a 'Source': header statements, per-export annotated
+expressions (a comment written above an export sticks with its value), and
+the comments that preceded the @return@ itself (e.g. a module-level
+commentary in a file with no header statements).
+'Language.PureScript.Backend.Lua' consumes it when lowering
+'Language.PureScript.Backend.IR.ForeignImport'.
 -}
 
-{- | Parse a foreign source file which has to be in the following format:
-@@
-  <header>
-  return {
-    identifier = (<value>),
-    ...
-    identifier = (<value>)
+data Source = Source
+  { header ∷ [Annotated Comments StatementF]
+  -- ^ statements preceding the final @return@
+  , returnComments ∷ Comments
+  -- ^ comments attached to the @return@ statement and its table
+  , exports ∷ NonEmpty (Key, Annotated Comments ExpF)
+  -- ^ export values in source order
   }
-@@
+  deriving stock (Eq, Show)
 
-The <header> is optional and can contain any Lua statements except 'return'.
-It is meant to host Lua code shared by all the export <values>.
-
-The <value> is a Lua expression. The braces around a <value> are required.
+{- | Locate, read, parse, and interpret the FFI file for a module.
+See Note [Foreign module source format].
 -}
 parseForeignSource ∷ Path Abs Dir → FilePath → IO (Either Error Source)
 parseForeignSource foreigns path = runExceptT do
   filePath ← toFilePath <$> resolveForModule path foreigns
-  src ← Text.strip . decodeUtf8 <$> liftIO (readFileBS filePath)
-  -- See Note [Foreign module source format] (header must contain no return)
-  let (headerLines, returnStat) = break isReturn (Text.lines src)
-  case Megaparsec.parse moduleParser filePath (unlines returnStat) of
-    Left err → throwE $ ForeignErrorParse filePath err
-    Right parsed → do
-      let header = guarded (not . Text.null) (Text.strip (unlines headerLines))
-      pure $ Source header parsed
+  src ← decodeUtf8 <$> liftIO (readFileBS filePath)
+  statements ←
+    except . first (ForeignErrorParse filePath) $
+      Parser.parseChunk filePath src
+  except $ interpretForeignModule filePath statements
  where
-  isReturn ∷ Text → Bool
-  isReturn = Text.isPrefixOf "return"
-
   resolveForModule ∷ FilePath → Path Abs Dir → ExceptT Error IO (Path Abs File)
   resolveForModule modulePath foreignBaseDir = do
     cwd ← Path.getCurrentDir
@@ -99,51 +95,50 @@ parseForeignSource foreigns path = runExceptT do
     except $
       maybeToRight (ForeignFileNotFound modulePath filesToSearch) (asum found)
 
---------------------------------------------------------------------------------
--- Parser ----------------------------------------------------------------------
-
-type Parser = Parsec Void Text
-
-moduleParser ∷ Parser (NonEmpty (Key, Text))
-moduleParser = do
-  MP.string "return" *> MP.space1
-  char '{'
-  exports ← NE.sepEndBy1 foreignExport (char ',')
-  char '}'
-  pure exports
-
-foreignExport ∷ Parser (Key, Text)
-foreignExport = do
-  -- See Note [Lua reserved words as foreign export keys] in ...Backend.Lua.Key
-  exportKey ← Key.parser
-  char '='
-  exportValue ← valueParser
-  pure (exportKey, toText exportValue)
-
--- See Note [Foreign module source format] (values are paren-wrapped)
-valueParser ∷ Parser String
-valueParser = char '(' *> go 0 DL.empty <* MP.space
+{- | Impose the foreign-module shape on a parsed chunk.
+See Note [Foreign module source format].
+-}
+interpretForeignModule
+  ∷ FilePath
+  → [Annotated Comments StatementF]
+  → Either Error Source
+interpretForeignModule filePath statements =
+  case reverse statements of
+    (retComments, Return [(tableComments, TableCtor rows)]) : reversedHeader → do
+      exports ←
+        maybeToRight (ForeignNoExports filePath) . nonEmpty
+          =<< traverse rowToExport rows
+      pure
+        Source
+          { header = reverse reversedHeader
+          , returnComments = retComments <> tableComments
+          , exports
+          }
+    _ → Left (ForeignNoExportsReturn filePath)
  where
-  go ∷ Int → DList Char → Parser String
-  go numToClose value = do
-    cs ← many $ MP.satisfy (\c → c /= '(' && c /= ')')
-    MP.optional MP.anySingle >>= \case
-      Just '(' → go (succ numToClose) (DL.snoc (value <> DL.fromList cs) '(')
-      Just ')' →
-        if numToClose > 0
-          then go (pred numToClose) (DL.snoc (value <> DL.fromList cs) ')')
-          else pure $ DL.toList $ value <> DL.fromList cs
-      _ → pure $ DL.toList (value <> DL.fromList cs)
-
-char ∷ Char → Parser ()
-char c = MP.char c *> MP.space
+  rowToExport
+    ∷ Annotated Comments TableRowF
+    → Either Error (Key, Annotated Comments ExpF)
+  rowToExport (rowComments, row) = case row of
+    TableRowNV name (valueComments, value) →
+      Right (KeyName name, (rowComments <> valueComments, value))
+    TableRowKV (_, String key) (valueComments, value)
+      -- See Note [Lua reserved words as foreign export keys]
+      | key `Set.member` Name.reserved →
+          Right (KeyReserved key, (rowComments <> valueComments, value))
+      | Just name ← Name.fromText key →
+          Right (KeyName name, (rowComments <> valueComments, value))
+    _ → Left (ForeignUnsupportedExportKey filePath)
 
 --------------------------------------------------------------------------------
 -- Errors ----------------------------------------------------------------------
 
 data Error
   = ForeignFileNotFound FilePath (NonEmpty (Path Abs File))
-  | ForeignErrorParse FilePath (Megaparsec.ParseErrorBundle Text Void)
+  | ForeignErrorParse FilePath Parser.ParseError
+  | ForeignNoExportsReturn FilePath
+  | ForeignNoExports FilePath
+  | ForeignUnsupportedExportKey FilePath
   deriving stock (Eq)
 
 instance Show Error where
@@ -156,4 +151,16 @@ instance Show Error where
     "Error parsing foreign file "
       <> show filePath
       <> ":\n"
-      <> Megaparsec.errorBundlePretty err
+      <> Parser.renderParseError err
+  show (ForeignNoExportsReturn filePath) =
+    "Foreign file "
+      <> show filePath
+      <> " must end in `return { ... }` with a table of exports."
+  show (ForeignNoExports filePath) =
+    "Foreign file " <> show filePath <> " exports an empty table."
+  show (ForeignUnsupportedExportKey filePath) =
+    "Foreign file "
+      <> show filePath
+      <> " has an export with an unsupported key; every export must be\n"
+      <> "keyed by an identifier (name = ...) or a quoted Lua keyword\n"
+      <> "([\"if\"] = ...)."

--- a/lib/Language/PureScript/Backend/Lua/NestingCheck.hs
+++ b/lib/Language/PureScript/Backend/Lua/NestingCheck.hs
@@ -60,16 +60,29 @@ blockDepth = foldl' (\acc s → acc `max` statementDepth s) 0
 
 statementDepth ∷ StatementF a → Int
 statementDepth = \case
-  Assign v e → varDepth (unAnn v) `max` expDepth (unAnn e)
-  Local _name me → maybe 0 (expDepth . unAnn) me
-  Return e → expDepth (unAnn e)
-  ForeignSourceStat _ → 0
+  Assign vs es →
+    maxOf (varDepth . unAnn) (toList vs) `max` maxOf (expDepth . unAnn) es
+  Local _names es → maxOf (expDepth . unAnn) es
+  Return es → maxOf (expDepth . unAnn) es
+  CallStatement e → expDepth (unAnn e)
+  Break → 0
   IfThenElse c t e →
     1
       + ( expDepth (unAnn c)
             `max` blockDepth (unAnn <$> t)
             `max` blockDepth (unAnn <$> e)
         )
+  Do body → 1 + blockDepth (unAnn <$> body)
+  While c body → 1 + (expDepth (unAnn c) `max` blockDepth (unAnn <$> body))
+  Repeat body c → 1 + (blockDepth (unAnn <$> body) `max` expDepth (unAnn c))
+  ForNum _name start limit step body →
+    1
+      + ( maxOf (expDepth . unAnn) ([start, limit] <> maybeToList step)
+            `max` blockDepth (unAnn <$> body)
+        )
+  ForIn _names es body →
+    1 + (maxOf (expDepth . unAnn) es `max` blockDepth (unAnn <$> body))
+  LocalFunction _name _params body → 1 + blockDepth (unAnn <$> body)
 
 expDepth ∷ ExpF a → Int
 expDepth = \case
@@ -78,17 +91,19 @@ expDepth = \case
   Integer _ → 0
   Float _ → 0
   String _ → 0
-  ForeignSourceExp _ → 0
+  Vararg → 0
   Var v → varDepth (unAnn v)
   UnOp _op e → 1 + expDepth (unAnn e)
   BinOp _op l r → 1 + (expDepth (unAnn l) `max` expDepth (unAnn r))
   Function _params body → 1 + blockDepth (unAnn <$> body)
-  TableCtor rows → 1 + foldl' (\acc r → acc `max` rowDepth (unAnn r)) 0 rows
+  TableCtor rows → 1 + maxOf (rowDepth . unAnn) rows
   -- The callee spine of @f(a)(b)@ is parsed iteratively, so it does not add a
   -- level; each argument position does.
   FunctionCall f args →
-    expDepth (unAnn f)
-      `max` (1 + foldl' (\acc a → acc `max` expDepth (unAnn a)) 0 args)
+    expDepth (unAnn f) `max` (1 + maxOf (expDepth . unAnn) args)
+  MethodCall o _name args →
+    expDepth (unAnn o) `max` (1 + maxOf (expDepth . unAnn) args)
+  Paren e → 1 + expDepth (unAnn e)
 
 varDepth ∷ VarF a → Int
 varDepth = \case
@@ -100,3 +115,7 @@ rowDepth ∷ TableRowF a → Int
 rowDepth = \case
   TableRowKV k v → expDepth (unAnn k) `max` expDepth (unAnn v)
   TableRowNV _name v → expDepth (unAnn v)
+  TableRowV v → expDepth (unAnn v)
+
+maxOf ∷ Foldable t ⇒ (x → Int) → t x → Int
+maxOf f = foldl' (\acc x → acc `max` f x) 0

--- a/lib/Language/PureScript/Backend/Lua/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Optimizer.hs
@@ -12,10 +12,11 @@ import Language.PureScript.Backend.Lua.Traversal
 import Language.PureScript.Backend.Lua.Types
   ( Annotated
   , Chunk
+  , Comments
   , Exp
   , ExpF (..)
   , Statement
-  , StatementF (IfThenElse, Return)
+  , StatementF (..)
   , TableRowF (..)
   , VarF (..)
   , pattern Ann
@@ -92,11 +93,12 @@ reduceTableDefinitionAccessor = \case
     | otherwise → original
   e → e
  where
-  isNameValue ∷ Annotated () TableRowF → Bool
+  isNameValue ∷ Annotated Comments TableRowF → Bool
   isNameValue (_ann, row) = case row of
     TableRowNV {} → True
     TableRowKV {} → False
-  hasDuplicateNames ∷ [Annotated () TableRowF] → Bool
+    TableRowV {} → False
+  hasDuplicateNames ∷ [Annotated Comments TableRowF] → Bool
   hasDuplicateNames rows =
     let names = [n | (_ann, TableRowNV n _) ← rows]
      in length names /= length (ordNub names)
@@ -115,11 +117,9 @@ the call. See issue #159.
 
 The rule declines when a leading statement contains a body-level 'Return':
 such an early return exits the call on a path the projection would not
-cover. A 'Return' inside a nested 'Function' belongs to a different
-activation and does not count. 'ForeignSourceStat' is opaque text and is
-assumed return-free: a foreign header returning at body level would skip
-the exports return that follows it and break the module regardless of this
-rule.
+cover. A 'Return' inside a nested 'Function' (or 'LocalFunction') belongs
+to a different activation and does not count, while a 'Return' inside a
+loop or 'Do' block at body level does.
 -}
 foldFieldProjectionThroughScopeCall ∷ RewriteRule
 foldFieldProjectionThroughScopeCall original
@@ -127,15 +127,16 @@ foldFieldProjectionThroughScopeCall original
       matchScopeCallProjection original =
       let projectedReturnValue =
             optimizeExpression (Lua.varField returnExp accessedField)
-          returnStatement = Lua.ann (Return (Lua.ann projectedReturnValue))
+          returnStatement = Lua.ann (Return [Lua.ann projectedReturnValue])
        in FunctionCall (Lua.ann (Function [] (leading <> [returnStatement]))) []
   | otherwise = original
  where
   -- Matches 'Var (VarField (FunctionCall (Function [] body) []) field)' where
-  -- the last statement of 'body' is a 'Return', splitting it into the
-  -- accessed field name, the leading statements, and the returned expression.
+  -- the last statement of 'body' is a single-valued 'Return', splitting it
+  -- into the accessed field name, the leading statements, and the returned
+  -- expression.
   matchScopeCallProjection
-    ∷ Exp → Maybe (Lua.Name, [Annotated () StatementF], Exp)
+    ∷ Exp → Maybe (Lua.Name, [Annotated Comments StatementF], Exp)
   matchScopeCallProjection = \case
     Var
       ( Ann
@@ -144,15 +145,26 @@ foldFieldProjectionThroughScopeCall original
               accessedField
             )
         ) → case reverse body of
-        Ann (Return (Ann returnExp)) : reverseLeading
+        Ann (Return [Ann returnExp]) : reverseLeading
           | not (any containsReturn reverseLeading) →
               Just (accessedField, reverse reverseLeading, returnExp)
         _ → Nothing
     _ → Nothing
 
-  containsReturn ∷ Annotated () StatementF → Bool
+  containsReturn ∷ Annotated Comments StatementF → Bool
   containsReturn (Ann statement) = case statement of
     Return {} → True
     IfThenElse _predicate thenBlock elseBlock →
       any containsReturn thenBlock || any containsReturn elseBlock
-    _ → False
+    Do body → any containsReturn body
+    While _predicate body → any containsReturn body
+    Repeat body _predicate → any containsReturn body
+    ForNum _name _start _limit _step body → any containsReturn body
+    ForIn _names _exprs body → any containsReturn body
+    -- A nested (local) function is a different activation: its returns do
+    -- not exit this call.
+    LocalFunction {} → False
+    Assign {} → False
+    Local {} → False
+    CallStatement {} → False
+    Break → False

--- a/lib/Language/PureScript/Backend/Lua/Parser.hs
+++ b/lib/Language/PureScript/Backend/Lua/Parser.hs
@@ -1,0 +1,885 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+{- | A parser for the Lua 5.1 grammar producing the backend's own AST
+('Language.PureScript.Backend.Lua.Types').
+
+See Note [Parsing foreign Lua sources].
+-}
+module Language.PureScript.Backend.Lua.Parser
+  ( parseChunk
+  , parseExpression
+  , unsafeParseStatements
+  , ParseError
+  , renderParseError
+
+    -- * Internal
+  , Parser
+  ) where
+
+import Data.Char qualified as Char
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Language.PureScript.Backend.Lua.Name (Name)
+import Language.PureScript.Backend.Lua.Name qualified as Name
+import Language.PureScript.Backend.Lua.Types hiding
+  ( and
+  , concat
+  , error
+  , exponent
+  , local
+  , mod
+  , negate
+  , or
+  , return
+  , var
+  )
+import Text.Megaparsec (Parsec, (<?>))
+import Text.Megaparsec qualified as MP
+import Text.Megaparsec.Char qualified as MP.Char
+
+{- Note [Parsing foreign Lua sources]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a complete parser for the Lua 5.1 grammar (the compilation target's
+floor, see docs/QUIRKS.md), replacing the earlier lexical splitter that
+extracted foreign export values as opaque text blobs. Values parsed into the
+real AST are visible to every Lua-level optimization; a syntax error in a
+foreign file is now a compile-time error rather than a luacheck/runtime one.
+
+Three design points are worth spelling out:
+
+  * /Comments ride in annotation slots./ The token-consuming primitives stash
+    every comment they skip into backtracking-safe user state ('Parser' is
+    'StateT' over 'Parsec', so a failed alternative restores pending
+    comments). When a node that owns an annotation slot starts, it adopts the
+    pending comments ('attachComments'/'mergeComments'). Comments thus attach
+    to the closest following statement, table row, or expression — which is
+    where FFI comments live. Comments trailing a block (before @end@) attach
+    to the next node after the block, and comments at end of input are
+    dropped: placement fidelity beyond "in front of the right node" is a
+    non-goal, blank-line fidelity likewise.
+
+  * /Strings are kept in source form./ A 'String' literal's payload is the
+    text between double quotes with escapes unexpanded (see the Haddock on
+    'ExpF'): decoding an escape like @\\255@ into Text and re-encoding would
+    corrupt byte-oriented Lua strings. Single-quoted and long-bracket strings
+    are converted to the double-quoted form (escaping @"@, backslash-newline,
+    and for long brackets also @\\@ and raw newlines).
+
+  * /Operator parsing mirrors lparser.c./ 'subexpr' is the precedence-climbing
+    algorithm from Lua 5.1's own parser, with its left/right priority table
+    ('binOpPriority'); this pins associativity (@..@ and @^@ right, all else
+    left) and the unary-operator binding level to the reference
+    implementation. Lua 5.3 operators recognised by the printer (@//@ and the
+    bitwise family) are deliberately absent from the grammar.
+
+Explicit parentheses around a call or @...@ are semantic in Lua (they adjust
+a multi-value expression to exactly one value), so they parse into 'Paren';
+parens around any single-valued expression are mere grouping and are dropped
+— the printer re-derives them from precedence.
+
+Known divergences from the reference parser (lua-5.1.5 lparser.c):
+
+  * @goto@ is rejected as an identifier even though it became a keyword only
+    in Lua 5.2. Deliberate: parsed FFI code and generated code (mangled
+    against the same 'Name.reserved' set) share one output chunk, which must
+    stay loadable on LuaJIT and Lua 5.2+, where @goto@ is reserved. See
+    Note [Lua reserved words as foreign export keys] in
+    "Language.PureScript.Backend.Lua.Key".
+
+Everything else follows the reference, including its rejections: a line
+break between a callee and the @(@ of its argument list is "ambiguous
+syntax" ('callArgs', driven by 'newlineInGap'), @...@ outside a vararg
+function is an error ('simpleExp' checks 'inVarargScope'), and 'withDepth'
+caps parser recursion ('subexpr'/'block') the way LUAI_MAXCCALLS caps the
+reference's C stack — at 500 rather than 200, since the cap only protects
+the compiler from stack overflow on adversarial input, while the binding
+limit for /generated/ nesting stays
+'Language.PureScript.Backend.Lua.NestingCheck.nestingLimit' (180).
+-}
+
+type Parser = StateT ParserState (Parsec Void Text)
+
+{- | Parser state, backtracking-safe by construction: 'Parser' is 'StateT'
+/over/ 'Parsec', so a failed alternative restores the whole record.
+-}
+data ParserState = ParserState
+  { pendingComments ∷ Comments
+  -- ^ comments collected since the previous token, oldest first
+  , newlineInGap ∷ Bool
+  {- ^ whether a line break separates the previous token from the current
+  one; drives the "ambiguous syntax" rejection in 'callArgs'
+  -}
+  , syntaxDepth ∷ Int
+  -- ^ current 'withDepth' nesting level
+  , inVarargScope ∷ Bool
+  {- ^ whether @...@ is legal here: the innermost enclosing function has a
+  @...@ parameter (the main chunk counts as a vararg function)
+  -}
+  }
+
+initialParserState ∷ ParserState
+initialParserState =
+  ParserState
+    { pendingComments = []
+    , newlineInGap = False
+    , syntaxDepth = 0
+    , inVarargScope = True
+    }
+
+type ParseError = MP.ParseErrorBundle Text Void
+
+renderParseError ∷ ParseError → String
+renderParseError = MP.errorBundlePretty
+
+--------------------------------------------------------------------------------
+-- Entry points ----------------------------------------------------------------
+
+-- | Parse a complete Lua 5.1 chunk (a block covering the whole input).
+parseChunk
+  ∷ FilePath
+  → Text
+  → Either ParseError [Annotated Comments StatementF]
+parseChunk = MP.parse (evalStateT (sc *> block <* MP.eof) initialParserState)
+
+-- | Parse a single Lua 5.1 expression covering the whole input.
+parseExpression
+  ∷ Text
+  → Either ParseError (Annotated Comments ExpF)
+parseExpression =
+  MP.parse
+    (evalStateT (sc *> expression <* MP.eof) initialParserState)
+    "<expression>"
+
+{- | Parse statements from a static (compiler-provided) Lua source, erroring
+on a syntax error. For trusted fixture code only, never for user input.
+-}
+unsafeParseStatements ∷ HasCallStack ⇒ Text → [Statement]
+unsafeParseStatements src =
+  case parseChunk "<fixture>" src of
+    Left err →
+      error . toText $
+        "Language.PureScript.Backend.Lua.Parser.unsafeParseStatements: "
+          <> renderParseError err
+    Right stats → unAnn <$> stats
+
+--------------------------------------------------------------------------------
+-- Comments in annotation slots ------------------------------------------------
+
+-- | Pending comments collected since the previous token, oldest first.
+takeComments ∷ Parser Comments
+takeComments = state \s → (pendingComments s, s {pendingComments = []})
+
+{- | Attach pending comments to the node about to be parsed. The parser is
+one token past the comments at this point, so they belong to this node.
+-}
+attachComments ∷ Parser (f Comments) → Parser (Annotated Comments f)
+attachComments p = do
+  comments ← takeComments
+  node ← p
+  pure (comments, node)
+
+-- | Like 'attachComments' for parsers already producing an annotated node.
+mergeComments
+  ∷ Parser (Annotated Comments f)
+  → Parser (Annotated Comments f)
+mergeComments p = do
+  comments ← takeComments
+  (comments', node) ← p
+  pure (comments <> comments', node)
+
+--------------------------------------------------------------------------------
+-- Lexer -----------------------------------------------------------------------
+
+{- | Skip whitespace and comments, stashing each comment into user state.
+Also (re)computes 'newlineInGap': whether the skipped gap — including the
+raw text of a long-bracket comment — contains a line break.
+-}
+sc ∷ Parser ()
+sc = do
+  modify' \s → s {newlineInGap = False}
+  void $ MP.many (whitespace <|> comment)
+ where
+  whitespace = do
+    gap ← MP.takeWhile1P (Just "white space") Char.isSpace
+    when (hasNewline gap) markNewlineInGap
+  comment = do
+    (raw, _) ← MP.match do
+      void (MP.Char.string "--")
+      void (MP.try longBracket) <|> restOfLine
+    when (hasNewline raw) markNewlineInGap
+    modify' \s → s {pendingComments = pendingComments s <> [raw]}
+  restOfLine = void $ MP.takeWhileP Nothing (\c → c /= '\n' && c /= '\r')
+  hasNewline = Text.any \c → c == '\n' || c == '\r'
+  markNewlineInGap = modify' \s → s {newlineInGap = True}
+
+lexeme ∷ Parser a → Parser a
+lexeme p = p <* sc
+
+symbol ∷ Text → Parser ()
+symbol s = lexeme (void (MP.Char.string s))
+
+keyword ∷ Text → Parser ()
+keyword k =
+  lexeme . MP.try $
+    MP.Char.string k *> MP.notFollowedBy (MP.satisfy isIdentRest)
+
+-- | @=@ that is not @==@.
+equals ∷ Parser ()
+equals = lexeme . MP.try $ MP.Char.char '=' *> MP.notFollowedBy (MP.Char.char '=')
+
+-- | @.@ that is not @..@ (concatenation) or @...@ (vararg).
+dot ∷ Parser ()
+dot = lexeme . MP.try $ MP.Char.char '.' *> MP.notFollowedBy (MP.Char.char '.')
+
+-- | @[@ that is not the opening of a long-bracket string.
+openBracket ∷ Parser ()
+openBracket =
+  lexeme . MP.try $
+    MP.Char.char '['
+      *> MP.notFollowedBy (MP.satisfy \c → c == '[' || c == '=')
+
+{- | Cap on 'withDepth' nesting. Chosen above the emitter's own
+'Language.PureScript.Backend.Lua.NestingCheck.nestingLimit' (180) and above
+the reference parser's LUAI_MAXCCALLS (200): this cap exists only to turn a
+stack overflow on adversarially nested input into a parse error, not to
+enforce the target's runtime limits.
+-}
+syntaxNestingLimit ∷ Int
+syntaxNestingLimit = 500
+
+{- | Run a parser one syntax level deeper, failing once the depth exceeds
+'syntaxNestingLimit'. Wraps the two recursions whose depth is driven by
+input nesting: 'subexpr' (parenthesised\/unary\/right-associative chains)
+and 'block' (statement bodies). On failure the 'StateT' backtracking
+restores the depth by itself.
+-}
+withDepth ∷ Parser a → Parser a
+withDepth p = do
+  depth ← gets syntaxDepth
+  when (depth >= syntaxNestingLimit) $
+    fail
+      ("nesting too deep: more than " <> show syntaxNestingLimit <> " syntax levels")
+  modify' \s → s {syntaxDepth = depth + 1}
+  a ← p
+  modify' \s → s {syntaxDepth = depth}
+  pure a
+
+isIdentStart ∷ Char → Bool
+isIdentStart c = Char.isAlpha c || c == '_'
+
+isIdentRest ∷ Char → Bool
+isIdentRest c = Char.isAlphaNum c || c == '_'
+
+-- | An identifier that is not a reserved word.
+identifier ∷ Parser Name
+identifier = lexeme . MP.try $ do
+  c ← MP.satisfy isIdentStart <?> "identifier"
+  rest ← MP.takeWhileP Nothing isIdentRest
+  let txt = Text.cons c rest
+  if txt `Set.member` Name.reserved
+    then fail ("unexpected keyword " <> show txt)
+    else maybe (fail ("invalid identifier " <> show txt)) pure (Name.fromText txt)
+
+--------------------------------------------------------------------------------
+-- Literals --------------------------------------------------------------------
+
+{- | Lua 5.1 numerals: decimal integers, decimal floats (fraction and\/or
+exponent, including forms like @.5@ and @1.@), and hexadecimal integers.
+-}
+numberLit ∷ Parser (ExpF Comments)
+numberLit =
+  lexeme $
+    (MP.try hexadecimal <|> MP.try decimal)
+      <* MP.notFollowedBy (MP.satisfy isIdentRest)
+ where
+  hexadecimal ∷ Parser (ExpF Comments)
+  hexadecimal = do
+    void (MP.Char.string "0x" <|> MP.Char.string "0X")
+    digits ← MP.takeWhile1P (Just "hexadecimal digit") Char.isHexDigit
+    pure . Integer $
+      Text.foldl' (\acc c → acc * 16 + toInteger (Char.digitToInt c)) 0 digits
+
+  decimal ∷ Parser (ExpF Comments)
+  decimal = do
+    (txt, isFloat) ← MP.match do
+      intPart ← MP.takeWhileP Nothing Char.isDigit
+      fracPart ← MP.optional (MP.Char.char '.' *> MP.takeWhileP Nothing Char.isDigit)
+      guard (not (Text.null intPart) || not (all Text.null fracPart))
+      expoPart ← MP.optional . MP.try $ do
+        void (MP.satisfy \c → c == 'e' || c == 'E')
+        void (MP.optional (MP.satisfy \c → c == '+' || c == '-'))
+        void (MP.takeWhile1P (Just "exponent digit") Char.isDigit)
+      pure (isJust fracPart || isJust expoPart)
+    if isFloat
+      then Float <$> readDouble txt
+      else Integer <$> readInteger txt
+
+  readDouble ∷ Text → Parser Double
+  readDouble txt =
+    -- Haskell's Read is stricter than Lua about a bare dot: pad "1." / ".5"
+    -- (and "1.e5") into forms it accepts.
+    let (mantissa, expo) = Text.break (\c → c == 'e' || c == 'E') txt
+        padded =
+          mantissa
+            & (\m → if "." `Text.isPrefixOf` m then "0" <> m else m)
+            & (\m → if "." `Text.isSuffixOf` m then m <> "0" else m)
+     in maybe (fail ("malformed number " <> show txt)) pure $
+          readMaybe (toString (padded <> expo))
+
+  readInteger ∷ Text → Parser Integer
+  readInteger txt =
+    maybe (fail ("malformed number " <> show txt)) pure $
+      readMaybe (toString txt)
+
+{- | A Lua 5.1 string literal, converted to /double-quoted source form/
+(see the Haddock on 'ExpF').
+-}
+stringLit ∷ Parser (ExpF Comments)
+stringLit =
+  lexeme $
+    String
+      <$> ( shortString '"'
+              <|> shortString '\''
+              <|> (escapeRawText . dropLeadingNewline <$> MP.try longBracket)
+          )
+
+{- | The body of a short string literal. Escape sequences stay unexpanded;
+an escaped newline is normalized to @\\n@, and when converting from a
+single-quoted literal every unescaped @"@ becomes @\\"@.
+-}
+shortString ∷ Char → Parser Text
+shortString quote = MP.Char.char quote *> body
+ where
+  body = do
+    chunk ←
+      MP.takeWhileP Nothing \c →
+        c /= quote && c /= '\\' && c /= '\n' && c /= '\r'
+    let converted
+          | quote == '\'' = Text.replace "\"" "\\\"" chunk
+          | otherwise = chunk
+    MP.choice
+      [ MP.Char.char quote $> converted
+      , do
+          void (MP.Char.char '\\')
+          c ← MP.anySingle <?> "escape sequence"
+          escaped ← case c of
+            '\n' → MP.optional (MP.Char.char '\r') $> "\\n"
+            '\r' → MP.optional (MP.Char.char '\n') $> "\\n"
+            _ → pure (Text.pack ['\\', c])
+          rest ← body
+          pure (converted <> escaped <> rest)
+      , fail "unterminated string"
+      ]
+
+{- | A long-bracket payload @[==[ ... ]==]@ (any level), returning the raw
+content. Backtracks if the input does not open a long bracket.
+-}
+longBracket ∷ Parser Text
+longBracket = do
+  level ← MP.try do
+    void (MP.Char.char '[')
+    eqs ← MP.takeWhileP Nothing (== '=')
+    void (MP.Char.char '[')
+    pure eqs
+  let close = "]" <> level <> "]"
+  let go acc = do
+        chunk ← MP.takeWhileP Nothing (/= ']')
+        MP.choice
+          [ MP.Char.string close $> (acc <> chunk)
+          , MP.Char.char ']' *> go (acc <> chunk <> "]")
+          ]
+  go ""
+
+-- | Lua drops a newline immediately following a long bracket's opener.
+dropLeadingNewline ∷ Text → Text
+dropLeadingNewline t =
+  fromMaybe t $
+    Text.stripPrefix "\r\n" t
+      <|> Text.stripPrefix "\n\r" t
+      <|> Text.stripPrefix "\n" t
+      <|> Text.stripPrefix "\r" t
+
+-- | Escape raw (long-bracket) content into double-quoted source form.
+escapeRawText ∷ Text → Text
+escapeRawText = Text.concatMap \case
+  '\\' → "\\\\"
+  '"' → "\\\""
+  '\n' → "\\n"
+  '\r' → "\\r"
+  c → Text.singleton c
+
+--------------------------------------------------------------------------------
+-- Expressions -----------------------------------------------------------------
+
+type AnnExp = Annotated Comments ExpF
+
+{- | In a position that consumes exactly one value — an operator operand or
+a prefix base for indexing\/field access\/calls — the multi-value
+adjustment of explicit parens is a no-op, so @(f()).x@, @#(...)@ and the
+like canonicalize to the paren-free form. This also makes @parse . print@
+the identity: the printer parenthesizes unary operands and non-name
+prefixes for readability.
+-}
+unparen ∷ AnnExp → AnnExp
+unparen (comments, Paren (comments', inner)) = (comments <> comments', inner)
+unparen e = e
+
+expression ∷ Parser AnnExp
+expression = subexpr 0
+
+explist1 ∷ Parser (NonEmpty AnnExp)
+explist1 = do
+  e ← expression
+  es ← MP.many (symbol "," *> expression)
+  pure (e :| es)
+
+{- | Precedence climbing, transcribed from @subexpr@ in Lua 5.1's lparser.c
+(see Note [Parsing foreign Lua sources]). Left-associative chains stay in
+'loop' at one depth; parens, unary operators, and right-associative
+operators recurse under 'withDepth'.
+-}
+subexpr ∷ Int → Parser AnnExp
+subexpr limit = withDepth (prefix >>= loop)
+ where
+  prefix =
+    mergeComments $
+      MP.choice
+        [ do
+            op ← unaryOp
+            e ← subexpr unaryPriority
+            pure ([], UnOp op (unparen e))
+        , simpleExp
+        ]
+
+  loop left =
+    MP.choice
+      [ do
+          op ← MP.try do
+            op ← binaryOp
+            guard (fst (binOpPriority op) > limit)
+            pure op
+          right ← subexpr (snd (binOpPriority op))
+          loop ([], BinOp op left right)
+      , pure left
+      ]
+
+unaryPriority ∷ Int
+unaryPriority = 8
+
+-- | (left, right) binding priorities from Lua 5.1's lparser.c.
+binOpPriority ∷ BinaryOp → (Int, Int)
+binOpPriority = \case
+  Or → (1, 1)
+  And → (2, 2)
+  LessThan → (3, 3)
+  GreaterThan → (3, 3)
+  LessThanOrEqualTo → (3, 3)
+  GreaterThanOrEqualTo → (3, 3)
+  NotEqualTo → (3, 3)
+  EqualTo → (3, 3)
+  Concat → (5, 4) -- right-associative
+  Add → (6, 6)
+  Sub → (6, 6)
+  Mul → (7, 7)
+  FloatDiv → (7, 7)
+  Mod → (7, 7)
+  Exp → (10, 9) -- right-associative
+  -- Not part of the Lua 5.1 grammar; unreachable from 'binaryOp'.
+  BitOr → (4, 4)
+  BitXor → (5, 5)
+  BitAnd → (6, 6)
+  BitShiftRight → (7, 7)
+  BitShiftLeft → (7, 7)
+  FloorDiv → (7, 7)
+
+unaryOp ∷ Parser UnaryOp
+unaryOp =
+  MP.choice
+    [ LogicalNot <$ keyword "not"
+    , HashOp <$ symbol "#"
+    , Negate <$ minus
+    ]
+
+-- | @-@ that is not the @--@ comment opener.
+minus ∷ Parser ()
+minus = lexeme . MP.try $ MP.Char.char '-' *> MP.notFollowedBy (MP.Char.char '-')
+
+binaryOp ∷ Parser BinaryOp
+binaryOp =
+  MP.choice
+    [ Add <$ symbol "+"
+    , Sub <$ minus
+    , Mul <$ symbol "*"
+    , FloatDiv <$ symbol "/"
+    , Mod <$ symbol "%"
+    , Exp <$ symbol "^"
+    , Concat <$ concatOp
+    , EqualTo <$ symbol "=="
+    , NotEqualTo <$ symbol "~="
+    , LessThanOrEqualTo <$ MP.try (symbol "<=")
+    , LessThan <$ symbol "<"
+    , GreaterThanOrEqualTo <$ MP.try (symbol ">=")
+    , GreaterThan <$ symbol ">"
+    , And <$ keyword "and"
+    , Or <$ keyword "or"
+    ]
+ where
+  -- @..@ that is not the @...@ vararg.
+  concatOp =
+    lexeme . MP.try $
+      MP.Char.string ".." *> MP.notFollowedBy (MP.Char.char '.')
+
+simpleExp ∷ Parser AnnExp
+simpleExp =
+  mergeComments . MP.choice $
+    [ plain (Nil <$ keyword "nil")
+    , plain (Boolean True <$ keyword "true")
+    , plain (Boolean False <$ keyword "false")
+    , plain do
+        MP.try (symbol "...")
+        varargScope ← gets inVarargScope
+        unless varargScope $
+          fail "cannot use '...' outside a vararg function"
+        pure Vararg
+    , plain numberLit
+    , plain stringLit
+    , plain (TableCtor <$> tableCtor)
+    , plain functionExp
+    , suffixedExp
+    ]
+ where
+  plain ∷ Parser (ExpF Comments) → Parser AnnExp
+  plain = fmap ([],)
+
+functionExp ∷ Parser (ExpF Comments)
+functionExp = do
+  keyword "function"
+  (params, body) ← funcBody
+  pure (Function params body)
+
+{- | @funcbody ::= '(' [parlist] ')' block end@ with
+@parlist ::= namelist [',' '...'] | '...'@.
+-}
+funcBody
+  ∷ Parser ([Annotated Comments ParamF], [Annotated Comments StatementF])
+funcBody = do
+  symbol "("
+  params ← param `MP.sepBy` symbol ","
+  symbol ")"
+  let isVararg = (== ParamVararg) . unAnn
+  case reverse params of
+    _last : earlier
+      | any isVararg earlier →
+          fail "'...' must be the last parameter"
+    _ → pass
+  -- The body's vararg scope is this function's own, not the enclosing one.
+  outerVarargScope ← gets inVarargScope
+  modify' \s → s {inVarargScope = any isVararg params}
+  body ← block
+  keyword "end"
+  modify' \s → s {inVarargScope = outerVarargScope}
+  pure (params, body)
+ where
+  param ∷ Parser (Annotated Comments ParamF)
+  param =
+    ([],)
+      <$> MP.choice
+        [ ParamVararg <$ MP.try (symbol "...")
+        , ParamNamed <$> identifier
+        ]
+
+{- | @prefixexp@\/@functioncall@\/@var@: a primary expression (name or
+parenthesised expression) followed by any number of index, field, method
+call, and call suffixes.
+-}
+suffixedExp ∷ Parser AnnExp
+suffixedExp = primaryExp >>= suffixes
+ where
+  primaryExp ∷ Parser AnnExp
+  primaryExp =
+    MP.choice
+      [ ([],) . Var . ([],) . VarName <$> identifier
+      , do
+          symbol "("
+          e@(comments, inner) ← expression
+          symbol ")"
+          pure case inner of
+            -- Parens adjust a multi-valued expression to one value.
+            FunctionCall {} → ([], Paren e)
+            MethodCall {} → ([], Paren e)
+            Vararg → ([], Paren e)
+            -- Around a single-valued expression they are mere grouping.
+            _ → (comments, inner)
+      ]
+
+  suffixes ∷ AnnExp → Parser AnnExp
+  suffixes base =
+    MP.choice
+      [ do
+          dot
+          n ← identifier
+          suffixes ([], Var ([], VarField base' n))
+      , do
+          openBracket
+          k ← expression
+          symbol "]"
+          suffixes ([], Var ([], VarIndex base' k))
+      , do
+          symbol ":"
+          n ← identifier
+          args ← callArgs
+          suffixes ([], MethodCall base' n args)
+      , do
+          args ← callArgs
+          suffixes ([], FunctionCall base' args)
+      , pure base
+      ]
+   where
+    -- See 'unparen': in prefix position the adjustment is a no-op.
+    base' = unparen base
+
+{- | @args ::= '(' [explist] ')' | tableconstructor | String@
+
+A line break between the callee and @(@ is rejected the way the reference
+parser rejects it ("ambiguous syntax"): it cannot tell a call from a new
+statement that starts with a parenthesised expression. The flag is sampled
+/before/ 'symbol' (whose trailing 'sc' resets it), and the failure happens
+/after/ @(@ is consumed: a consuming failure commits the error, whereas
+failing first would make 'suffixes' silently take its no-suffix branch and
+misread the input as two statements. String and table arguments stay legal
+across a line break — the reference accepts those.
+-}
+callArgs ∷ Parser [AnnExp]
+callArgs =
+  MP.choice
+    [ do
+        gapBeforeParen ← gets newlineInGap
+        symbol "("
+        when gapBeforeParen $
+          fail . mconcat $
+            [ "ambiguous syntax (function call x new statement): "
+            , "terminate the previous statement with ';' "
+            , "or keep '(' on the same line as the callee"
+            ]
+        args ← expression `MP.sepBy` symbol ","
+        symbol ")"
+        pure args
+    , one . ([],) . TableCtor <$> tableCtor
+    , one . ([],) <$> lexeme (String <$> shortStringOrLong)
+    ]
+ where
+  shortStringOrLong =
+    shortString '"'
+      <|> shortString '\''
+      <|> (escapeRawText . dropLeadingNewline <$> MP.try longBracket)
+
+{- | @tableconstructor ::= '{' [fieldlist] '}'@ where fields are separated
+by @,@ or @;@ with an optional trailing separator.
+-}
+tableCtor ∷ Parser [Annotated Comments TableRowF]
+tableCtor = do
+  symbol "{"
+  rows ← row `MP.sepEndBy` fieldSep
+  symbol "}"
+  pure rows
+ where
+  fieldSep = symbol "," <|> symbol ";"
+  row =
+    attachComments $
+      MP.choice
+        [ do
+            openBracket
+            k ← expression
+            symbol "]"
+            equals
+            TableRowKV k <$> expression
+        , MP.try do
+            n ← identifier
+            equals
+            TableRowNV n <$> expression
+        , TableRowV <$> expression
+        ]
+
+--------------------------------------------------------------------------------
+-- Statements ------------------------------------------------------------------
+
+type AnnStat = Annotated Comments StatementF
+
+{- | @block ::= {stat [';']} [laststat [';']]@ — @return@\/@break@ may only
+close a block.
+-}
+block ∷ Parser [AnnStat]
+block = withDepth do
+  stats ← MP.many (statement <* MP.optional (symbol ";"))
+  final ← MP.optional (lastStatement <* MP.optional (symbol ";"))
+  pure (stats <> maybeToList final)
+
+lastStatement ∷ Parser AnnStat
+lastStatement =
+  attachComments . MP.choice $
+    [ Break <$ keyword "break"
+    , do
+        keyword "return"
+        values ← MP.optional explist1
+        pure (Return (maybe [] toList values))
+    ]
+
+statement ∷ Parser AnnStat
+statement =
+  attachComments . MP.choice $
+    [ doStat
+    , whileStat
+    , repeatStat
+    , ifStat
+    , forStat
+    , functionStat
+    , localStat
+    , exprStat
+    ]
+
+doStat ∷ Parser (StatementF Comments)
+doStat = do
+  keyword "do"
+  body ← block
+  keyword "end"
+  pure (Do body)
+
+whileStat ∷ Parser (StatementF Comments)
+whileStat = do
+  keyword "while"
+  predicate ← expression
+  keyword "do"
+  body ← block
+  keyword "end"
+  pure (While predicate body)
+
+repeatStat ∷ Parser (StatementF Comments)
+repeatStat = do
+  keyword "repeat"
+  body ← block
+  keyword "until"
+  Repeat body <$> expression
+
+{- | @elseif@ chains parse into a nested 'IfThenElse' in the else-slot; the
+printer re-sugars comment-free chains back to @elseif@. The clauses are
+collected iteratively (the reference parser loops over @elseif@ the same
+way) and folded into the nested shape afterwards, so a long ladder costs no
+parser recursion depth.
+-}
+ifStat ∷ Parser (StatementF Comments)
+ifStat = do
+  keyword "if"
+  predicate ← expression
+  keyword "then"
+  thenBlock ← block
+  IfThenElse predicate thenBlock <$> elseTail []
+ where
+  -- Clauses accumulate most-recent-first; 'nestClauses' wraps them around
+  -- the final else-block from the innermost @elseif@ outwards.
+  elseTail ∷ [(Comments, AnnExp, [AnnStat])] → Parser [AnnStat]
+  elseTail clauses =
+    MP.choice
+      [ keyword "end" $> nestClauses []
+      , nestClauses <$> (keyword "else" *> block <* keyword "end")
+      , do
+          comments ← takeComments
+          keyword "elseif"
+          predicate ← expression
+          keyword "then"
+          thenBlock ← block
+          elseTail ((comments, predicate, thenBlock) : clauses)
+      ]
+   where
+    nestClauses ∷ [AnnStat] → [AnnStat]
+    nestClauses = flip (foldl' nest) clauses
+    nest ∷ [AnnStat] → (Comments, AnnExp, [AnnStat]) → [AnnStat]
+    nest inner (comments, predicate, thenBlock) =
+      [(comments, IfThenElse predicate thenBlock inner)]
+
+forStat ∷ Parser (StatementF Comments)
+forStat = do
+  keyword "for"
+  name ← identifier
+  numericFor name <|> genericFor name
+ where
+  numericFor name = do
+    equals
+    start ← expression
+    symbol ","
+    limit ← expression
+    step ← MP.optional (symbol "," *> expression)
+    keyword "do"
+    body ← block
+    keyword "end"
+    pure (ForNum name start limit step body)
+
+  genericFor name = do
+    names ← MP.many (symbol "," *> identifier)
+    keyword "in"
+    exprs ← explist1
+    keyword "do"
+    body ← block
+    keyword "end"
+    pure (ForIn (name :| names) exprs body)
+
+{- | @function funcname funcbody@ desugars to the assignment the Lua manual
+defines it as; a method name adds the implicit @self@ parameter.
+-}
+functionStat ∷ Parser (StatementF Comments)
+functionStat = do
+  keyword "function"
+  root ← identifier
+  fields ← MP.many (dot *> identifier)
+  method ← MP.optional (symbol ":" *> identifier)
+  (params, body) ← funcBody
+  let selfParam ∷ Annotated Comments ParamF
+      selfParam = ([], ParamNamed [Name.name|self|])
+      params' = maybe params (const (selfParam : params)) method
+      target =
+        foldl'
+          (\v field → VarField ([], Var ([], v)) field)
+          (VarName root)
+          (fields <> maybeToList method)
+  pure (Assign (one ([], target)) (one ([], Function params' body)))
+
+localStat ∷ Parser (StatementF Comments)
+localStat = do
+  keyword "local"
+  localFunction <|> localNames
+ where
+  localFunction = do
+    keyword "function"
+    name ← identifier
+    (params, body) ← funcBody
+    pure (LocalFunction name params body)
+
+  localNames = do
+    name ← identifier
+    names ← MP.many (symbol "," *> identifier)
+    values ← MP.optional (equals *> explist1)
+    pure (Local (name :| names) (maybe [] toList values))
+
+{- | The @varlist '=' explist@ / @functioncall@ statements, disambiguated the
+way Lua's parser does it: parse one suffixed expression, then decide by the
+next token.
+-}
+exprStat ∷ Parser (StatementF Comments)
+exprStat = do
+  e ← suffixedExp
+  MP.choice
+    [ do
+        vars ← MP.many (symbol "," *> suffixedExp)
+        equals
+        values ← explist1
+        variables ← traverse toVar (e :| vars)
+        pure (Assign variables values)
+    , case e of
+        (_, FunctionCall {}) → pure (CallStatement e)
+        (_, MethodCall {}) → pure (CallStatement e)
+        _ → fail "unexpected expression in statement position"
+    ]
+ where
+  toVar ∷ AnnExp → Parser (Annotated Comments VarF)
+  toVar = \case
+    (comments, Var (comments', v)) → pure (comments <> comments', v)
+    _ → fail "expected a variable on the left of '='"

--- a/lib/Language/PureScript/Backend/Lua/Printer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Printer.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Backend.Lua.Printer where
 
-import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as Text
 import Language.PureScript.Backend.Lua.Name qualified as Lua
 import Language.PureScript.Backend.Lua.Types
 import Language.PureScript.Backend.Lua.Types qualified as Lua
@@ -12,6 +12,7 @@ import Prettyprinter
   , dquotes
   , flatAlt
   , group
+  , hardline
   , hsep
   , indent
   , lbrace
@@ -31,54 +32,173 @@ type ADoc = Doc ()
 type PADoc = (Precedence, ADoc)
 
 printLuaChunk ∷ Lua.Chunk → ADoc
-printLuaChunk = vsep . fmap printStatement
+printLuaChunk = vsep . printStatements . fmap Lua.ann
+
+{- | Print a statement sequence, terminating a statement with @;@ whenever
+the next one starts with an open paren: @local a = f\n(g).x = 1@ would
+otherwise read as the call @f(g)@ (Lua 5.1 rejects it as "ambiguous
+syntax"), and the semicolon after the previous statement is the only
+separator its grammar allows.
+-}
+printStatements ∷ [Annotated Comments StatementF] → [ADoc]
+printStatements statements =
+  zipWith
+    (\stat next → printStatementA stat <> separator next)
+    statements
+    (fmap Just (drop 1 statements) <> [Nothing])
+ where
+  separator = \case
+    Just (Ann next) | startsWithOpenParen next → ";"
+    _ → mempty
+
+{- | Whether the statement's printed form begins with @(@.
+Mirrors 'wrapIndexedPrefix' and 'wrapCallTarget'.
+-}
+startsWithOpenParen ∷ StatementF a → Bool
+startsWithOpenParen = \case
+  Assign (Ann variable :| _) _values → varStarts variable
+  CallStatement (Ann e) → prefixStarts e
+  _ → False
+ where
+  varStarts ∷ VarF a → Bool
+  varStarts = \case
+    VarName _ → False
+    VarIndex (Ann e) _ → indexedPrefixStarts e
+    VarField (Ann e) _ → indexedPrefixStarts e
+  -- 'wrapIndexedPrefix' prints every non-'Var' base parenthesised.
+  indexedPrefixStarts ∷ ExpF a → Bool
+  indexedPrefixStarts = \case
+    Var (Ann v) → varStarts v
+    _ → True
+  -- 'wrapCallTarget' also lets (method) calls through bare.
+  prefixStarts ∷ ExpF a → Bool
+  prefixStarts = \case
+    Var (Ann v) → varStarts v
+    FunctionCall (Ann f) _args → prefixStarts f
+    MethodCall (Ann o) _name _args → prefixStarts o
+    _ → True
+
+{- | Comments attached to a node print on their own lines before it. The
+'hardline' is deliberate: a line comment must be terminated by a newline, so
+any enclosing 'group' falls back to the vertical layout.
+-}
+withComments ∷ Comments → ADoc → ADoc
+withComments comments doc =
+  foldr
+    (\c d → pretty c <> hardline <> d)
+    doc
+    (concatMap Text.lines comments)
+
+printStatementA ∷ Annotated Comments StatementF → ADoc
+printStatementA (comments, statement) =
+  withComments comments (printStatement statement)
 
 printStatement ∷ Lua.Statement → ADoc
 printStatement = \case
-  Lua.Assign (Ann variable) (Ann expr) →
-    printAssign variable expr
-  Lua.Local name value →
-    printLocal name (printedExp . unAnn <$> value)
-  Lua.IfThenElse (Ann predicate) thenBlock elseBlock →
-    printIfThenElse predicate (unAnn <$> thenBlock) (unAnn <$> elseBlock)
-  Lua.Return (Ann expr) →
-    "return" <+> printedExp expr
-  Lua.ForeignSourceStat code →
-    pretty code
-
-printAssign ∷ Lua.Var → Lua.Exp → ADoc
-printAssign variable expr = printVar variable <+> "=" <+> printedExp expr
+  Lua.Assign variables values →
+    commaSep (printVar . unAnn <$> toList variables)
+      <+> "="
+      <+> commaSep (printedExpA <$> toList values)
+  Lua.Local names values →
+    printLocal (toList names) (printedExpA <$> values)
+  Lua.IfThenElse predicate thenBlock elseBlock →
+    printIfThenElse predicate thenBlock elseBlock
+  Lua.Return values →
+    case values of
+      [] → "return"
+      _ → "return" <+> commaSep (printedExpA <$> values)
+  Lua.CallStatement e →
+    printedExpA e
+  Lua.Do body →
+    sep ["do", flex (printStatements body), "end"]
+  Lua.While predicate body →
+    sep
+      [ hsep ["while", printedExpA predicate, "do"]
+      , flex (printStatements body)
+      , "end"
+      ]
+  Lua.Repeat body predicate →
+    sep
+      [ "repeat"
+      , flex (printStatements body)
+      , "until" <+> printedExpA predicate
+      ]
+  Lua.ForNum name start limit step body →
+    sep
+      [ hsep
+          [ "for"
+          , printName name
+          , "="
+          , commaSep
+              ( printedExpA
+                  <$> ([start, limit] <> maybeToList step)
+              )
+          , "do"
+          ]
+      , flex (printStatements body)
+      , "end"
+      ]
+  Lua.ForIn names exprs body →
+    sep
+      [ hsep
+          [ "for"
+          , commaSep (printName <$> toList names)
+          , "in"
+          , commaSep (printedExpA <$> toList exprs)
+          , "do"
+          ]
+      , flex (printStatements body)
+      , "end"
+      ]
+  Lua.LocalFunction name params body →
+    sep
+      [ group ("local function" <+> printName name <> printParams params)
+      , flex (printStatements body)
+      , "end"
+      ]
+  Lua.Break → "break"
 
 -- | Printed expression without a precedence
 printedExp ∷ Lua.Exp → ADoc
 printedExp = snd . printExp
 
+printedExpA ∷ Annotated Comments ExpF → ADoc
+printedExpA = snd . printExpA
+
+printExpA ∷ Annotated Comments ExpF → PADoc
+printExpA (comments, e) =
+  let (precedence, doc) = printExp e
+   in (precedence, withComments comments doc)
+
 printExp ∷ Lua.Exp → PADoc
 printExp = \case
   Lua.Nil → (PrecAtom, "nil")
   Lua.Boolean b → (PrecAtom, if b then "true" else "false")
+  -- A negative literal renders with a leading minus, which Lua reads as the
+  -- unary operator, so it must carry the unary precedence: as an atom, "-2"
+  -- as the base of `^` would print unparenthesised and reassociate to
+  -- -(2 ^ e).
   Lua.Float f
     | isNaN f → (PrecAtom, "(0/0)")
     | isInfinite f && f > 0 → (PrecAtom, "math.huge")
     | isInfinite f → (prec Lua.Negate, "-math.huge")
+    | f < 0 → (prec Lua.Negate, pretty f)
     | otherwise → (PrecAtom, pretty f)
-  Lua.Integer i → (PrecAtom, pretty i)
+  Lua.Integer i
+    | i < 0 → (prec Lua.Negate, pretty i)
+    | otherwise → (PrecAtom, pretty i)
   Lua.String t → (PrecAtom, dquotes (pretty t))
-  Lua.Function args body →
-    let argNames =
-          args >>= \case
-            Ann (ParamNamed n) → [n]
-            Ann ParamUnused → []
-     in (PrecFunction, printFunction argNames (unAnn <$> body))
-  Lua.TableCtor rows → (PrecTable, printTableCtor (unAnn <$> rows))
-  Lua.UnOp op (Ann a) → printUnaryOp op (printExp a)
-  Lua.BinOp op (Ann l) (Ann r) → printBinaryOp op (printExp l) (printExp r)
+  Lua.Vararg → (PrecAtom, "...")
+  Lua.Function params body → (PrecFunction, printFunction params body)
+  Lua.TableCtor rows → (PrecTable, printTableCtor rows)
+  Lua.UnOp op a → printUnaryOp op (printExpA a)
+  Lua.BinOp op l r → printBinaryOp op (printExpA l) (printExpA r)
   Lua.Var (Ann v) → (PrecAtom, printVar v)
   Lua.FunctionCall (Ann prefix) args →
-    ( PrecPrefix
-    , printFunctionCall prefix (printExp . unAnn <$> args)
-    )
-  Lua.ForeignSourceExp code → (PrecFunction, pretty code)
+    (PrecPrefix, printFunctionCall prefix (printExpA <$> args))
+  Lua.MethodCall (Ann obj) name args →
+    (PrecPrefix, printMethodCall obj name (printExpA <$> args))
+  Lua.Paren e → (PrecAtom, parens (printedExpA e))
 
 printUnaryOp ∷ Lua.UnaryOp → PADoc → PADoc
 printUnaryOp op (_, a) = (prec op, pretty (sym op) <> parens a)
@@ -92,35 +212,56 @@ printBinaryOp op l r =
     Lua.LeftAssoc → (wrapPrec op, wrapPrecGte op)
     Lua.RightAssoc → (wrapPrecGte op, wrapPrec op)
 
-printFunction ∷ [Lua.Name] → [Lua.Statement] → ADoc
+printFunction
+  ∷ [Annotated Comments ParamF] → [Annotated Comments StatementF] → ADoc
 printFunction params body =
-  sep [group ("function" <> tupled fparams), flex fbody, "end"]
+  sep [group ("function" <> printParams params), flex fbody, "end"]
  where
-  fparams = printName <$> params
-  fbody = printStatement <$> body
+  fbody = printStatements body
 
-printTableCtor ∷ [Lua.TableRow] → ADoc
+printParams ∷ [Annotated Comments ParamF] → ADoc
+printParams params =
+  tupled do
+    Ann param ← params
+    case param of
+      ParamNamed n → [printName n]
+      ParamUnused → []
+      ParamVararg → ["..."]
+
+printTableCtor ∷ [Annotated Comments TableRowF] → ADoc
 printTableCtor [] = "{}"
 printTableCtor tableRows = sep [lbrace, flex rows, rbrace]
  where
-  rows = punctuate comma $ fmap printRow tableRows
+  rows = punctuate comma $ fmap printRowA tableRows
+
+printRowA ∷ Annotated Comments TableRowF → ADoc
+printRowA (comments, row) = withComments comments (printRow row)
 
 printRow ∷ Lua.TableRow → ADoc
 printRow = \case
-  Lua.TableRowKV (Ann kexp) (Ann vexp) →
-    brackets (printedExp kexp) <+> "=" <+> printedExp vexp
-  Lua.TableRowNV name (Ann vexp) →
-    printName name <+> "=" <+> printedExp vexp
+  Lua.TableRowKV k vexp →
+    brackets (printedExpA k) <+> "=" <+> printedExpA vexp
+  Lua.TableRowNV name vexp →
+    printName name <+> "=" <+> printedExpA vexp
+  Lua.TableRowV vexp →
+    printedExpA vexp
 
 printVar ∷ Lua.Var → ADoc
 printVar = \case
   Lua.VarName name → printName name
-  Lua.VarIndex (Ann e) (Ann i) → wrapIndexedPrefix e <> brackets (printedExp i)
+  Lua.VarIndex (Ann e) i → wrapIndexedPrefix e <> brackets (printedExpA i)
   Lua.VarField (Ann e) n → wrapIndexedPrefix e <> "." <> printName n
 
 printFunctionCall ∷ Lua.Exp → [PADoc] → ADoc
 printFunctionCall prefixExp args =
   wrapCallTarget prefixExp
+    <> parens (hsep (punctuate comma (snd <$> args)))
+
+printMethodCall ∷ Lua.Exp → Lua.Name → [PADoc] → ADoc
+printMethodCall prefixExp name args =
+  wrapCallTarget prefixExp
+    <> ":"
+    <> printName name
     <> parens (hsep (punctuate comma (snd <$> args)))
 
 {- | Lua's grammar allows a bare variable before '.' or '[...]'; every other
@@ -141,37 +282,40 @@ operator results -- must be parenthesised there.
 wrapCallTarget ∷ Lua.Exp → ADoc
 wrapCallTarget e@(Lua.Var _) = printedExp e
 wrapCallTarget e@(Lua.FunctionCall _ _) = printedExp e
+wrapCallTarget e@(Lua.MethodCall {}) = printedExp e
 wrapCallTarget e = parens (printedExp e)
 
-printLocal ∷ Lua.Name → Maybe ADoc → ADoc
-printLocal name value =
-  "local" <+> case value of
-    Nothing → printName name
-    Just v → printName name <+> "=" <+> v
+printLocal ∷ [Lua.Name] → [ADoc] → ADoc
+printLocal names values =
+  "local" <+> case values of
+    [] → commaSep (printName <$> names)
+    _ → commaSep (printName <$> names) <+> "=" <+> commaSep values
 
 printRequire ∷ Lua.ChunkName → ADoc
 printRequire name =
   vsep ["require" <> parens (dquotes (printChunkName name)), ""]
 
-printBlock ∷ NonEmpty Statement → ADoc
-printBlock (NE.toList → statements) =
-  sep ["do", flex (printStatement <$> statements), "end"]
-
 printIfThenElse
-  ∷ Lua.Exp
-  → [Statement]
-  → [Statement]
+  ∷ Annotated Comments ExpF
+  → [Annotated Comments StatementF]
+  → [Annotated Comments StatementF]
   → ADoc
 printIfThenElse predicate thenBlock elseBlock =
   sep . join $
-    [ [hsep ["if", printedExp predicate, "then"], thenDoc]
-    , if not (null elseBlock)
-        then ["else", flex (printStatement <$> elseBlock)]
-        else []
-    , ["end"]
-    ]
+    [[hsep ["if", printedExpA predicate, "then"], thenDoc]]
+      <> elseChain elseBlock
+      <> [["end"]]
  where
-  thenDoc = flex (printStatement <$> thenBlock)
+  thenDoc = flex (printStatements thenBlock)
+  -- An else-block holding exactly one (comment-free) 'IfThenElse' prints as
+  -- an @elseif@ continuation of the same statement, mirroring how the parser
+  -- reads @elseif@ chains into nested else-blocks.
+  elseChain = \case
+    [] → []
+    [([], Lua.IfThenElse p tb eb)] →
+      [hsep ["elseif", printedExpA p, "then"], flex (printStatements tb)]
+        : elseChain eb
+    stats → [["else", flex (printStatements stats)]]
 
 printName ∷ Lua.Name → ADoc
 printName = pretty
@@ -181,6 +325,9 @@ printChunkName = pretty
 
 --------------------------------------------------------------------------------
 -- Utility functions -----------------------------------------------------------
+
+commaSep ∷ [ADoc] → ADoc
+commaSep = hsep . punctuate comma
 
 flex ∷ Foldable t ⇒ t ADoc → ADoc
 flex b =

--- a/lib/Language/PureScript/Backend/Lua/Traversal.hs
+++ b/lib/Language/PureScript/Backend/Lua/Traversal.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-
 module Language.PureScript.Backend.Lua.Traversal where
 
 import Language.PureScript.Backend.Lua.Types
@@ -20,6 +18,9 @@ everywhereInChunkM
   → (Chunk → m Chunk)
 everywhereInChunkM f g = traverse (everywhereStatM g f)
 
+{- | Bottom-up rewriting. Rebuilt nodes keep the annotations of the originals:
+a rewrite that returns its argument unchanged is comment-preserving.
+-}
 everywhereExpM
   ∷ ∀ m
    . Monad m
@@ -28,27 +29,45 @@ everywhereExpM
   → (Exp → m Exp)
 everywhereExpM f g = goe
  where
+  goe ∷ Exp → m Exp
   goe = \case
-    Var (Ann v) → case v of
-      VarIndex (Ann e1) (Ann e2) → f =<< varIndex <$> goe e1 <*> goe e2
-      VarField (Ann e) n → f . (`varField` n) =<< goe e
-      VarName n → f (varName n)
-    Function names statements →
-      f . functionDef (snd <$> names)
-        =<< forM statements (everywhereStatM g f . unAnn)
-    TableCtor (fmap unAnn → rows) → do
-      tableRows ← forM rows \case
-        TableRowKV (Ann k) (Ann v) → tableRowKV <$> goe k <*> goe v
-        TableRowNV n (Ann e) → tableRowNV n <$> goe e
-      f $ table tableRows
-    UnOp op (Ann e) →
-      f . unOp op =<< goe e
-    BinOp op (Ann e1) (Ann e2) →
-      f =<< binOp op <$> goe e1 <*> goe e2
-    FunctionCall (Ann fn) (fmap unAnn → args) →
-      f =<< functionCall <$> goe fn <*> forM args goe
+    Var (c, v) → f . Var . (c,) =<< goVar v
+    Function params body →
+      f . Function params =<< traverse (traverse gos) body
+    TableCtor rows →
+      f . TableCtor =<< forM rows \(c, row) → (c,) <$> goRow row
+    UnOp op e →
+      f . UnOp op =<< goAnn e
+    BinOp op e1 e2 →
+      f =<< BinOp op <$> goAnn e1 <*> goAnn e2
+    FunctionCall fn args →
+      f =<< FunctionCall <$> goAnn fn <*> traverse goAnn args
+    MethodCall obj n args →
+      f =<< MethodCall <$> goAnn obj <*> pure n <*> traverse goAnn args
+    Paren e → f . Paren =<< goAnn e
     other → f other
 
+  goAnn ∷ Annotated Comments ExpF → m (Annotated Comments ExpF)
+  goAnn = traverse goe
+
+  goVar ∷ VarF Comments → m (VarF Comments)
+  goVar = \case
+    VarName n → pure (VarName n)
+    VarIndex e1 e2 → VarIndex <$> goAnn e1 <*> goAnn e2
+    VarField e n → (`VarField` n) <$> goAnn e
+
+  goRow ∷ TableRowF Comments → m (TableRowF Comments)
+  goRow = \case
+    TableRowKV k v → TableRowKV <$> goAnn k <*> goAnn v
+    TableRowNV n e → TableRowNV n <$> goAnn e
+    TableRowV e → TableRowV <$> goAnn e
+
+  gos ∷ Statement → m Statement
+  gos = everywhereStatM g f
+
+{- | Bottom-up rewriting. Rebuilt nodes keep the annotations of the originals:
+a rewrite that returns its argument unchanged is comment-preserving.
+-}
 everywhereStatM
   ∷ ∀ m
    . Monad m
@@ -57,212 +76,43 @@ everywhereStatM
   → (Statement → m Statement)
 everywhereStatM f g = go
  where
+  goe ∷ Exp → m Exp
   goe = everywhereExpM g f
+
+  goAnn ∷ Annotated Comments ExpF → m (Annotated Comments ExpF)
+  goAnn = traverse goe
+
+  goVar ∷ Annotated Comments VarF → m (Annotated Comments VarF)
+  goVar (c, v) =
+    (c,) <$> case v of
+      VarName n → pure (VarName n)
+      VarIndex e1 e2 → VarIndex <$> goAnn e1 <*> goAnn e2
+      VarField e n → (`VarField` n) <$> goAnn e
+
+  goBlock ∷ [Annotated Comments StatementF] → m [Annotated Comments StatementF]
+  goBlock = traverse (traverse go)
+
+  go ∷ Statement → m Statement
   go = \case
-    Assign (Ann variable) (Ann value) → f . assign variable =<< goe value
-    Local name val → f . local name =<< forM val (goe . unAnn)
-    IfThenElse (Ann p) tb eb → do
-      predicate ← goe p
-      thenBranch ← forM tb (go . unAnn)
-      elseBranch ← forM eb (go . unAnn)
-      f $ ifThenElse predicate thenBranch elseBranch
-    Return (Ann e) → f . Return . ann =<< goe e
-    ForeignSourceStat src → f $ ForeignSourceStat src
-
---------------------------------------------------------------------------------
--- Annotating ------------------------------------------------------------------
-
-data Annotator m f f' = Annotator
-  { unAnnotate ∷ ∀ g. Annotated f g → g f
-  -- ^ How to remove an annotation
-  , annotateStat ∷ StatementF f' → m (Annotated f' StatementF)
-  -- ^ How to annotate a statement
-  , annotateExp ∷ ExpF f' → m (Annotated f' ExpF)
-  -- ^ How to annotate an expression
-  , annotateParam ∷ ParamF f' → m (Annotated f' ParamF)
-  -- ^ How to annotate a function parameter
-  , annotateVar ∷ VarF f' → m (Annotated f' VarF)
-  -- ^ How to annotate a variable
-  , annotateRow ∷ TableRowF f' → m (Annotated f' TableRowF)
-  -- ^ How to annotate a table row
-  }
-
-unAnnotateStatement
-  ∷ (∀ g. Annotated f g → g f) → Annotated f StatementF → Statement
-unAnnotateStatement unAnnotate =
-  unAnn
-    . runIdentity
-    . annotateStatementInsideOutM
-      Annotator
-        { unAnnotate
-        , annotateStat = pure . ann
-        , annotateExp = pure . ann
-        , annotateParam = pure . ann
-        , annotateVar = pure . ann
-        , annotateRow = pure . ann
-        }
-
---------------------------------------------------------------------------------
--- Inside-out ------------------------------------------------------------------
-
-annotateStatementInsideOutM
-  ∷ ∀ m f f'
-   . Monad m
-  ⇒ Annotator m f f'
-  → (Annotated f StatementF → m (Annotated f' StatementF))
-annotateStatementInsideOutM annotator@Annotator {..} stat =
-  case unAnnotate stat of
-    Assign variable value → do
-      indexedVars ← goV variable
-      indexedVals ← goE value
-      annotateStat $ Assign indexedVars indexedVals
-    Local names vals → annotateStat . Local names =<< forM vals goE
-    IfThenElse p tb eb → do
-      iPred ← goE p
-      iThen ← traverse goS tb
-      iElse ← traverse goS eb
-      annotateStat $ IfThenElse iPred iThen iElse
-    Return e → annotateStat . Return =<< goE e
-    ForeignSourceStat src → annotateStat $ ForeignSourceStat src
- where
-  goS = annotateStatementInsideOutM annotator
-  goE = annotateExpInsideOutM annotator
-  goV = annotateVarInsideOutM annotator
-
-annotateExpInsideOutM
-  ∷ ∀ m f f'
-   . Monad m
-  ⇒ Annotator m f f'
-  → (Annotated f ExpF → m (Annotated f' ExpF))
-annotateExpInsideOutM annotator@Annotator {..} expf =
-  case unAnnotate expf of
-    Var v → annotateExp . Var =<< goV v
-    Function params stats → do
-      paramNames ← forM params \case
-        (_, ParamNamed n) → annotateParam (ParamNamed n)
-        (_, ParamUnused) → annotateParam ParamUnused
-      aStats ← forM stats goS
-      annotateExp $ Function paramNames aStats
-    TableCtor rows →
-      annotateExp . TableCtor =<< forM rows \row →
-        case unAnnotate row of
-          TableRowKV k v → annotateRow =<< TableRowKV <$> goE k <*> goE v
-          TableRowNV n e → annotateRow . TableRowNV n =<< goE e
-    UnOp op e → annotateExp . UnOp op =<< goE e
-    BinOp op e1 e2 → annotateExp =<< BinOp op <$> goE e1 <*> goE e2
-    FunctionCall fn args →
-      annotateExp =<< FunctionCall <$> goE fn <*> forM args goE
-    Nil → annotateExp Nil
-    Boolean b → annotateExp $ Boolean b
-    Integer i → annotateExp $ Integer i
-    Float f → annotateExp $ Float f
-    String s → annotateExp $ String s
-    ForeignSourceExp src → annotateExp $ ForeignSourceExp src
- where
-  goS = annotateStatementInsideOutM annotator
-  goE = annotateExpInsideOutM annotator
-  goV = annotateVarInsideOutM annotator
-
-annotateVarInsideOutM
-  ∷ ∀ m f f'
-   . Monad m
-  ⇒ Annotator m f f'
-  → (Annotated f VarF → m (Annotated f' VarF))
-annotateVarInsideOutM annotator@Annotator {..} =
-  unAnnotate >>> \case
-    VarName qualifiedName → annotateVar $ VarName qualifiedName
-    VarIndex e1 e2 → annotateVar =<< VarIndex <$> goE e1 <*> goE e2
-    VarField e name → annotateVar . (`VarField` name) =<< goE e
- where
-  goE = annotateExpInsideOutM annotator
-
---------------------------------------------------------------------------------
--- Outside-in ------------------------------------------------------------------
-
-data Visitor m a = Visitor
-  { aroundChunk ∷ [Annotated a StatementF] → m [Annotated a StatementF]
-  , beforeStat ∷ Annotated a StatementF → m (Annotated a StatementF)
-  , afterStat ∷ StatementF a → m (StatementF a)
-  , beforeExp ∷ Annotated a ExpF → m (Annotated a ExpF)
-  , afterExp ∷ ExpF a → m (ExpF a)
-  , beforeVar ∷ Annotated a VarF → m (Annotated a VarF)
-  , afterVar ∷ VarF a → m (VarF a)
-  , beforeRow ∷ Annotated a TableRowF → m (Annotated a TableRowF)
-  , afterRow ∷ TableRowF a → m (TableRowF a)
-  }
-
-makeVisitor ∷ Applicative m ⇒ Visitor m a
-makeVisitor =
-  Visitor
-    { aroundChunk = pure
-    , beforeStat = pure
-    , afterStat = pure
-    , beforeExp = pure
-    , afterExp = pure
-    , beforeVar = pure
-    , afterVar = pure
-    , beforeRow = pure
-    , afterRow = pure
-    }
-
-visitStatementM
-  ∷ Monad m
-  ⇒ Visitor m a
-  → (Annotated a StatementF → m (Annotated a StatementF))
-visitStatementM visitor@Visitor {..} stat = do
-  let goS = visitStatementM visitor
-      goE = visitExpM visitor
-      goV = visitVarM visitor
-  beforeStat stat >>= traverse \case
-    Assign variable value → do
-      indexedVars ← goV variable
-      indexedVals ← goE value
-      afterStat $ Assign indexedVars indexedVals
-    Local names vals →
-      afterStat . Local names =<< forM vals goE
-    IfThenElse p tb eb → do
-      iPred ← goE p
-      iThen ← traverse goS tb
-      iElse ← traverse goS eb
-      afterStat $ IfThenElse iPred iThen iElse
-    Return e → afterStat . Return =<< goE e
-    other → afterStat other
-
-visitExpM
-  ∷ ∀ m a
-   . Monad m
-  ⇒ Visitor m a
-  → (Annotated a ExpF → m (Annotated a ExpF))
-visitExpM visitor@Visitor {..} expf = do
-  let goS = visitStatementM visitor
-      goE = visitExpM visitor
-      goV = visitVarM visitor
-  beforeExp expf >>= traverse \case
-    Var v →
-      afterExp . Var =<< goV v
-    Function names stats →
-      afterExp . Function names =<< forM stats goS
-    TableCtor rows →
-      TableCtor <$> forM rows do
-        beforeRow >=> traverse \case
-          TableRowKV k v → afterRow =<< TableRowKV <$> goE k <*> goE v
-          TableRowNV n e → afterRow . TableRowNV n =<< goE e
-    UnOp op e →
-      afterExp . UnOp op =<< goE e
-    BinOp op e1 e2 →
-      afterExp =<< BinOp op <$> goE e1 <*> goE e2
-    FunctionCall fn args →
-      afterExp =<< FunctionCall <$> goE fn <*> forM args goE
-    other → afterExp other
-
-visitVarM
-  ∷ ∀ m a
-   . Monad m
-  ⇒ Visitor m a
-  → (Annotated a VarF → m (Annotated a VarF))
-visitVarM visitor@Visitor {..} variable = do
-  let goE = visitExpM visitor
-  beforeVar variable >>= traverse \case
-    VarName qualifiedName → afterVar $ VarName qualifiedName
-    VarIndex e1 e2 → afterVar =<< VarIndex <$> goE e1 <*> goE e2
-    VarField e name → afterVar . (`VarField` name) =<< goE e
+    Assign vars vals →
+      f =<< Assign <$> traverse goVar vars <*> traverse goAnn vals
+    Local names vals → f . Local names =<< traverse goAnn vals
+    IfThenElse p tb eb →
+      f =<< IfThenElse <$> goAnn p <*> goBlock tb <*> goBlock eb
+    Return es → f . Return =<< traverse goAnn es
+    CallStatement e → f . CallStatement =<< goAnn e
+    Do body → f . Do =<< goBlock body
+    While p body → f =<< While <$> goAnn p <*> goBlock body
+    Repeat body p → f =<< Repeat <$> goBlock body <*> goAnn p
+    ForNum n start limit step body →
+      f
+        =<< ForNum n
+          <$> goAnn start
+          <*> goAnn limit
+          <*> traverse goAnn step
+          <*> goBlock body
+    ForIn names es body →
+      f =<< ForIn names <$> traverse goAnn es <*> goBlock body
+    LocalFunction n params body →
+      f . LocalFunction n params =<< goBlock body
+    Break → f Break

--- a/lib/Language/PureScript/Backend/Lua/Types.hs
+++ b/lib/Language/PureScript/Backend/Lua/Types.hs
@@ -22,6 +22,15 @@ newtype ChunkName = ChunkName Text
   deriving stock (Show)
   deriving newtype (Pretty)
 
+{- | Comments attached to an AST node: each element is one comment verbatim,
+including its markers (@--@ or @--[[ ... ]]@). The Lua parser
+('Language.PureScript.Backend.Lua.Parser') fills these slots with the
+comments preceding a node; the printer emits them back in front of the
+node. Code-generated nodes carry no comments ('ann' annotates with
+'mempty').
+-}
+type Comments = [Text]
+
 type Annotated (a ∷ Type) (f ∷ Type → Type) = (a, f a)
 
 pattern Ann ∷ b → (a, b)
@@ -31,8 +40,9 @@ pattern Ann fa ← (_ann, fa)
 data ParamF a
   = ParamNamed Name
   | ParamUnused
+  | ParamVararg
 
-type Param = ParamF ()
+type Param = ParamF Comments
 
 deriving stock instance Eq a ⇒ Eq (ParamF a)
 deriving stock instance Ord a ⇒ Ord (ParamF a)
@@ -43,7 +53,7 @@ data VarF a
   | VarIndex (Annotated a ExpF) (Annotated a ExpF)
   | VarField (Annotated a ExpF) Name
 
-type Var = VarF ()
+type Var = VarF Comments
 
 deriving stock instance Eq a ⇒ Eq (VarF a)
 deriving stock instance Ord a ⇒ Ord (VarF a)
@@ -52,8 +62,10 @@ deriving stock instance Show a ⇒ Show (VarF a)
 data TableRowF ann
   = TableRowKV (Annotated ann ExpF) (Annotated ann ExpF)
   | TableRowNV Name (Annotated ann ExpF)
+  | -- | Array-part row: @{ e1, e2 }@ assigns to consecutive integer keys.
+    TableRowV (Annotated ann ExpF)
 
-type TableRow = TableRowF ()
+type TableRow = TableRowF Comments
 
 deriving stock instance Eq a ⇒ Eq (TableRowF a)
 deriving stock instance Ord a ⇒ Ord (TableRowF a)
@@ -216,29 +228,53 @@ instance HasSymbol BinaryOp where
     Mod → "%"
     Exp → "^"
 
+{- | The string payload of a 'String' literal is kept in /source form/: the
+text between the quotes of a double-quoted Lua string literal, escape
+sequences unexpanded. The printer emits it verbatim between double quotes.
+Keeping escapes unexpanded is load-bearing: a @\\255@ escape denotes a
+single byte on the Lua 5.1 target, which decoded-and-reencoded Text could
+not represent (see the Char quirk in docs/QUIRKS.md). Consequently the
+payload must never contain a raw newline or an unescaped @"@ — the parser
+normalizes both when converting from other quoting styles.
+-}
 data ExpF ann
   = Nil
   | Boolean Bool
   | Integer Integer
   | Float Double
   | String Text
+  | Vararg
   | Function [Annotated ann ParamF] [Annotated ann StatementF]
   | TableCtor [Annotated ann TableRowF]
   | UnOp UnaryOp (Annotated ann ExpF)
   | BinOp BinaryOp (Annotated ann ExpF) (Annotated ann ExpF)
   | Var (Annotated ann VarF)
   | FunctionCall (Annotated ann ExpF) [Annotated ann ExpF]
-  | ForeignSourceExp Text
+  | MethodCall (Annotated ann ExpF) Name [Annotated ann ExpF]
+  | {- | Explicit parentheses around a multi-valued expression (a call or
+    '...'), which Lua adjusts to exactly one value. Grouping parens around
+    single-valued expressions are not represented; the printer re-derives
+    those from precedence.
+    -}
+    Paren (Annotated ann ExpF)
 
-type Exp = ExpF ()
+type Exp = ExpF Comments
 
 deriving stock instance Eq a ⇒ Eq (ExpF a)
 deriving stock instance Ord a ⇒ Ord (ExpF a)
 deriving stock instance Show a ⇒ Show (ExpF a)
 
 data StatementF ann
-  = Assign (Annotated ann VarF) (Annotated ann ExpF)
-  | Local Name (Maybe (Annotated ann ExpF))
+  = Assign
+      (NonEmpty (Annotated ann VarF))
+      -- ^ variables (multiple assignment assigns simultaneously)
+      (NonEmpty (Annotated ann ExpF))
+      -- ^ values
+  | Local
+      (NonEmpty Name)
+      -- ^ declared names
+      [Annotated ann ExpF]
+      -- ^ initializers; @[]@ declares without a value
   | IfThenElse
       (Annotated ann ExpF)
       -- ^ predicate
@@ -246,10 +282,34 @@ data StatementF ann
       -- ^ then block
       [Annotated ann StatementF]
       -- ^ else block
-  | Return (Annotated ann ExpF)
-  | ForeignSourceStat Text
+  | Return [Annotated ann ExpF]
+  | CallStatement (Annotated ann ExpF)
+  | Do [Annotated ann StatementF]
+  | While (Annotated ann ExpF) [Annotated ann StatementF]
+  | Repeat [Annotated ann StatementF] (Annotated ann ExpF)
+  | ForNum
+      Name
+      -- ^ loop variable
+      (Annotated ann ExpF)
+      -- ^ start
+      (Annotated ann ExpF)
+      -- ^ limit
+      (Maybe (Annotated ann ExpF))
+      -- ^ step
+      [Annotated ann StatementF]
+  | ForIn
+      (NonEmpty Name)
+      -- ^ loop variables
+      (NonEmpty (Annotated ann ExpF))
+      -- ^ iterator expressions
+      [Annotated ann StatementF]
+  | {- | @local function f() … end@; distinct from @local f = function() … end@
+    in that @f@ is in scope inside the body (self-recursion).
+    -}
+    LocalFunction Name [Annotated ann ParamF] [Annotated ann StatementF]
+  | Break
 
-type Statement = StatementF ()
+type Statement = StatementF Comments
 
 deriving stock instance Eq a ⇒ Eq (StatementF a)
 deriving stock instance Ord a ⇒ Ord (StatementF a)
@@ -258,8 +318,8 @@ deriving stock instance Show a ⇒ Show (StatementF a)
 --------------------------------------------------------------------------------
 -- Smarter constructors --------------------------------------------------------
 
-ann ∷ f () → Annotated () f
-ann f = ((), f)
+ann ∷ f Comments → Annotated Comments f
+ann f = ([], f)
 
 unAnn ∷ Annotated a f → f a
 unAnn = snd
@@ -268,25 +328,25 @@ var ∷ Var → Exp
 var = Var . ann
 
 assign ∷ Var → Exp → Statement
-assign v e = Assign (ann v) (ann e)
+assign v e = Assign (pure (ann v)) (pure (ann e))
 
 assignVar ∷ Name → Exp → Statement
 assignVar name = assign (VarName name)
 
 local ∷ Name → Maybe Exp → Statement
-local name expr = Local name (ann <$> expr)
+local name expr = Local (pure name) (ann <$> maybeToList expr)
 
 local1 ∷ Name → Exp → Statement
-local1 name expr = Local name (Just (ann expr))
+local1 name expr = Local (pure name) [ann expr]
 
 local0 ∷ Name → Statement
-local0 name = Local name Nothing
+local0 name = Local (pure name) []
 
 ifThenElse ∷ Exp → Chunk → Chunk → Statement
 ifThenElse i t e = IfThenElse (ann i) (ann <$> t) (ann <$> e)
 
 return ∷ Exp → Statement
-return = Return . ann
+return e = Return [ann e]
 
 chunkToExpression ∷ Chunk → Exp
 chunkToExpression ss = functionCall (Function [] (ann <$> ss)) []
@@ -311,6 +371,9 @@ functionDef params body = Function (ann <$> params) (ann <$> body)
 functionCall ∷ Exp → [Exp] → Exp
 functionCall f args = FunctionCall (ann f) (ann <$> args)
 
+methodCall ∷ Exp → Name → [Exp] → Exp
+methodCall obj n args = MethodCall (ann obj) n (ann <$> args)
+
 unOp ∷ UnaryOp → Exp → Exp
 unOp op e = UnOp op (ann e)
 
@@ -324,7 +387,7 @@ pun ∷ Name → TableRow
 pun n = TableRowNV n (ann (varName n))
 
 thunk ∷ Exp → Exp
-thunk e = scope [Return (ann e)]
+thunk e = scope [Return [ann e]]
 
 scope ∷ Chunk → Exp
 scope body = functionCall (Function [] (ann <$> body)) []
@@ -415,3 +478,6 @@ tableRowKV k v = TableRowKV (ann k) (ann v)
 
 tableRowNV ∷ Name → Exp → TableRow
 tableRowNV n v = TableRowNV n (ann v)
+
+tableRowV ∷ Exp → TableRow
+tableRowV = TableRowV . ann

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -149,6 +149,7 @@ library
     Language.PureScript.Backend.Lua.Name
     Language.PureScript.Backend.Lua.NestingCheck
     Language.PureScript.Backend.Lua.Optimizer
+    Language.PureScript.Backend.Lua.Parser
     Language.PureScript.Backend.Lua.Printer
     Language.PureScript.Backend.Lua.Run
     Language.PureScript.Backend.Lua.Traversal
@@ -186,19 +187,24 @@ test-suite spec
     Language.PureScript.Backend.IR.SpecUtils
     Language.PureScript.Backend.IR.Types.Spec
     Language.PureScript.Backend.IR.Uniquify.Spec
+    Language.PureScript.Backend.Lua.Differential.Spec
+    Language.PureScript.Backend.Lua.Gen
     Language.PureScript.Backend.Lua.Golden.Spec
     Language.PureScript.Backend.Lua.Linker.Foreign.Spec
     Language.PureScript.Backend.Lua.NestingCheck.Spec
     Language.PureScript.Backend.Lua.Optimizer.Spec
+    Language.PureScript.Backend.Lua.Parser.Spec
     Language.PureScript.Backend.Lua.Printer.Spec
     Language.PureScript.Backend.Lua.Run.Spec
     Language.PureScript.Backend.Lua.Spec
+    Language.PureScript.Backend.Lua.Traversal.Spec
     Language.PureScript.Backend.Output.Spec
     Language.PureScript.PSString.Spec
     Test.Hspec.Expectations.Pretty
     Test.Hspec.Extra
     Test.Hspec.Golden
     Test.Hspec.Hedgehog.Extended
+    Test.Lua
 
   hs-source-dirs: test
 

--- a/test/Language/PureScript/Backend/Lua/Differential/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Differential/Spec.hs
@@ -1,0 +1,107 @@
+{- | Differential tests against the reference Lua implementation.
+
+The @parse . print ≡ id@ round trip certifies the parser and the printer
+against each other, so a /matched/ pair of defects — the parser misreading a
+construct exactly the way the printer misprints it — is invisible to it.
+The two properties here bring in an arbiter that cannot share such a bug:
+
+  * @luac -p@ must accept everything the printer emits (syntax);
+  * evaluating an expression printed normally and printed with parens around
+    every node must agree inside @lua@ (semantics: the precedence\/
+    associativity tables versus the interpreter, not versus themselves).
+-}
+module Language.PureScript.Backend.Lua.Differential.Spec where
+
+import Data.Text qualified as Text
+import Hedgehog (annotate, evalIO, forAll, (===))
+import Language.PureScript.Backend.Lua.Gen qualified as Gen
+import Language.PureScript.Backend.Lua.Parser qualified as Parser
+import Language.PureScript.Backend.Lua.Parser.Spec (roundTripCorpus)
+import Language.PureScript.Backend.Lua.Printer qualified as Printer
+import Language.PureScript.Backend.Lua.Types (pattern Ann)
+import Language.PureScript.Backend.Lua.Types qualified as Lua
+import Prettyprinter (defaultLayoutOptions, layoutPretty, vsep)
+import Prettyprinter.Render.Text (renderStrict)
+import System.Process.Typed (ExitCode (..))
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec.Extra (annotatingWith)
+import Test.Hspec.Hedgehog.Extended (prop)
+import Test.Lua (luacParse, runLuaFile)
+import Prelude hiding (exp)
+
+spec ∷ Spec
+spec = describe "differential against the reference Lua implementation" do
+  describe "luac accepts everything the printer emits" do
+    prop 100 "generated chunks" do
+      stats ← forAll Gen.block
+      let printed = renderBlock stats
+      annotate (toString printed)
+      (code, out) ← evalIO (luacParse printed)
+      annotate (toString out)
+      code === ExitSuccess
+
+    for_ roundTripCorpus \(title, source) →
+      it (title <> ": source and printed form") do
+        (sourceCode, sourceOut) ← luacParse source
+        sourceCode `shouldBe` ExitSuccess `annotatingWith` toString sourceOut
+        case Parser.parseChunk "<corpus>" source of
+          Left err → expectationFailure (Parser.renderParseError err)
+          Right stats → do
+            (printedCode, printedOut) ← luacParse (renderBlock stats)
+            printedCode
+              `shouldBe` ExitSuccess
+                `annotatingWith` toString printedOut
+
+  prop
+    100
+    "the printer's precedence/associativity agrees with the interpreter"
+    do
+      e ← forAll Gen.evaluableExp
+      let script =
+            Text.unlines
+              [ "local a = " <> renderExp e
+              , "local b = " <> fullParens e
+              , -- Compare inside Lua (bit-for-bit for numbers, no output
+                -- formatting involved); `a ~= a and b ~= b` admits NaN.
+                "os.exit(((a == b) or (a ~= a and b ~= b)) and 0 or 1)"
+              ]
+      annotate (toString script)
+      (code, out) ← evalIO (runLuaFile script)
+      annotate (toString out)
+      code === ExitSuccess
+
+--------------------------------------------------------------------------------
+-- Rendering -------------------------------------------------------------------
+
+renderBlock ∷ [Lua.Annotated Lua.Comments Lua.StatementF] → Text
+renderBlock =
+  renderStrict
+    . layoutPretty defaultLayoutOptions
+    . vsep
+    . Printer.printStatements
+
+renderExp ∷ Lua.Exp → Text
+renderExp = renderStrict . layoutPretty defaultLayoutOptions . Printer.printedExp
+
+{- | Render the differential subset ('Gen.evaluableExp') with parentheses
+around every node: a rendering whose evaluation order is dictated by the AST
+alone, independent of the printer's precedence\/associativity tables.
+-}
+fullParens ∷ HasCallStack ⇒ Lua.Exp → Text
+fullParens = \case
+  e@(Lua.Integer _) → atom e
+  e@(Lua.Float _) → atom e
+  e@(Lua.Boolean _) → atom e
+  e@(Lua.String _) → atom e
+  Lua.UnOp op (Ann a) →
+    parenthesized (Lua.sym op <> " " <> fullParens a)
+  Lua.BinOp op (Ann l) (Ann r) →
+    parenthesized (fullParens l <> " " <> Lua.sym op <> " " <> fullParens r)
+  other → error ("outside the differential subset: " <> show other)
+ where
+  -- Literals reuse the printer's rendering (a formatting difference would
+  -- compare different values); grouping parens around them are value-neutral.
+  atom ∷ Lua.Exp → Text
+  atom = parenthesized . renderExp
+  parenthesized ∷ Text → Text
+  parenthesized t = "(" <> t <> ")"

--- a/test/Language/PureScript/Backend/Lua/Gen.hs
+++ b/test/Language/PureScript/Backend/Lua/Gen.hs
@@ -1,0 +1,350 @@
+{- | Hedgehog generators for the Lua AST, used by the print\/parse round-trip
+property in 'Language.PureScript.Backend.Lua.Parser.Spec', the traversal
+identity property, and the external-arbiter properties in
+'Language.PureScript.Backend.Lua.Differential.Spec'.
+
+The generators cover the /canonical/ AST shapes — the ones code generation
+and the parser itself produce — so that @parse . print@ is the identity:
+
+  * Numeric literals are non-negative and finite: a negative or non-finite
+    value prints with a leading operator or as a synthetic expression
+    (@-2@, @math.huge@, @(0\/0)@), which parses back as that expression, not
+    as a literal.
+  * String payloads avoid characters that engage escape normalization.
+  * Only Lua 5.1 operators are drawn ('ParamUnused' is likewise skipped:
+    it prints as nothing).
+  * 'Paren' wraps only multi-valued expressions (calls, @...@); around
+    anything else the parser drops grouping parens.
+  * @return@ appears only where the Lua grammar allows it: closing a block.
+    'Break' is left to example-based tests, since Lua 5.1 additionally
+    requires an enclosing loop.
+  * @...@ appears only where the reference parser allows it: under a
+    function whose parameter list ends in @...@, or at the top level (the
+    main chunk is a vararg function). 'VarargScope' threads that through.
+  * Comments (roughly one slot in three) attach to statement and table-row
+    annotation slots only — the placements the parser pins exactly.
+    Expression slots stay comment-free: placement there is not stable under
+    print\/parse and is documented as a non-goal.
+-}
+module Language.PureScript.Backend.Lua.Gen where
+
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Hedgehog (MonadGen)
+import Hedgehog.Gen.Extended qualified as Gen
+import Hedgehog.Range qualified as Range
+import Language.PureScript.Backend.Lua.Name (Name)
+import Language.PureScript.Backend.Lua.Name qualified as Name
+import Language.PureScript.Backend.Lua.Types qualified as Lua
+import Prelude hiding (exp)
+
+-- | Whether @...@ is legal in the position being generated.
+type VarargScope = Bool
+
+--------------------------------------------------------------------------------
+-- Top-level entry points (main chunk: vararg scope) ---------------------------
+
+block ∷ ∀ m. MonadGen m ⇒ m [Lua.Annotated Lua.Comments Lua.StatementF]
+block = blockIn True
+
+statement ∷ ∀ m. MonadGen m ⇒ m Lua.Statement
+statement = statementIn True
+
+exp ∷ ∀ m. MonadGen m ⇒ m Lua.Exp
+exp = expIn True
+
+--------------------------------------------------------------------------------
+-- Comments in annotation slots ------------------------------------------------
+
+{- | A line comment. The @"-- "@ prefix (with the space) structurally rules
+out a long-bracket opener; the payload has no line breaks and no trailing
+whitespace (a layout is not obliged to preserve it).
+-}
+comment ∷ ∀ m. MonadGen m ⇒ m Text
+comment = do
+  payload ←
+    Gen.text (Range.linear 1 12) $
+      Gen.element (['a' .. 'z'] <> ['0' .. '9'] <> " _")
+  let trimmed = Text.dropWhileEnd (== ' ') payload
+  pure ("-- " <> if Text.null trimmed then "c" else trimmed)
+
+comments ∷ ∀ m. MonadGen m ⇒ m Lua.Comments
+comments =
+  Gen.frequency
+    [ (2, pure [])
+    , (1, Gen.list (Range.linear 1 2) comment)
+    ]
+
+-- | Annotate a node with generated 'comments'.
+annotated
+  ∷ ∀ m f. MonadGen m ⇒ m (f Lua.Comments) → m (Lua.Annotated Lua.Comments f)
+annotated gen = (,) <$> comments <*> gen
+
+--------------------------------------------------------------------------------
+-- Statements ------------------------------------------------------------------
+
+blockIn
+  ∷ ∀ m
+   . MonadGen m
+  ⇒ VarargScope
+  → m [Lua.Annotated Lua.Comments Lua.StatementF]
+blockIn vararg = do
+  statements ← Gen.list (Range.linear 0 3) (annotated (statementIn vararg))
+  final ← Gen.maybe (annotated (returnStatementIn vararg))
+  pure (statements <> maybeToList final)
+
+returnStatementIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Statement
+returnStatementIn vararg =
+  Lua.Return <$> Gen.list (Range.linear 0 2) (Lua.ann <$> expIn vararg)
+
+statementIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Statement
+statementIn vararg =
+  Gen.recursiveFrequency
+    [ (2, assign)
+    , (3, localStat)
+    , (2, callStatement)
+    ]
+    [ (2, ifThenElse)
+    , (1, Lua.Do <$> blockIn vararg)
+    , (1, Lua.While . Lua.ann <$> expIn vararg <*> blockIn vararg)
+    , (1, Lua.Repeat <$> blockIn vararg <*> (Lua.ann <$> expIn vararg))
+    , (1, forNum)
+    , (1, forIn)
+    , (1, localFunction)
+    ]
+ where
+  assign = do
+    vars ← Gen.nonEmpty (Range.linear 1 2) (Lua.ann <$> varIn vararg)
+    vals ← Gen.nonEmpty (Range.linear 1 2) (Lua.ann <$> expIn vararg)
+    pure (Lua.Assign vars vals)
+  localStat = do
+    names ← Gen.nonEmpty (Range.linear 1 2) name
+    vals ← Gen.list (Range.linear 0 2) (Lua.ann <$> expIn vararg)
+    pure (Lua.Local names vals)
+  callStatement = Lua.CallStatement . Lua.ann <$> callExpIn vararg
+  ifThenElse =
+    Lua.IfThenElse . Lua.ann
+      <$> expIn vararg
+      <*> blockIn vararg
+      <*> blockIn vararg
+  forNum = do
+    n ← name
+    start ← Lua.ann <$> expIn vararg
+    limit ← Lua.ann <$> expIn vararg
+    step ← Gen.maybe (Lua.ann <$> expIn vararg)
+    Lua.ForNum n start limit step <$> blockIn vararg
+  forIn = do
+    names ← Gen.nonEmpty (Range.linear 1 3) name
+    exps ← Gen.nonEmpty (Range.linear 1 2) (Lua.ann <$> expIn vararg)
+    Lua.ForIn names exps <$> blockIn vararg
+  localFunction = do
+    n ← name
+    (params, body) ← functionParts
+    pure (Lua.LocalFunction n params body)
+
+--------------------------------------------------------------------------------
+-- Expressions -----------------------------------------------------------------
+
+expIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Exp
+expIn vararg =
+  Gen.recursiveFrequency
+    ( [ (1, pure Lua.Nil)
+      , (2, Lua.Boolean <$> Gen.bool)
+      , (2, Lua.Integer <$> Gen.integral (Range.linear 0 0xFFFFFFFF))
+      , (2, Lua.Float <$> Gen.double (Range.linearFrac 0 1.0e9))
+      , (2, Lua.String <$> stringPayload)
+      , (2, Lua.varName <$> name)
+      ]
+        <> [(1, pure Lua.Vararg) | vararg]
+    )
+    [ (3, Lua.var <$> varIn vararg)
+    , (3, uncurry Lua.Function <$> functionParts)
+    , (2, Lua.TableCtor <$> Gen.list (Range.linear 0 3) (tableRowIn vararg))
+    , (2, Lua.UnOp <$> unaryOp <*> (Lua.ann . adjusted <$> expIn vararg))
+    ,
+      ( 3
+      , Lua.BinOp
+          <$> binaryOp
+          <*> (Lua.ann <$> expIn vararg)
+          <*> (Lua.ann <$> expIn vararg)
+      )
+    , (3, callExpIn vararg)
+    , (1, Lua.Paren . Lua.ann <$> multiValueExpIn vararg)
+    ]
+
+-- | A function call or method call (valid as a statement and under 'Paren').
+callExpIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Exp
+callExpIn vararg = do
+  callee ← adjusted <$> Gen.small (expIn vararg)
+  args ← Gen.list (Range.linear 0 2) (Gen.small (expIn vararg))
+  Gen.choice
+    [ pure (Lua.functionCall callee args)
+    , (\n → Lua.methodCall callee n args) <$> name
+    ]
+
+{- | Strip a top-level 'Paren' for positions that consume exactly one value
+(operator operands, prefix bases): the parser canonicalizes the paren away
+there, so the generator must not produce it.
+-}
+adjusted ∷ Lua.Exp → Lua.Exp
+adjusted (Lua.Paren (Lua.Ann e)) = e
+adjusted e = e
+
+multiValueExpIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Exp
+multiValueExpIn vararg =
+  Gen.frequency $
+    [(4, callExpIn vararg)] <> [(1, pure Lua.Vararg) | vararg]
+
+varIn ∷ ∀ m. MonadGen m ⇒ VarargScope → m Lua.Var
+varIn vararg =
+  Gen.recursiveFrequency
+    [(3, Lua.VarName <$> name)]
+    [ (1, Lua.VarField . Lua.ann . adjusted <$> Gen.small (expIn vararg) <*> name)
+    ,
+      ( 1
+      , Lua.VarIndex . Lua.ann . adjusted
+          <$> Gen.small (expIn vararg)
+          <*> (Lua.ann <$> Gen.small (expIn vararg))
+      )
+    ]
+
+tableRowIn
+  ∷ ∀ m. MonadGen m ⇒ VarargScope → m (Lua.Annotated Lua.Comments Lua.TableRowF)
+tableRowIn vararg =
+  annotated $
+    Gen.choice
+      [ Lua.tableRowKV <$> Gen.small (expIn vararg) <*> Gen.small (expIn vararg)
+      , Lua.tableRowNV <$> name <*> Gen.small (expIn vararg)
+      , Lua.tableRowV <$> Gen.small (expIn vararg)
+      ]
+
+-- | Parameters first; the body's vararg scope is the function's own.
+functionParts
+  ∷ ∀ m
+   . MonadGen m
+  ⇒ m
+      ( [Lua.Annotated Lua.Comments Lua.ParamF]
+      , [Lua.Annotated Lua.Comments Lua.StatementF]
+      )
+functionParts = do
+  named ← Gen.list (Range.linear 0 3) (Lua.ParamNamed <$> name)
+  vararg ← Gen.frequency [(3, pure []), (1, pure [Lua.ParamVararg])]
+  body ← blockIn (not (null vararg))
+  pure (Lua.ann <$> (named <> vararg), body)
+
+unaryOp ∷ ∀ m. MonadGen m ⇒ m Lua.UnaryOp
+unaryOp = Gen.element [Lua.HashOp, Lua.Negate, Lua.LogicalNot]
+
+-- | Lua 5.1 binary operators (no 5.3 floor-division/bitwise family).
+binaryOp ∷ ∀ m. MonadGen m ⇒ m Lua.BinaryOp
+binaryOp =
+  Gen.element
+    [ Lua.Or
+    , Lua.And
+    , Lua.LessThan
+    , Lua.GreaterThan
+    , Lua.LessThanOrEqualTo
+    , Lua.GreaterThanOrEqualTo
+    , Lua.NotEqualTo
+    , Lua.EqualTo
+    , Lua.Concat
+    , Lua.Add
+    , Lua.Sub
+    , Lua.Mul
+    , Lua.FloatDiv
+    , Lua.Mod
+    , Lua.Exp
+    ]
+
+name ∷ ∀ m. MonadGen m ⇒ m Name
+name = do
+  c ← Gen.element ['a' .. 'z']
+  cs ← Gen.list (Range.linear 0 6) identChar
+  let raw = toText (c : cs)
+  -- Dodge reserved words constructively; the result is always a valid name.
+  pure . Name.unsafeName $
+    if raw `Set.member` Name.reserved then raw <> "_k" else raw
+ where
+  identChar = Gen.element (['a' .. 'z'] <> ['0' .. '9'] <> "_")
+
+stringPayload ∷ ∀ m. MonadGen m ⇒ m Text
+stringPayload =
+  Gen.text (Range.linear 0 12) $
+    Gen.element (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> " _.,!?+-*/")
+
+--------------------------------------------------------------------------------
+-- Evaluable expressions (semantic differential) -------------------------------
+
+{- | A closed, runtime-error-free expression for the semantic differential in
+'Language.PureScript.Backend.Lua.Differential.Spec': three sorts (number,
+boolean, string) over constants, closed under the operators that cannot
+raise at runtime on those sorts. Division\/modulo\/power by zero yield
+inf\/nan deterministically, so they stay in. Excluded by construction:
+arithmetic or comparison over mismatched sorts, concatenation of booleans
+or nil, and any free variable.
+-}
+evaluableExp ∷ ∀ m. MonadGen m ⇒ m Lua.Exp
+evaluableExp = Gen.choice [numExp, boolExp, strExp]
+
+numExp ∷ ∀ m. MonadGen m ⇒ m Lua.Exp
+numExp =
+  Gen.recursiveFrequency
+    [ (2, Lua.Integer <$> Gen.integral (Range.linear 0 1000))
+    , (2, Lua.Float <$> Gen.double (Range.linearFrac 0 1000))
+    ]
+    [ (4, arithmetic)
+    , (1, Lua.negate <$> numExp)
+    , (1, Lua.hash <$> strExp)
+    ]
+ where
+  arithmetic = do
+    op ←
+      Gen.element [Lua.Add, Lua.Sub, Lua.Mul, Lua.FloatDiv, Lua.Mod, Lua.Exp]
+    Lua.binOp op <$> numExp <*> numExp
+
+boolExp ∷ ∀ m. MonadGen m ⇒ m Lua.Exp
+boolExp =
+  Gen.recursiveFrequency
+    [(2, Lua.Boolean <$> Gen.bool)]
+    [ (2, comparison)
+    , (2, equality)
+    , (2, logical)
+    , (1, Lua.logicalNot <$> boolExp)
+    ]
+ where
+  comparison = do
+    op ←
+      Gen.element
+        [ Lua.LessThan
+        , Lua.GreaterThan
+        , Lua.LessThanOrEqualTo
+        , Lua.GreaterThanOrEqualTo
+        ]
+    -- Ordering is defined within one sort only: numbers or strings.
+    Gen.choice
+      [ Lua.binOp op <$> numExp <*> numExp
+      , Lua.binOp op <$> strExp <*> strExp
+      ]
+  equality = do
+    op ← Gen.element [Lua.EqualTo, Lua.NotEqualTo]
+    Gen.choice
+      [ Lua.binOp op <$> numExp <*> numExp
+      , Lua.binOp op <$> strExp <*> strExp
+      , Lua.binOp op <$> boolExp <*> boolExp
+      ]
+  logical = do
+    op ← Gen.element [Lua.And, Lua.Or]
+    Lua.binOp op <$> boolExp <*> boolExp
+
+strExp ∷ ∀ m. MonadGen m ⇒ m Lua.Exp
+strExp =
+  Gen.recursiveFrequency
+    [(2, Lua.String <$> stringPayload)]
+    [
+      ( 2
+      , -- @..@ accepts strings and numbers (coercing the numbers).
+        Lua.concat <$> concatOperand <*> concatOperand
+      )
+    ]
+ where
+  concatOperand = Gen.frequency [(2, strExp), (1, numExp)]

--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -9,7 +9,6 @@ import Data.List qualified as List
 import Data.String qualified as String
 import Data.Tagged (Tagged (..))
 import Data.Text qualified as Text
-import Data.Text.IO qualified as Text.IO
 import Language.PureScript.Backend.IR qualified as IR
 import Language.PureScript.Backend.IR.FlattenDeepBinds (flattenDeepBinds)
 import Language.PureScript.Backend.IR.Linker (LinkMode (..))
@@ -18,6 +17,7 @@ import Language.PureScript.Backend.IR.Linker qualified as Linker
 import Language.PureScript.Backend.IR.Optimizer (optimizedUberModuleChecked)
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Optimizer (optimizeChunk)
+import Language.PureScript.Backend.Lua.Parser qualified as Parser
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
 import Language.PureScript.Backend.Types (AppOrModule (..))
 import Language.PureScript.CoreFn.Reader qualified as CoreFn
@@ -44,7 +44,6 @@ import Path.IO
   , makeAbsolute
   , walkDirAccum
   , withCurrentDir
-  , withSystemTempFile
   )
 import Path.Posix (mkRelFile)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
@@ -52,7 +51,6 @@ import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath qualified as FilePath
 import System.Process.Typed
   ( ExitCode (..)
-  , proc
   , readProcessInterleaved
   , runProcess
   , setWorkingDir
@@ -70,6 +68,7 @@ import Test.Hspec
   )
 import Test.Hspec.Extra (annotatingWith)
 import Test.Hspec.Golden (acceptableGolden, defaultGolden)
+import Test.Lua (luacParse)
 import Text.Pretty.Simple
   ( OutputOptions (..)
   , defaultOutputOptionsNoColor
@@ -128,7 +127,7 @@ spec = do
         it luaTestName do
           acceptableGolden luaGolden (Just luaActual) do
             appOrModule ←
-              (doesFileExist evalGolden) <&> \case
+              doesFileExist evalGolden <&> \case
                 True → AsApplication moduleName (PS.Ident "main")
                 False → AsModule moduleName
             cfn ← compileCorefn (Tagged (Rel psOutputPath)) moduleName
@@ -249,21 +248,6 @@ applySpineUberModule n =
       (IR.App IR.noAnn applyHead acc)
       (IR.LiteralInt IR.noAnn (fromIntegral i))
 
-{- | Parse-check (no execution) a Lua source with @luac -p@; returns the exit
-code and combined output. Writes to a unique auto-cleaned temp file and invokes
-@luac@ via 'proc' (an argv list, no shell), so it is portable and safe against
-paths with spaces or concurrent runs.
--}
-luacParse ∷ Text → IO (ExitCode, Text)
-luacParse src =
-  withSystemTempFile "pslua-nesting.lua" \file handle → do
-    -- Write through the handle the bracket owns and flush (so the separate
-    -- `luac` process sees the bytes); the bracket closes it on cleanup.
-    Text.IO.hPutStr handle src
-    hFlush handle
-    (code, out) ← readProcessInterleaved (proc "luac" ["-p", toFilePath file])
-    pure (code, decodeUtf8 out)
-
 {- | Corefn files that participate in golden tests: only Golden.* modules.
 Other modules compiled from test/ps/src pass through uncollected —
 bench/link relies on this to link the Bench.* corefns without them
@@ -324,7 +308,14 @@ compileIr appOrModule uberModule = withCurrentDir [reldir|test/ps|] do
           & optimizeChunk
           & Printer.printLuaChunk
   let addTrailingLf = (<> "\n")
-  pure $ addTrailingLf $ renderStrict $ layoutPretty defaultLayoutOptions doc
+  let rendered = addTrailingLf $ renderStrict $ layoutPretty defaultLayoutOptions doc
+  -- Everything the codegen prints must be readable back by the compiler's
+  -- own Lua parser (#173): the golden corpus doubles as its round-trip
+  -- fixture (luacheck separately vouches for third-party parseability).
+  liftIO $
+    either (fail . Parser.renderParseError) (const pass) $
+      Parser.parseChunk "<rendered>" rendered
+  pure rendered
 
 --------------------------------------------------------------------------------
 -- Error handlers --------------------------------------------------------------

--- a/test/Language/PureScript/Backend/Lua/Linker/Foreign/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Linker/Foreign/Spec.hs
@@ -55,6 +55,23 @@ spec = describe "Foreign module parser" do
         expectationFailure
           ("Expected an ambiguity parse error, got: " <> show other)
 
+  it "rejects '...' in the chunk's top-level scope" do
+    -- Legal Lua (the main chunk is vararg), but the file is embedded into
+    -- a function scope in the output, where chunk varargs cannot mean
+    -- anything (see the Copilot finding on PR #197).
+    headerResult ← parseForeign "local m = ...\nreturn { m = m }"
+    headerResult `shouldSatisfy` \case
+      Left (ForeignChunkVararg _path) → True
+      _ → False
+    exportResult ← parseForeign "return { v = ... }"
+    exportResult `shouldSatisfy` \case
+      Left (ForeignChunkVararg _path) → True
+      _ → False
+
+  it "keeps '...' legal inside a vararg function export" do
+    result ← parseForeign "return { f = function(...) return ... end }"
+    result `shouldSatisfy` isRight
+
   it "rejects a file that does not end in `return { ... }`" do
     result ← parseForeign "local x = 1"
     result `shouldSatisfy` \case

--- a/test/Language/PureScript/Backend/Lua/Linker/Foreign/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Linker/Foreign/Spec.hs
@@ -1,82 +1,156 @@
 {-# LANGUAGE QuasiQuotes #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
-{-# HLINT ignore "Use fewer imports" #-}
 
 module Language.PureScript.Backend.Lua.Linker.Foreign.Spec where
 
-import Data.List.NonEmpty qualified as NE
+import Data.List (isInfixOf)
 import Data.String.Interpolate (__i)
 import Language.PureScript.Backend.Lua.Key (Key (..))
 import Language.PureScript.Backend.Lua.Linker.Foreign
 import Language.PureScript.Backend.Lua.Name (unsafeName)
+import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Parser (renderParseError)
+import Language.PureScript.Backend.Lua.Types (ParamF (..))
+import Language.PureScript.Backend.Lua.Types qualified as Lua
 import Path (relfile, toFilePath, (</>))
 import Path.IO (withSystemTempDir)
-import Test.HUnit (Assertion)
-import Test.Hspec (Spec, describe, it)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldSatisfy)
 import Test.Hspec.Expectations.Pretty (shouldBe)
-import Text.Megaparsec qualified as M
 
 spec ∷ Spec
-spec = do
-  describe "Foreign parser" do
-    it "exports" do
-      shouldParse moduleParser (toText rawExports) parsedExports
+spec = describe "Foreign module parser" do
+  it "parses a foreign module into header statements and AST exports" do
+    parseForeign (rawHeader <> "\n" <> rawExports) >>= \case
+      Left err → expectationFailure (show err)
+      Right Source {header, returnComments, exports} → do
+        header `shouldBe` expectedHeader
+        returnComments `shouldBe` []
+        toList exports `shouldBe` expectedExports
 
-    it "value" do
-      shouldParse valueParser "(((x)(y)))" "((x)(y))"
+  it "keeps module-level comments of a header-less file on the return" do
+    parseForeign commentOnlyModule >>= \case
+      Left err → expectationFailure (show err)
+      Right Source {header, returnComments, exports} → do
+        header `shouldBe` []
+        returnComments `shouldBe` ["-- Module-level commentary."]
+        toList exports
+          `shouldBe` [(unsafeKey "topInt", ([], Lua.Integer 2147483647))]
 
-  describe "Foreign module parser" do
-    it "parses file" do
-      foreignSource ← withSystemTempDir "foreigns" \foreigns → do
-        let path = toFilePath $ foreigns </> [relfile|Foo.lua|]
-        writeFile path $ rawHeader <> "\n" <> rawExports
-        parseForeignSource foreigns path
-      case foreignSource of
-        Left err → fail $ show err
-        Right source →
-          source
-            `shouldBe` Source
-              { header = Just (toText rawHeader)
-              , exports = parsedExports
-              }
+  it "reports a syntax error inside an export value at compile time" do
+    -- The lexical splitter accepted anything with balanced parens; the
+    -- parser rejects this file outright (issue #173).
+    result ← parseForeign "return { foo = (42 + ) }"
+    result `shouldSatisfy` \case
+      Left (ForeignErrorParse _path _err) → True
+      _ → False
 
-shouldParse ∷ (Eq a, Show a) ⇒ Parser a → Text → a → Assertion
-shouldParse p s e =
-  case M.parse p "Test" s of
-    Left eb → fail $ M.errorBundlePretty eb
-    Right a → a `shouldBe` e
+  it "rejects an ambiguous line-broken call the way `luac` does" do
+    -- `local x = f` followed by a line starting with `(` is Lua 5.1's
+    -- "ambiguous syntax (function call x new statement)".
+    result ← parseForeign "local x = f\n(g).y = 1\nreturn { x = x }"
+    case result of
+      Left (ForeignErrorParse _path err) →
+        renderParseError err
+          `shouldSatisfy` isInfixOf "ambiguous syntax"
+      other →
+        expectationFailure
+          ("Expected an ambiguity parse error, got: " <> show other)
+
+  it "rejects a file that does not end in `return { ... }`" do
+    result ← parseForeign "local x = 1"
+    result `shouldSatisfy` \case
+      Left (ForeignNoExportsReturn _path) → True
+      _ → False
+
+  it "rejects an empty exports table" do
+    result ← parseForeign "return {}"
+    result `shouldSatisfy` \case
+      Left (ForeignNoExports _path) → True
+      _ → False
+
+  it "rejects an export keyed by a non-identifier" do
+    result ← parseForeign "return { [1] = 42 }"
+    result `shouldSatisfy` \case
+      Left (ForeignUnsupportedExportKey _path) → True
+      _ → False
+
+parseForeign ∷ String → IO (Either Error Source)
+parseForeign contents =
+  withSystemTempDir "foreigns" \foreigns → do
+    let path = toFilePath $ foreigns </> [relfile|Foo.lua|]
+    writeFile path contents
+    parseForeignSource foreigns path
 
 rawHeader ∷ String
 rawHeader =
   [__i|
-    function foo()
+    -- header
+    local function foo()
       return 42
     end
     local boo = "boo"
-    local zoo = "boo" .. "zoo"
+    local zoo = boo .. "zoo"
   |]
 
+-- Values are no longer required to be wrapped in parens (compare `foo` and
+-- `bar`); a reserved word appears as a bracketed string key.
 rawExports ∷ String
 rawExports =
   [__i|
     return {
-      foo = (42),
+      foo = 42,
       bar = ("ok"),
-      baz = (function(unused)
+      -- baz doc
+      baz = function(unused)
         return zoo
-      end),
-      [ "if"]= (function() return "if" end),
+      end,
+      [ "if"]= function() return "if" end,
     }
   |]
 
-parsedExports ∷ NE.NonEmpty (Key, Text)
-parsedExports =
-  (unsafeKey "foo", "42")
-    :| [ (unsafeKey "bar", "\"ok\"")
-       , (unsafeKey "baz", "function(unused)\n    return zoo\n  end")
-       , (KeyReserved "if", "function() return \"if\" end")
-       ]
+commentOnlyModule ∷ String
+commentOnlyModule =
+  [__i|
+    -- Module-level commentary.
+    return { topInt = 2147483647 }
+  |]
+
+expectedHeader ∷ [Lua.Annotated Lua.Comments Lua.StatementF]
+expectedHeader =
+  [
+    ( ["-- header"]
+    , Lua.LocalFunction
+        [Lua.name|foo|]
+        []
+        [Lua.ann (Lua.return (Lua.Integer 42))]
+    )
+  , ([], Lua.local1 [Lua.name|boo|] (Lua.String "boo"))
+  ,
+    ( []
+    , Lua.local1
+        [Lua.name|zoo|]
+        (Lua.varName [Lua.name|boo|] `Lua.concat` Lua.String "zoo")
+    )
+  ]
+
+expectedExports ∷ [(Key, Lua.Annotated Lua.Comments Lua.ExpF)]
+expectedExports =
+  [ (unsafeKey "foo", ([], Lua.Integer 42))
+  , -- parens around a single-valued expression are grouping and are dropped
+    (unsafeKey "bar", ([], Lua.String "ok"))
+  ,
+    ( unsafeKey "baz"
+    ,
+      ( ["-- baz doc"]
+      , Lua.functionDef
+          [ParamNamed [Lua.name|unused|]]
+          [Lua.return (Lua.varName [Lua.name|zoo|])]
+      )
+    )
+  ,
+    ( KeyReserved "if"
+    , ([], Lua.functionDef [] [Lua.return (Lua.String "if")])
+    )
+  ]
 
 unsafeKey ∷ Text → Key
 unsafeKey = KeyName . unsafeName

--- a/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
@@ -123,3 +123,62 @@ spec = describe "Lua AST Optimizer" do
               [name|foo|]
       assertEqual (toString $ pShow original) original $
         rewriteExpWithRule foldFieldProjectionThroughScopeCall original
+
+    it "declines when a leading loop body contains a return" do
+      -- A `return` at the body level of a `while` exits the call the same
+      -- way a top-level early return does.
+      let original ∷ Lua.Exp =
+            Lua.varField
+              ( Lua.scope
+                  [ Lua.While
+                      (Lua.ann (Lua.Boolean True))
+                      [Lua.ann (Lua.return (Lua.varName [name|a|]))]
+                  , Lua.return (Lua.varName [name|b|])
+                  ]
+              )
+              [name|foo|]
+      assertEqual (toString $ pShow original) original $
+        rewriteExpWithRule foldFieldProjectionThroughScopeCall original
+
+    it "folds past a leading loop without a return" do
+      let scopeBody ∷ Lua.Exp → [Lua.Statement]
+          scopeBody returned =
+            [ Lua.While
+                (Lua.ann (Lua.Boolean True))
+                [Lua.ann (Lua.assignVar [name|a|] Lua.Nil)]
+            , Lua.return returned
+            ]
+          original ∷ Lua.Exp =
+            Lua.varField
+              (Lua.scope (scopeBody (Lua.varName [name|b|])))
+              [name|foo|]
+          expected ∷ Lua.Exp =
+            Lua.scope
+              ( scopeBody
+                  (Lua.varField (Lua.varName [name|b|]) [name|foo|])
+              )
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule foldFieldProjectionThroughScopeCall original
+
+    it "folds past a leading local function whose body returns" do
+      -- A `return` inside a nested (local) function belongs to a different
+      -- activation: it does not exit this call, so the fold may proceed.
+      let scopeBody ∷ Lua.Exp → [Lua.Statement]
+          scopeBody returned =
+            [ Lua.LocalFunction
+                [name|helper|]
+                []
+                [Lua.ann (Lua.return Lua.Nil)]
+            , Lua.return returned
+            ]
+          original ∷ Lua.Exp =
+            Lua.varField
+              (Lua.scope (scopeBody (Lua.varName [name|b|])))
+              [name|foo|]
+          expected ∷ Lua.Exp =
+            Lua.scope
+              ( scopeBody
+                  (Lua.varField (Lua.varName [name|b|]) [name|foo|])
+              )
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule foldFieldProjectionThroughScopeCall original

--- a/test/Language/PureScript/Backend/Lua/Parser/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Parser/Spec.hs
@@ -1,0 +1,713 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Language.PureScript.Backend.Lua.Parser.Spec where
+
+import Data.List (isInfixOf)
+import Data.String.Interpolate (__i)
+import Data.Text qualified as Text
+import Hedgehog (annotate, failure, forAll, (===))
+import Language.PureScript.Backend.Lua.Gen qualified as Gen
+import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Parser
+  ( ParseError
+  , parseChunk
+  , parseExpression
+  , renderParseError
+  )
+import Language.PureScript.Backend.Lua.Printer qualified as Printer
+import Language.PureScript.Backend.Lua.Types (ParamF (..))
+import Language.PureScript.Backend.Lua.Types qualified as Lua
+import Prettyprinter
+  ( LayoutOptions (..)
+  , PageWidth (..)
+  , defaultLayoutOptions
+  , layoutPretty
+  , vsep
+  )
+import Prettyprinter.Render.Text (renderStrict)
+import Test.Hspec
+  ( Expectation
+  , Spec
+  , describe
+  , expectationFailure
+  , it
+  , shouldSatisfy
+  )
+import Test.Hspec.Expectations.Pretty (shouldBe)
+import Test.Hspec.Hedgehog.Extended (prop)
+import Prelude hiding (exp)
+
+spec ∷ Spec
+spec = do
+  describe "expressions" do
+    describe "literals" do
+      it "nil, booleans" do
+        "nil" `parsesTo` Lua.Nil
+        "true" `parsesTo` Lua.Boolean True
+        "false" `parsesTo` Lua.Boolean False
+
+      it "decimal and hexadecimal integers" do
+        "42" `parsesTo` Lua.Integer 42
+        "0xFF" `parsesTo` Lua.Integer 255
+        "0X10" `parsesTo` Lua.Integer 16
+        "0x100000000" `parsesTo` Lua.Integer 4294967296
+
+      it "floats: fraction, exponent, bare-dot forms" do
+        "1.5" `parsesTo` Lua.Float 1.5
+        ".5" `parsesTo` Lua.Float 0.5
+        "1." `parsesTo` Lua.Float 1
+        "1e2" `parsesTo` Lua.Float 100
+        "1.5E-3" `parsesTo` Lua.Float 0.0015
+
+      it "exponents: sign, capital E, bare-dot mantissa padding" do
+        "1e+5" `parsesTo` Lua.Float 100000
+        "1E5" `parsesTo` Lua.Float 100000
+        ".5e3" `parsesTo` Lua.Float 500
+        "1.e5" `parsesTo` Lua.Float 100000
+
+      it "rejects malformed numerals" do
+        expectExpParseError "0x"
+        expectExpParseError "0xG"
+        expectExpParseError "123abc"
+
+      it "double-quoted strings keep escapes unexpanded" do
+        "\"a\\255b\"" `parsesTo` Lua.String "a\\255b"
+        "\"tab\\there\"" `parsesTo` Lua.String "tab\\there"
+
+      it "escaped newlines normalize to the two-character escape" do
+        "\"one\\\ntwo\"" `parsesTo` Lua.String "one\\ntwo"
+        "\"one\\\r\ntwo\"" `parsesTo` Lua.String "one\\ntwo"
+
+      it "'--' inside a string literal is not a comment" do
+        "\"a--b\"" `parsesTo` Lua.String "a--b"
+
+      it "rejects an unterminated string" do
+        expectExpParseError "\"abc"
+
+      it "rejects a raw newline inside a short string" do
+        expectExpParseError "\"a\nb\""
+
+      it "single-quoted strings convert to double-quoted form" do
+        "'don\\'t say \"hi\"'" `parsesTo` Lua.String "don\\'t say \\\"hi\\\""
+
+      it "long-bracket strings escape into double-quoted form" do
+        "[[back\\slash \"quote\"]]"
+          `parsesTo` Lua.String "back\\\\slash \\\"quote\\\""
+        "[==[nested ]] here]==]" `parsesTo` Lua.String "nested ]] here"
+
+      it "long-bracket strings drop the leading newline" do
+        "[[\nfirst]]" `parsesTo` Lua.String "first"
+
+      it "long-bracket strings escape interior raw newlines" do
+        "[[a\nb]]" `parsesTo` Lua.String "a\\nb"
+        "[[a\rb]]" `parsesTo` Lua.String "a\\rb"
+
+      it "vararg" do
+        "..." `parsesTo` Lua.Vararg
+
+    describe "operators" do
+      it "precedence: * binds tighter than +" do
+        "1 + 2 * 3"
+          `parsesTo` (Lua.Integer 1 `Lua.add` (Lua.Integer 2 `Lua.mul` Lua.Integer 3))
+
+      it "left associativity of -" do
+        "1 - 2 - 3"
+          `parsesTo` ((Lua.Integer 1 `Lua.sub` Lua.Integer 2) `Lua.sub` Lua.Integer 3)
+
+      it "right associativity of .. and ^" do
+        "a .. b .. c"
+          `parsesTo` (name' "a" `Lua.concat` (name' "b" `Lua.concat` name' "c"))
+        "2 ^ 3 ^ 4"
+          `parsesTo` ( Lua.Integer 2
+                         `Lua.exponent` (Lua.Integer 3 `Lua.exponent` Lua.Integer 4)
+                     )
+
+      it "unary minus binds looser than ^" do
+        -- -x^2 is -(x^2) in Lua
+        "-x ^ 2"
+          `parsesTo` Lua.negate (name' "x" `Lua.exponent` Lua.Integer 2)
+
+      it "unary operator in the right operand of ^" do
+        "2 ^ -3" `parsesTo` (Lua.Integer 2 `Lua.exponent` Lua.negate (Lua.Integer 3))
+
+      it "not binds tighter than ==" do
+        "not a == b" `parsesTo` (Lua.logicalNot (name' "a") `Lua.equalTo` name' "b")
+
+      it "or/and precedence" do
+        "a or b and c"
+          `parsesTo` (name' "a" `Lua.or` (name' "b" `Lua.and` name' "c"))
+
+      it "comparison and concat" do
+        "#t .. x < y"
+          `parsesTo` ( (Lua.hash (name' "t") `Lua.concat` name' "x")
+                         `Lua.lessThan` name' "y"
+                     )
+
+    describe "prefix expressions" do
+      it "field and index chains" do
+        "a.b.c" `parsesTo` Lua.varField (Lua.varField (name' "a") (n "b")) (n "c")
+        "a[1]" `parsesTo` Lua.varIndex (name' "a") (Lua.Integer 1)
+
+      it "curried calls" do
+        "f(1)(2)"
+          `parsesTo` Lua.functionCall
+            (Lua.functionCall (name' "f") [Lua.Integer 1])
+            [Lua.Integer 2]
+
+      it "method calls" do
+        "s:sub(1, 2)"
+          `parsesTo` Lua.methodCall (name' "s") (n "sub") [Lua.Integer 1, Lua.Integer 2]
+
+      it "string- and table-argument call sugar" do
+        [__i|f "x"|] `parsesTo` Lua.functionCall (name' "f") [Lua.String "x"]
+        "f [[x]]" `parsesTo` Lua.functionCall (name' "f") [Lua.String "x"]
+        "f {}" `parsesTo` Lua.functionCall (name' "f") [Lua.table []]
+
+      it "parens around a call are semantic (multi-value adjustment)" do
+        "(f(x))"
+          `parsesTo` Lua.Paren
+            (Lua.ann (Lua.functionCall (name' "f") [name' "x"]))
+        "(...)" `parsesTo` Lua.Paren (Lua.ann Lua.Vararg)
+
+      it "parens around single-valued expressions are grouping" do
+        "(42)" `parsesTo` Lua.Integer 42
+        "(a).b" `parsesTo` Lua.varField (name' "a") (n "b")
+
+    describe "table constructors" do
+      it "all three field forms and both separators" do
+        [__i|{ [1] = "a", b = 2; 3 }|]
+          `parsesTo` Lua.table
+            [ Lua.tableRowKV (Lua.Integer 1) (Lua.String "a")
+            , Lua.tableRowNV (n "b") (Lua.Integer 2)
+            , Lua.tableRowV (Lua.Integer 3)
+            ]
+
+      it "trailing separator" do
+        "{ 1, }" `parsesTo` Lua.table [Lua.tableRowV (Lua.Integer 1)]
+
+    describe "functions" do
+      it "vararg parameter" do
+        "function(a, ...) return ... end"
+          `parsesTo` Lua.Function
+            [Lua.ann (ParamNamed (n "a")), Lua.ann ParamVararg]
+            [Lua.ann (Lua.Return [Lua.ann Lua.Vararg])]
+
+      it "rejects '...' before other parameters" do
+        expectExpParseError "function(..., a) return 1 end"
+
+  describe "statements" do
+    it "multiple assignment stays simultaneous" do
+      "a, b = b, a"
+        `statParsesTo` Lua.Assign
+          (Lua.ann (Lua.VarName (n "a")) :| [Lua.ann (Lua.VarName (n "b"))])
+          (Lua.ann (name' "b") :| [Lua.ann (name' "a")])
+
+    it "local declarations: single, multiple, uninitialized" do
+      "local x = 1" `statParsesTo` Lua.local1 (n "x") (Lua.Integer 1)
+      "local a, b = 1, x"
+        `statParsesTo` Lua.Local
+          (n "a" :| [n "b"])
+          [Lua.ann (Lua.Integer 1), Lua.ann (name' "x")]
+      "local y" `statParsesTo` Lua.local0 (n "y")
+
+    it "local function is self-recursive" do
+      "local function f() return f end"
+        `statParsesTo` Lua.LocalFunction
+          (n "f")
+          []
+          [Lua.ann (Lua.return (name' "f"))]
+
+    it "function statements desugar to assignments" do
+      "function M.f(x) return x end"
+        `statParsesTo` Lua.assign
+          (Lua.VarField (Lua.ann (name' "M")) (n "f"))
+          (Lua.functionDef [ParamNamed (n "x")] [Lua.return (name' "x")])
+
+    it "method definitions add the implicit self parameter" do
+      "function M:m(x) return x end"
+        `statParsesTo` Lua.assign
+          (Lua.VarField (Lua.ann (name' "M")) (n "m"))
+          ( Lua.functionDef
+              [ParamNamed [Lua.name|self|], ParamNamed (n "x")]
+              [Lua.return (name' "x")]
+          )
+
+    it "call statements" do
+      "f(1)"
+        `statParsesTo` Lua.CallStatement (Lua.ann (Lua.functionCall (name' "f") [Lua.Integer 1]))
+      "s:close()"
+        `statParsesTo` Lua.CallStatement (Lua.ann (Lua.methodCall (name' "s") (n "close") []))
+
+    it "while, repeat, and do blocks" do
+      "while x do break end"
+        `statParsesTo` Lua.While (Lua.ann (name' "x")) [Lua.ann Lua.Break]
+      "repeat f() until x"
+        `statParsesTo` Lua.Repeat
+          [Lua.ann (Lua.CallStatement (Lua.ann (Lua.functionCall (name' "f") [])))]
+          (Lua.ann (name' "x"))
+      "do local x = 1 end"
+        `statParsesTo` Lua.Do [Lua.ann (Lua.local1 (n "x") (Lua.Integer 1))]
+
+    it "numeric for with and without a step" do
+      "for i = 1, 10 do f(i) end"
+        `statParsesTo` Lua.ForNum
+          (n "i")
+          (Lua.ann (Lua.Integer 1))
+          (Lua.ann (Lua.Integer 10))
+          Nothing
+          [ Lua.ann (Lua.CallStatement (Lua.ann (Lua.functionCall (name' "f") [name' "i"])))
+          ]
+      "for i = 10, 1, -1 do break end"
+        `statParsesTo` Lua.ForNum
+          (n "i")
+          (Lua.ann (Lua.Integer 10))
+          (Lua.ann (Lua.Integer 1))
+          (Just (Lua.ann (Lua.negate (Lua.Integer 1))))
+          [Lua.ann Lua.Break]
+
+    it "generic for" do
+      "for k, v in pairs(t) do break end"
+        `statParsesTo` Lua.ForIn
+          (n "k" :| [n "v"])
+          (Lua.ann (Lua.functionCall (name' "pairs") [name' "t"]) :| [])
+          [Lua.ann Lua.Break]
+
+    it "bare and multi-value returns" do
+      "return" `statParsesTo` Lua.Return []
+      "return 1, 2"
+        `statParsesTo` Lua.Return [Lua.ann (Lua.Integer 1), Lua.ann (Lua.Integer 2)]
+
+    it "elseif chains parse into nested else-blocks" do
+      [__i|
+        if a then return 1
+        elseif b then return 2
+        else return 3 end
+      |]
+        `statParsesTo` Lua.ifThenElse
+          (name' "a")
+          [Lua.return (Lua.Integer 1)]
+          [ Lua.ifThenElse
+              (name' "b")
+              [Lua.return (Lua.Integer 2)]
+              [Lua.return (Lua.Integer 3)]
+          ]
+
+    it "rejects statements after a return" do
+      expectChunkParseError "return 1 local x = 2"
+
+    it "rejects an expression that is not a statement" do
+      expectChunkParseError "x + 1"
+
+    it "rejects an assignment whose left side is not a variable" do
+      expectChunkParseError "f() = 1"
+
+    it "rejects 'break' in the middle of a block" do
+      expectChunkParseError "while true do break f() end"
+
+    it "rejects a leading ';' (Lua 5.1 has no empty statement)" do
+      expectChunkParseError ";"
+      expectChunkParseError "; local x = 1"
+
+    it "accepts ';' after every statement" do
+      case parseChunk "<spec>" "local a = 1; local b = 2;" of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats
+            `shouldBe` [ Lua.ann (Lua.local1 (n "a") (Lua.Integer 1))
+                       , Lua.ann (Lua.local1 (n "b") (Lua.Integer 2))
+                       ]
+
+    it "'repeat' whose body closes with a return" do
+      "repeat return until x"
+        `statParsesTo` Lua.Repeat
+          [Lua.ann (Lua.Return [])]
+          (Lua.ann (name' "x"))
+
+    it "keyword-prefixed identifiers parse as identifiers" do
+      "dofile(x)"
+        `statParsesTo` Lua.CallStatement
+          (Lua.ann (Lua.functionCall (name' "dofile") [name' "x"]))
+      "local doit = 1" `statParsesTo` Lua.local1 (n "doit") (Lua.Integer 1)
+      "returnValue()"
+        `statParsesTo` Lua.CallStatement
+          (Lua.ann (Lua.functionCall (name' "returnValue") []))
+
+  describe "reference-parser conformance" do
+    describe "ambiguous call syntax (function call x new statement)" do
+      it "a call with '(' on the same line is a call" do
+        "f(g)"
+          `statParsesTo` Lua.CallStatement
+            (Lua.ann (Lua.functionCall (name' "f") [name' "g"]))
+
+      it "an inline block comment before '(' stays a call" do
+        "f --[[c]] (g)"
+          `statParsesTo` Lua.CallStatement
+            ( Lua.ann
+                ( Lua.FunctionCall
+                    (Lua.ann (name' "f"))
+                    [(["--[[c]]"], name' "g")]
+                )
+            )
+
+      it "a line break before '(' is rejected as the reference rejects it" do
+        expectChunkParseErrorWith "f\n(g)" "ambiguous syntax"
+        expectChunkParseErrorWith "local x = f\n(g).y = 1" "ambiguous syntax"
+
+      it "a line comment before '(' implies a line break: rejected" do
+        expectChunkParseErrorWith "f --c\n(g)" "ambiguous syntax"
+
+      it "a method call's argument list obeys the same rule" do
+        expectChunkParseErrorWith "obj:m\n(x)" "ambiguous syntax"
+
+      it "';' terminating the previous statement disambiguates" do
+        case parseChunk "<spec>" "local a = f;\n(g).x = 1" of
+          Left err → expectationFailure (renderParseError err)
+          Right stats →
+            stats
+              `shouldBe` [ Lua.ann (Lua.local1 (n "a") (name' "f"))
+                         , Lua.ann
+                             ( Lua.Assign
+                                 ( one
+                                     ( Lua.ann
+                                         ( Lua.VarField
+                                             (Lua.ann (name' "g"))
+                                             (n "x")
+                                         )
+                                     )
+                                 )
+                                 (one (Lua.ann (Lua.Integer 1)))
+                             )
+                         ]
+
+      it "string and table arguments stay legal across a line break" do
+        "f\n\"s\""
+          `statParsesTo` Lua.CallStatement
+            (Lua.ann (Lua.functionCall (name' "f") [Lua.String "s"]))
+        "f\n{}"
+          `statParsesTo` Lua.CallStatement
+            (Lua.ann (Lua.functionCall (name' "f") [Lua.table []]))
+
+    describe "vararg scope" do
+      it "'...' at the top level is legal (the main chunk is vararg)" do
+        "return ..." `statParsesTo` Lua.Return [Lua.ann Lua.Vararg]
+
+      it "'...' inside a non-vararg function is rejected" do
+        expectExpParseErrorWith
+          "function() return ... end"
+          "outside a vararg function"
+
+      it "a nested non-vararg function shadows the enclosing vararg scope" do
+        expectExpParseErrorWith
+          "function(a, ...) return function() return ... end end"
+          "outside a vararg function"
+
+      it "leaving a nested vararg function restores the enclosing scope" do
+        expectExpParseErrorWith
+          "function() local g = function(...) return ... end return ... end"
+          "outside a vararg function"
+
+    describe "nesting depth cap" do
+      it "parses 100 nested parentheses" do
+        let src =
+              Text.replicate 100 "(" <> "x" <> Text.replicate 100 ")"
+        case parseExpression src of
+          Left err → expectationFailure (renderParseError err)
+          Right e → e `shouldBe` Lua.ann (name' "x")
+
+      it "fails on 600 nested parentheses with a nesting error" do
+        let src =
+              Text.replicate 600 "(" <> "x" <> Text.replicate 600 ")"
+        expectExpParseErrorWith src "nesting too deep"
+
+      it "parses 50k call suffixes without exhausting the stack" do
+        let src = "f" <> Text.replicate 50000 "()"
+        parseExpression src `shouldSatisfy` isRight
+
+      it "parses 50k field suffixes without exhausting the stack" do
+        let src = "a" <> Text.replicate 50000 ".b"
+        parseExpression src `shouldSatisfy` isRight
+
+    describe "reserved words" do
+      it "rejects 'goto' as an identifier (kept loadable on LuaJIT/5.2+)" do
+        expectChunkParseErrorWith "local goto = 1" "goto"
+
+  describe "comments" do
+    it "attach to the following statement" do
+      case parseChunk "<spec>" "-- doc\n-- more\nlocal x = 1" of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats
+            `shouldBe` [(["-- doc", "-- more"], Lua.local1 (n "x") (Lua.Integer 1))]
+
+    it "block comments are preserved verbatim" do
+      case parseChunk "<spec>" "--[[ block\ncomment ]]\nreturn 1" of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats
+            `shouldBe` [(["--[[ block\ncomment ]]"], Lua.return (Lua.Integer 1))]
+
+    it "levelled long-bracket comments are preserved verbatim" do
+      case parseChunk "<spec>" "--[==[ x ]==]\nreturn 1" of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats `shouldBe` [(["--[==[ x ]==]"], Lua.return (Lua.Integer 1))]
+
+    it "'--[' that does not open a long bracket is a line comment" do
+      case parseChunk "<spec>" "--[ not long\nreturn 1" of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats `shouldBe` [(["--[ not long"], Lua.return (Lua.Integer 1))]
+
+    it "a comment at end of input (without a newline) is dropped" do
+      "return 1 -- trailing" `statParsesTo` Lua.return (Lua.Integer 1)
+
+    it "a comment before 'elseif' blocks resugaring, both ways" do
+      -- Parses into the nested else-of-if shape with the comment attached;
+      -- the printer then has to emit `else if … end end` (an `elseif` would
+      -- lose the comment's place), and the reparse agrees exactly.
+      let source =
+            "if a then return 1\n-- why\nelseif b then return 2\nelse return 3 end"
+      case parseChunk "<spec>" source of
+        Left err → expectationFailure (renderParseError err)
+        Right stats →
+          stats
+            `shouldBe` [ Lua.ann
+                           ( Lua.IfThenElse
+                               (Lua.ann (name' "a"))
+                               [Lua.ann (Lua.return (Lua.Integer 1))]
+                               [
+                                 ( ["-- why"]
+                                 , Lua.IfThenElse
+                                     (Lua.ann (name' "b"))
+                                     [Lua.ann (Lua.return (Lua.Integer 2))]
+                                     [Lua.ann (Lua.return (Lua.Integer 3))]
+                                 )
+                               ]
+                           )
+                       ]
+      roundTrips source
+
+  describe "print/reparse round trip" do
+    for_ roundTripCorpus \(title, source) →
+      it title (roundTrips source)
+
+    prop 500 "parse . print ≡ id for generated chunks, at every page width" do
+      stats ← forAll Gen.block
+      let doc = vsep (Printer.printStatements stats)
+      for_ pageWidths \(label, options) → do
+        let printed = renderStrict (layoutPretty options doc)
+        annotate label
+        annotate (toString printed)
+        case parseChunk "<generated>" printed of
+          Left err → do
+            annotate (renderParseError err)
+            failure
+          Right parsed → parsed === stats
+
+{- | The four layouts a chunk must survive: the one-column layout is the
+main stress for @;@ insertion and hardline comments, 'Unbounded' for
+everything the grouping logic can put on one line.
+-}
+pageWidths ∷ [(String, LayoutOptions)]
+pageWidths =
+  [ ("page width 1", LayoutOptions (AvailablePerLine 1 1.0))
+  , ("page width 40", LayoutOptions (AvailablePerLine 40 1.0))
+  , ("page width 80", defaultLayoutOptions)
+  , ("page width unbounded", LayoutOptions Unbounded)
+  ]
+
+--------------------------------------------------------------------------------
+-- Round-trip corpus -----------------------------------------------------------
+
+{- | Parse, print with the real printer, reparse: the two parses must agree
+exactly (including comment placement).
+-}
+roundTrips ∷ Text → Expectation
+roundTrips source = case parseChunk "<original>" source of
+  Left err → expectationFailure (renderParseError err)
+  Right stats → do
+    let printed =
+          renderStrict . layoutPretty defaultLayoutOptions $
+            vsep (Printer.printStatements stats)
+    case parseChunk "<reprinted>" printed of
+      Left err →
+        expectationFailure $
+          "Printed output failed to reparse:\n"
+            <> toString printed
+            <> "\n"
+            <> renderParseError err
+      Right stats' → stats' `shouldBe` stats
+
+roundTripCorpus ∷ [(String, Text)]
+roundTripCorpus =
+  [
+    ( "Data.Int-style header (methods, multi-locals, hex, repeat)"
+    , [__i|
+        -- Shared helpers.
+        local function toInt32(m)
+          m = math.modf(m)
+          m = m % 0x100000000
+          if m >= 0x80000000 then m = m - 0x100000000 end
+          return m
+        end
+        local function digitValue(c)
+          local b = c:byte()
+          if b >= 48 and b <= 57 then return b - 48 end
+          return nil
+        end
+        local sign, body = 1, s
+        sign, body = -1, s:sub(2)
+        repeat
+          body = body .. "x"
+        until \#body > 3 or digitValue(body)
+        return { toInt32 = toInt32 }
+      |]
+    )
+  ,
+    ( "Array-style code (while, statement calls, generic for)"
+    , [__i|
+        local function listToArray(list)
+          local arr = {}
+          local i = 1
+          local xs = list
+          while xs.tag == "Cons" do
+            arr[i] = xs.head
+            i = i + 1
+            xs = xs.tail
+          end
+          table.insert(arr, 1, 0)
+          for k, v in pairs(arr) do
+            print(k, v)
+          end
+          return arr
+        end
+        return { listToArray = listToArray }
+      |]
+    )
+  ,
+    ( "runtime-lazy fixture shape (nested closures, if/else)"
+    , [__i|
+        local function runtime_lazy(name)
+          return function(init)
+            local state = 0
+            local val = nil
+            return function()
+              if state == 2 then
+                return val
+              else
+                if state == 1 then
+                  return error(name .. " loop")
+                else
+                  state = 1
+                  val = init()
+                  state = 2
+                  return val
+                end
+              end
+            end
+          end
+        end
+        return { runtime_lazy = runtime_lazy }
+      |]
+    )
+  ,
+    ( "elseif ladder, numeric for, varargs, multi-value return"
+    , [__i|
+        local function classify(x, ...)
+          if x < 0 then
+            return "neg"
+          elseif x == 0 then
+            return "zero"
+          elseif x < 10 then
+            return "small"
+          else
+            return "big", select("\#", ...)
+          end
+        end
+        local function sum(n)
+          local acc = 0
+          for i = 1, n, 2 do
+            acc = acc + i
+          end
+          do
+            acc = toInt32(acc)
+          end
+          return acc
+        end
+        return { classify = classify, sum = sum }
+      |]
+    )
+  ,
+    ( "comments in bodies and above exports"
+    , [__i|
+        -- header comment
+        local unit = {}
+        return {
+          -- the unit value
+          unit = unit,
+          compare = function(a)
+            -- inner comment
+            return function(b)
+              if a < b then return LT end
+              return GT
+            end
+          end,
+        }
+      |]
+    )
+  ]
+
+--------------------------------------------------------------------------------
+-- Helpers ---------------------------------------------------------------------
+
+n ∷ Text → Lua.Name
+n = Lua.unsafeName
+
+name' ∷ Text → Lua.Exp
+name' = Lua.varName . n
+
+parsesTo ∷ HasCallStack ⇒ Text → Lua.Exp → Expectation
+parsesTo source expected =
+  case parseExpression source of
+    Left err → expectationFailure (renderParseError err)
+    Right e → e `shouldBe` Lua.ann expected
+
+statParsesTo ∷ HasCallStack ⇒ Text → Lua.Statement → Expectation
+statParsesTo source expected =
+  case parseChunk "<spec>" source of
+    Left err → expectationFailure (renderParseError err)
+    Right stats → stats `shouldBe` [Lua.ann expected]
+
+expectExpParseError ∷ HasCallStack ⇒ Text → Expectation
+expectExpParseError source =
+  case parseExpression source of
+    Left _ → pass
+    Right e → expectationFailure ("Expected a parse error, got: " <> show e)
+
+expectChunkParseError ∷ HasCallStack ⇒ Text → Expectation
+expectChunkParseError source =
+  case parseChunk "<spec>" source of
+    Left _ → pass
+    Right e → expectationFailure ("Expected a parse error, got: " <> show e)
+
+-- | Expect a parse error whose rendering mentions the given fragment.
+expectExpParseErrorWith ∷ HasCallStack ⇒ Text → String → Expectation
+expectExpParseErrorWith source fragment =
+  expectErrorWith fragment (show <$> parseExpression source)
+
+expectChunkParseErrorWith ∷ HasCallStack ⇒ Text → String → Expectation
+expectChunkParseErrorWith source fragment =
+  expectErrorWith fragment (show <$> parseChunk "<spec>" source)
+
+expectErrorWith
+  ∷ HasCallStack ⇒ String → Either ParseError String → Expectation
+expectErrorWith fragment = \case
+  Left err → do
+    let message = renderParseError err
+    unless (fragment `isInfixOf` message) . expectationFailure $
+      "Expected an error mentioning "
+        <> show fragment
+        <> ", got:\n"
+        <> message
+  Right parsed →
+    expectationFailure ("Expected a parse error, got: " <> parsed)

--- a/test/Language/PureScript/Backend/Lua/Printer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Printer/Spec.hs
@@ -5,12 +5,20 @@ module Language.PureScript.Backend.Lua.Printer.Spec where
 
 import Data.Text qualified as Text
 import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Parser qualified as Parser
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
 import Language.PureScript.Backend.Lua.Types (ParamF (..))
 import Language.PureScript.Backend.Lua.Types qualified as Lua
-import Prettyprinter (Doc, defaultLayoutOptions, layoutPretty)
+import Prettyprinter (Doc, defaultLayoutOptions, layoutPretty, vsep)
 import Prettyprinter.Render.Text (renderStrict)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec
+  ( Expectation
+  , Spec
+  , describe
+  , expectationFailure
+  , it
+  , shouldBe
+  )
 
 spec ∷ Spec
 spec = do
@@ -50,7 +58,7 @@ spec = do
 
   describe "Local declaration" do
     it "without a value" do
-      let s = Lua.Local [Lua.name|foo|] Nothing
+      let s = Lua.local0 [Lua.name|foo|]
       renderedStatement s `shouldBe` "local foo"
 
     it "with value" do
@@ -230,6 +238,177 @@ spec = do
       renderedExpression (Lua.functionCall callee [])
         `shouldBe` "({ foo = 1 })()"
 
+  describe "statement separator" do
+    -- Without the ';', `local a = f` and the next line's `(` would fuse
+    -- into the call `f(nil)` — Lua 5.1 rejects that as "ambiguous syntax".
+    it "';' terminates a statement when the next one starts with '('" do
+      let stats =
+            [ Lua.ann
+                (Lua.local1 [Lua.name|a|] (Lua.varName [Lua.name|f|]))
+            , Lua.ann
+                ( Lua.Assign
+                    ( one
+                        ( Lua.ann
+                            (Lua.VarField (Lua.ann Lua.Nil) [Lua.name|x|])
+                        )
+                    )
+                    (one (Lua.ann (Lua.Integer 1)))
+                )
+            ]
+      renderedStatements stats
+        `shouldBe` multiline ["local a = f;", "(nil).x = 1"]
+      reparsesToItself stats
+
+    it "';' separates an IIFE from a preceding call statement" do
+      let stats =
+            [ Lua.ann . Lua.CallStatement . Lua.ann $
+                Lua.functionCall (Lua.varName [Lua.name|f|]) []
+            , Lua.ann . Lua.CallStatement . Lua.ann $
+                Lua.functionCall (Lua.functionDef [] [Lua.Return []]) []
+            ]
+      renderedStatements stats
+        `shouldBe` multiline ["f();", "(function() return end)()"]
+      reparsesToItself stats
+
+    it "no ';' when the next statement starts with a name" do
+      let stats =
+            [ Lua.ann . Lua.CallStatement . Lua.ann $
+                Lua.functionCall (Lua.varName [Lua.name|f|]) []
+            , Lua.ann . Lua.CallStatement . Lua.ann $
+                Lua.functionCall (Lua.varName [Lua.name|g|]) []
+            ]
+      renderedStatements stats `shouldBe` multiline ["f()", "g()"]
+      reparsesToItself stats
+
+  describe "statements from parsed foreign code" do
+    it "multiple assignment" do
+      let s =
+            Lua.Assign
+              (Lua.ann (Lua.VarName [Lua.name|a|]) :| [Lua.ann (Lua.VarName [Lua.name|b|])])
+              (Lua.ann (Lua.varName [Lua.name|b|]) :| [Lua.ann (Lua.varName [Lua.name|a|])])
+      renderedStatement s `shouldBe` "a, b = b, a"
+
+    it "multi-name local declaration" do
+      let s =
+            Lua.Local
+              ([Lua.name|a|] :| [[Lua.name|b|]])
+              [Lua.ann (Lua.Integer 1), Lua.ann (Lua.Integer 2)]
+      renderedStatement s `shouldBe` "local a, b = 1, 2"
+
+    it "local function" do
+      let s =
+            Lua.LocalFunction
+              [Lua.name|go|]
+              [Lua.ann (ParamNamed [Lua.name|n|])]
+              [Lua.ann (Lua.return (Lua.varName [Lua.name|n|]))]
+      renderedStatement s `shouldBe` "local function go(n) return n end"
+
+    it "while / repeat / break" do
+      renderedStatement
+        (Lua.While (Lua.ann (Lua.Boolean True)) [Lua.ann Lua.Break])
+        `shouldBe` "while true do break end"
+      renderedStatement
+        (Lua.Repeat [Lua.ann Lua.Break] (Lua.ann (Lua.Boolean True)))
+        `shouldBe` "repeat break until true"
+
+    it "numeric for renders its optional step" do
+      let body = [Lua.ann Lua.Break]
+      renderedStatement
+        ( Lua.ForNum
+            [Lua.name|i|]
+            (Lua.ann (Lua.Integer 1))
+            (Lua.ann (Lua.Integer 9))
+            Nothing
+            body
+        )
+        `shouldBe` "for i = 1, 9 do break end"
+      renderedStatement
+        ( Lua.ForNum
+            [Lua.name|i|]
+            (Lua.ann (Lua.Integer 9))
+            (Lua.ann (Lua.Integer 1))
+            (Just (Lua.ann (Lua.negate (Lua.Integer 1))))
+            body
+        )
+        `shouldBe` "for i = 9, 1, -(1) do break end"
+
+    it "generic for over pairs" do
+      renderedStatement
+        ( Lua.ForIn
+            ([Lua.name|k|] :| [[Lua.name|v|]])
+            ( Lua.ann
+                (Lua.functionCall (Lua.varName [Lua.name|pairs|]) [Lua.varName [Lua.name|t|]])
+                :| []
+            )
+            [Lua.ann Lua.Break]
+        )
+        `shouldBe` "for k, v in pairs(t) do break end"
+
+    it "do-block and call statement" do
+      renderedStatement
+        ( Lua.Do
+            [ Lua.ann . Lua.CallStatement . Lua.ann $
+                Lua.functionCall (Lua.varName [Lua.name|f|]) []
+            ]
+        )
+        `shouldBe` "do f() end"
+
+    it "bare and multi-value return" do
+      renderedStatement (Lua.Return []) `shouldBe` "return"
+      renderedStatement
+        (Lua.Return [Lua.ann (Lua.Integer 1), Lua.ann (Lua.Integer 2)])
+        `shouldBe` "return 1, 2"
+
+    it "an else-block holding a single if prints as elseif" do
+      let s =
+            Lua.ifThenElse
+              (Lua.varName [Lua.name|a|])
+              [Lua.return (Lua.Integer 1)]
+              [ Lua.ifThenElse
+                  (Lua.varName [Lua.name|b|])
+                  [Lua.return (Lua.Integer 2)]
+                  [Lua.return (Lua.Integer 3)]
+              ]
+      renderedStatement s
+        `shouldBe` "if a then return 1 elseif b then return 2 else return 3 end"
+
+  describe "expressions from parsed foreign code" do
+    it "method call" do
+      renderedExpression
+        (Lua.methodCall (Lua.varName [Lua.name|s|]) [Lua.name|sub|] [Lua.Integer 1])
+        `shouldBe` "s:sub(1)"
+
+    it "vararg expression and parameter" do
+      renderedExpression
+        (Lua.Function [Lua.ann ParamVararg] [Lua.ann (Lua.return Lua.Vararg)])
+        `shouldBe` "function(...) return ... end"
+
+    it "multi-value adjustment parens are preserved" do
+      renderedExpression
+        (Lua.Paren (Lua.ann (Lua.functionCall (Lua.varName [Lua.name|f|]) [])))
+        `shouldBe` "(f())"
+
+    it "array-part table row" do
+      renderedExpression (Lua.table [Lua.tableRowV (Lua.Integer 7)])
+        `shouldBe` "{ 7 }"
+
+  describe "comments" do
+    it "print on their own lines before the annotated node" do
+      let s =
+            ( ["-- doc", "-- more"]
+            , Lua.local1 [Lua.name|x|] (Lua.Integer 1)
+            )
+      rendered (Printer.printStatementA s)
+        `shouldBe` multiline ["-- doc", "-- more", "local x = 1"]
+
+    it "force a table constructor into vertical layout" do
+      let e =
+            Lua.TableCtor
+              [ (["-- why"], Lua.tableRowNV [Lua.name|foo|] (Lua.Integer 1))
+              ]
+      renderedExpression e
+        `shouldBe` multiline ["{", "  -- why", "  foo = 1", "}"]
+
   describe "Float" do
     -- https://github.com/purescript-lua/purescript-lua/issues/164
     it "NaN prints as a Lua-readable expression, not \"NaN\"" do
@@ -245,6 +424,16 @@ spec = do
       renderedExpression (Lua.Float (-(1 / 0)) `Lua.exponent` Lua.Integer 2)
         `shouldBe` "(-math.huge) ^ 2"
 
+    it "negative literals carry unary precedence: parens under ^" do
+      renderedExpression (Lua.Integer (-2) `Lua.exponent` Lua.Integer 2)
+        `shouldBe` "(-2) ^ 2"
+      renderedExpression (Lua.Float (-1.5) `Lua.exponent` Lua.Integer 2)
+        `shouldBe` "(-1.5) ^ 2"
+
+    it "negative literals need no parens under looser operators" do
+      renderedExpression (Lua.Integer (-2) `Lua.add` Lua.Integer 1)
+        `shouldBe` "-2 + 1"
+
 --------------------------------------------------------------------------------
 -- Utility functions -----------------------------------------------------------
 
@@ -253,6 +442,17 @@ multiline = Text.concat . intersperse "\n"
 
 renderedStatement ∷ Lua.Statement → Text
 renderedStatement = rendered . Printer.printStatement
+
+renderedStatements ∷ [Lua.Annotated Lua.Comments Lua.StatementF] → Text
+renderedStatements = rendered . vsep . Printer.printStatements
+
+-- | The printed form must parse back to exactly the same statements.
+reparsesToItself
+  ∷ HasCallStack ⇒ [Lua.Annotated Lua.Comments Lua.StatementF] → Expectation
+reparsesToItself stats =
+  case Parser.parseChunk "<printed>" (renderedStatements stats) of
+    Left err → expectationFailure (Parser.renderParseError err)
+    Right reparsed → reparsed `shouldBe` stats
 
 renderedExpression ∷ Lua.Exp → Text
 renderedExpression = rendered . Printer.printedExp

--- a/test/Language/PureScript/Backend/Lua/Run/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Run/Spec.hs
@@ -4,6 +4,7 @@ module Language.PureScript.Backend.Lua.Run.Spec where
 
 import Language.PureScript.Backend.Lua.Fixture qualified as Fixture
 import Language.PureScript.Backend.Lua.Name qualified as Lua
+import Language.PureScript.Backend.Lua.Parser (unsafeParseStatements)
 import Language.PureScript.Backend.Lua.Run (runChunk)
 import Language.PureScript.Backend.Lua.Types qualified as Lua
 import System.Exit (ExitCode (..))
@@ -27,17 +28,14 @@ spec = describe "Lua.Run.runChunk (powers `spago run`)" do
     -- bumps a counter, force it twice, and exit 0 only if the initializer ran
     -- exactly once. A non-memoizing fixture runs it on every force and exits 1.
     code ←
-      runChunk
-        [ Fixture.runtimeLazy
-        , Lua.ForeignSourceStat . unlines $
-            [ "local count = 0"
-            , "local lazy = "
-                <> Lua.toText Fixture.runtimeLazyName
-                <> "(\"x\")(function() count = count + 1; return {} end)"
-            , "lazy(1)"
-            , "lazy(2)"
-            , "os.exit(count == 1 and 0 or 1)"
-            ]
+      runChunk . (Fixture.runtimeLazy :) . unsafeParseStatements . unlines $
+        [ "local count = 0"
+        , "local lazy = "
+            <> Lua.toText Fixture.runtimeLazyName
+            <> "(\"x\")(function() count = count + 1; return {} end)"
+        , "lazy(1)"
+        , "lazy(2)"
+        , "os.exit(count == 1 and 0 or 1)"
         ]
     code `shouldBe` ExitSuccess
  where

--- a/test/Language/PureScript/Backend/Lua/Traversal/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Traversal/Spec.hs
@@ -1,0 +1,27 @@
+module Language.PureScript.Backend.Lua.Traversal.Spec where
+
+import Hedgehog (forAll, (===))
+import Language.PureScript.Backend.Lua.Gen qualified as Gen
+import Language.PureScript.Backend.Lua.Traversal
+  ( everywhereExp
+  , everywhereStat
+  )
+import Test.Hspec (Spec, describe)
+import Test.Hspec.Hedgehog.Extended (prop)
+import Prelude hiding (exp)
+
+{- | The traversals rebuild every node by hand, threading each 'Annotated'
+slot's comments through. A rebuild that dropped a @(c,)@ pair would
+silently discard FFI comments from the output, and nothing else checks
+that: the rewrite rules all promise "a rewrite that returns its argument
+unchanged is comment-preserving" on top of exactly this contract.
+-}
+spec ∷ Spec
+spec = describe "Lua AST traversal" do
+  prop 300 "everywhereStat identity identity ≡ identity" do
+    s ← forAll Gen.statement
+    everywhereStat identity identity s === s
+
+  prop 300 "everywhereExp identity identity ≡ identity" do
+    e ← forAll Gen.exp
+    everywhereExp identity identity e === e

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,13 +11,16 @@ import Language.PureScript.Backend.IR.Pass.Spec qualified as IRPass
 import Language.PureScript.Backend.IR.Spec qualified as IR
 import Language.PureScript.Backend.IR.Types.Spec qualified as Types
 import Language.PureScript.Backend.IR.Uniquify.Spec qualified as IRUniquify
+import Language.PureScript.Backend.Lua.Differential.Spec qualified as LuaDifferential
 import Language.PureScript.Backend.Lua.Golden.Spec qualified as Golden
 import Language.PureScript.Backend.Lua.Linker.Foreign.Spec qualified as LuaLinkerForeign
 import Language.PureScript.Backend.Lua.NestingCheck.Spec qualified as NestingCheck
 import Language.PureScript.Backend.Lua.Optimizer.Spec qualified as LuaOptimizer
+import Language.PureScript.Backend.Lua.Parser.Spec qualified as LuaParser
 import Language.PureScript.Backend.Lua.Printer.Spec qualified as Printer
 import Language.PureScript.Backend.Lua.Run.Spec qualified as Run
 import Language.PureScript.Backend.Lua.Spec qualified as Lua
+import Language.PureScript.Backend.Lua.Traversal.Spec qualified as LuaTraversal
 import Language.PureScript.Backend.Output.Spec qualified as Output
 import Language.PureScript.PSString.Spec qualified as PSString
 import Test.Hspec (hspec)
@@ -36,6 +39,9 @@ main = hspec do
   IRUniquify.spec
   LuaOptimizer.spec
   Lua.spec
+  LuaParser.spec
+  LuaDifferential.spec
+  LuaTraversal.spec
   Printer.spec
   Run.spec
   LuaLinkerForeign.spec

--- a/test/Test/Lua.hs
+++ b/test/Test/Lua.hs
@@ -1,0 +1,45 @@
+{- | Access to the reference Lua toolchain (@luac@, @lua@) — the external
+arbiter for generated Lua: unlike the compiler's own parser, it cannot share
+a bug with the printer.
+-}
+module Test.Lua
+  ( luacParse
+  , runLuaFile
+  ) where
+
+import Data.Text.IO qualified as Text.IO
+import Path (toFilePath)
+import Path.IO (withSystemTempFile)
+import System.Process.Typed
+  ( ExitCode
+  , ProcessConfig
+  , proc
+  , readProcessInterleaved
+  )
+
+{- | Parse-check (no execution) a Lua source with @luac -p@; returns the exit
+code and combined output. Writes to a unique auto-cleaned temp file and
+invokes @luac@ via 'proc' (an argv list, no shell), so it is portable and
+safe against paths with spaces or concurrent runs.
+-}
+luacParse ∷ Text → IO (ExitCode, Text)
+luacParse = withLuaTempFile \file → proc "luac" ["-p", file]
+
+{- | Run a Lua source with the @lua@ interpreter; returns the exit code and
+combined output. Same temp-file pattern as 'luacParse'.
+-}
+runLuaFile ∷ Text → IO (ExitCode, Text)
+runLuaFile = withLuaTempFile \file → proc "lua" [file]
+
+withLuaTempFile
+  ∷ (FilePath → ProcessConfig () () ())
+  → Text
+  → IO (ExitCode, Text)
+withLuaTempFile mkProcess src =
+  withSystemTempFile "pslua-test.lua" \file handle → do
+    -- Write through the handle the bracket owns and flush (so the separate
+    -- process sees the bytes); the bracket closes it on cleanup.
+    Text.IO.hPutStr handle src
+    hFlush handle
+    (code, out) ← readProcessInterleaved (mkProcess (toFilePath file))
+    pure (code, decodeUtf8 out)

--- a/test/ps/output/Golden.Annotations.M1/golden.lua
+++ b/test/ps/output/Golden.Annotations.M1/golden.lua
@@ -2,12 +2,8 @@ local M = {}
 M.Golden_Annotations_M1_foreign = (function()
   local step = 2
   return {
-    dontInlineClosure = function(i)
-        return i + step
-      end,
-    inlineMeLambda = function(i)
-        return i + i
-      end
+    dontInlineClosure = function(i) return i + step end,
+    inlineMeLambda = function(i) return i + i end
   }
 end)()
 return {

--- a/test/ps/output/Golden.Annotations.M2/golden.lua
+++ b/test/ps/output/Golden.Annotations.M2/golden.lua
@@ -2,12 +2,8 @@ local M = {}
 M.Golden_Annotations_M1_foreign = (function()
   local step = 2
   return {
-    dontInlineClosure = function(i)
-        return i + step
-      end,
-    inlineMeLambda = function(i)
-        return i + i
-      end
+    dontInlineClosure = function(i) return i + step end,
+    inlineMeLambda = function(i) return i + i end
   }
 end)()
 return {

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -27,29 +25,31 @@ M.Data_Semiring_foreign = {
 }
 M.Data_Foldable_foreign = {
   foldrArray = function(f)
-      return function(init)
-        return function(xs)
-          local acc = init
-          local len = #xs
-          for i = len, 1, -1 do acc = f(xs[i])(acc) end
-          return acc
-        end
-      end
-    end,
-  foldlArray = function(f)
-      return function(init)
-        return function(xs)
-          local acc = init
-          local len = #xs
-          for i = 1, len do acc = f(acc)(xs[i]) end
-          return acc
-        end
+    return function(init)
+      return function(xs)
+        local acc = init
+        local len = #(xs)
+        for i = len, 1, -(1) do acc = f(xs[i])(acc) end
+        return acc
       end
     end
+  end,
+  foldlArray = function(f)
+    return function(init)
+      return function(xs)
+        local acc = init
+        local len = #(xs)
+        for i = 1, len do acc = f(acc)(xs[i]) end
+        return acc
+      end
+    end
+  end
 }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end

--- a/test/ps/output/Golden.ArrayPatternMatch.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayPatternMatch.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -29,7 +27,9 @@ M.Data_Ring_foreign = {
 }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -25,7 +23,7 @@ M.Record_Unsafe_foreign = {
 M.Data_HeytingAlgebra_foreign = {
   boolConj = function(b1) return function(b2) return b1 and b2 end end,
   boolDisj = function(b1) return function(b2) return b1 or b2 end end,
-  boolNot = function(b) return not b end
+  boolNot = function(b) return not(b) end
 }
 M.Data_Eq_foreign = (function()
   local refEq = function(r1) return function(r2) return r1 == r2 end end
@@ -33,7 +31,9 @@ M.Data_Eq_foreign = (function()
 end)()
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
@@ -127,12 +127,10 @@ M.Golden_BugListGenericEq_Test_logShow = function(a_S_2)
   return M.Effect_Console_foreign.log((function()
     if a_S_2 then
       return "true"
+    elseif false == a_S_2 then
+      return "false"
     else
-      if false == a_S_2 then
-        return "false"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end)())
 end
@@ -149,12 +147,10 @@ M.Golden_BugListGenericEq_Test_genericList = {
   to = function(x)
     if "Data.Generic.Rep∷Sum.Inl" == x["$ctor"] then
       return M.Golden_BugListGenericEq_Test_Nil
+    elseif "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
+      return M.Golden_BugListGenericEq_Test_Cons(x.value0)
     else
-      if "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
-        return M.Golden_BugListGenericEq_Test_Cons(x.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end,
   from = function(x0)
@@ -162,14 +158,12 @@ M.Golden_BugListGenericEq_Test_genericList = {
       return (function(value0)
         return { ["$ctor"] = "Data.Generic.Rep∷Sum.Inl", value0 = value0 }
       end)({})
+    elseif "Golden.BugListGenericEq.Test∷List.Cons" == x0["$ctor"] then
+      return (function(value0)
+        return { ["$ctor"] = "Data.Generic.Rep∷Sum.Inr", value0 = value0 }
+      end)(x0.value0)
     else
-      if "Golden.BugListGenericEq.Test∷List.Cons" == x0["$ctor"] then
-        return (function(value0)
-          return { ["$ctor"] = "Data.Generic.Rep∷Sum.Inr", value0 = value0 }
-        end)(x0.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 }
@@ -199,34 +193,32 @@ M.Golden_BugListGenericEq_Test_eqList = function(dictEq)
                 else
                   return false
                 end
-              else
-                if "Data.Generic.Rep∷Sum.Inr" == v_S_13["$ctor"] then
-                  if "Data.Generic.Rep∷Sum.Inr" == v1_S_14["$ctor"] then
-                    return M.Data_Eq_Generic_genericEqPrime(M.Data_Eq_Generic_genericEqConstructor({
-                      genericEqPrime = function(v_S_21)
-                        return function(v1_S_22)
-                          return M.Data_Eq_eq({
-                            eq = M.Data_Eq_eqRecord(M.Data_Eq_eqRowCons(M.Data_Eq_eqRowCons({
-                              eqRecord = function()
-                                return function()
-                                  return function() return true end
-                                end
+              elseif "Data.Generic.Rep∷Sum.Inr" == v_S_13["$ctor"] then
+                if "Data.Generic.Rep∷Sum.Inr" == v1_S_14["$ctor"] then
+                  return M.Data_Eq_Generic_genericEqPrime(M.Data_Eq_Generic_genericEqConstructor({
+                    genericEqPrime = function(v_S_21)
+                      return function(v1_S_22)
+                        return M.Data_Eq_eq({
+                          eq = M.Data_Eq_eqRecord(M.Data_Eq_eqRowCons(M.Data_Eq_eqRowCons({
+                            eqRecord = function()
+                              return function()
+                                return function() return true end
                               end
-                            })()({
-                              reflectSymbol = function() return "tail" end
-                            })(M.Golden_BugListGenericEq_Test_eqList(dictEq)))()({
-                              reflectSymbol = function() return "head" end
-                            })(dictEq))(M.Type_Proxy_Proxy)
-                          })(v_S_21)(v1_S_22)
-                        end
+                            end
+                          })()({
+                            reflectSymbol = function() return "tail" end
+                          })(M.Golden_BugListGenericEq_Test_eqList(dictEq)))()({
+                            reflectSymbol = function() return "head" end
+                          })(dictEq))(M.Type_Proxy_Proxy)
+                        })(v_S_21)(v1_S_22)
                       end
-                    }))(v_S_13.value0)(v1_S_14.value0)
-                  else
-                    return false
-                  end
+                    end
+                  }))(v_S_13.value0)(v1_S_14.value0)
                 else
                   return false
                 end
+              else
+                return false
               end
             end
           end

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -25,20 +23,20 @@ M.Data_Eq_foreign = (function()
 end)()
 M.Data_Show_foreign = {
   showCharImpl = function(n)
-      local code = n:byte()
-      if code < 0x20 or code == 0x7F then
-        if n == "\a" then return "'\\a'" end
-        if n == "\b" then return "'\\b'" end
-        if n == "\f" then return "'\\f'" end
-        if n == "\n" then return "'\\n'" end
-        if n == "\r" then return "'\\r'" end
-        if n == "\t" then return "'\\t'" end
-        if n == "\v" then return "'\\v'" end
-        return "'\\" .. tostring(code) .. "'"
-      end
-      if n == "'" or n == "\\" then return "'\\" .. n .. "'" end
-      return "'" .. n .. "'"
+    local code = n:byte()
+    if code < 32 or code == 127 then
+      if n == "\a" then return "'\\a'" end
+      if n == "\b" then return "'\\b'" end
+      if n == "\f" then return "'\\f'" end
+      if n == "\n" then return "'\\n'" end
+      if n == "\r" then return "'\\r'" end
+      if n == "\t" then return "'\\t'" end
+      if n == "\v" then return "'\\v'" end
+      return "'\\" .. tostring(code) .. "'"
     end
+    if n == "'" or n == "\\" then return "'\\" .. n .. "'" end
+    return "'" .. n .. "'"
+  end
 }
 M.Data_Ord_foreign = (function()
   local unsafeCoerceImpl = function(lt)
@@ -62,7 +60,9 @@ M.Data_Ord_foreign = (function()
 end)()
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
@@ -116,12 +116,10 @@ M.Golden_CharLiterals_Test_show1 = M.Data_Show_show({
   show = function(v_S_111)
     if v_S_111 then
       return "true"
+    elseif false == v_S_111 then
+      return "false"
     else
-      if false == v_S_111 then
-        return "false"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })

--- a/test/ps/output/Golden.DerivedFunctor.Test/golden.lua
+++ b/test/ps/output/Golden.DerivedFunctor.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -26,7 +24,9 @@ M.Data_Semiring_foreign = {
 }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
@@ -113,12 +113,10 @@ end
 M.Golden_DerivedFunctor_Test_sumTree = function(v)
   if "Golden.DerivedFunctor.Test∷Tree.Leaf" == v["$ctor"] then
     return 0
+  elseif "Golden.DerivedFunctor.Test∷Tree.Node" == v["$ctor"] then
+    return M.Golden_DerivedFunctor_Test_add(M.Golden_DerivedFunctor_Test_add(M.Golden_DerivedFunctor_Test_sumTree(v.value0))(v.value1))(M.Golden_DerivedFunctor_Test_sumTree(v.value2))
   else
-    if "Golden.DerivedFunctor.Test∷Tree.Node" == v["$ctor"] then
-      return M.Golden_DerivedFunctor_Test_add(M.Golden_DerivedFunctor_Test_add(M.Golden_DerivedFunctor_Test_sumTree(v.value0))(v.value1))(M.Golden_DerivedFunctor_Test_sumTree(v.value2))
-    else
-      return error("No patterns matched")
-    end
+    return error("No patterns matched")
   end
 end
 M.Golden_DerivedFunctor_Test_functorTree = {
@@ -126,12 +124,10 @@ M.Golden_DerivedFunctor_Test_functorTree = {
     return function(m)
       if "Golden.DerivedFunctor.Test∷Tree.Leaf" == m["$ctor"] then
         return M.Golden_DerivedFunctor_Test_Leaf
+      elseif "Golden.DerivedFunctor.Test∷Tree.Node" == m["$ctor"] then
+        return M.Golden_DerivedFunctor_Test_Node(M.Data_Functor_map(M.Golden_DerivedFunctor_Test_functorTree)(f)(m.value0))(f(m.value1))(M.Data_Functor_map(M.Golden_DerivedFunctor_Test_functorTree)(f)(m.value2))
       else
-        if "Golden.DerivedFunctor.Test∷Tree.Node" == m["$ctor"] then
-          return M.Golden_DerivedFunctor_Test_Node(M.Data_Functor_map(M.Golden_DerivedFunctor_Test_functorTree)(f)(m.value0))(f(m.value1))(M.Data_Functor_map(M.Golden_DerivedFunctor_Test_functorTree)(f)(m.value2))
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   end
@@ -141,12 +137,10 @@ M.Golden_DerivedFunctor_Test_functorEither = {
     return function(m)
       if "Golden.DerivedFunctor.Test∷Either.Left" == m["$ctor"] then
         return M.Golden_DerivedFunctor_Test_Left(m.value0)
+      elseif "Golden.DerivedFunctor.Test∷Either.Right" == m["$ctor"] then
+        return M.Golden_DerivedFunctor_Test_Right(f(m.value0))
       else
-        if "Golden.DerivedFunctor.Test∷Either.Right" == m["$ctor"] then
-          return M.Golden_DerivedFunctor_Test_Right(f(m.value0))
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   end
@@ -156,12 +150,10 @@ M.Golden_DerivedFunctor_Test_fromRight = function(fallback)
   return function(v)
     if "Golden.DerivedFunctor.Test∷Either.Left" == v["$ctor"] then
       return fallback
+    elseif "Golden.DerivedFunctor.Test∷Either.Right" == v["$ctor"] then
+      return v.value0
     else
-      if "Golden.DerivedFunctor.Test∷Either.Right" == v["$ctor"] then
-        return v.value0
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 end

--- a/test/ps/output/Golden.Fibonacci.Test/golden.lua
+++ b/test/ps/output/Golden.Fibonacci.Test/golden.lua
@@ -12,12 +12,10 @@ M.Effect_Console_foreign = {
 M.Golden_Fibonacci_Test_fib = function(v)
   if 0 == v then
     return 0
+  elseif 1 == v then
+    return 1
   else
-    if 1 == v then
-      return 1
-    else
-      return M.Data_Semiring_foreign.intAdd(M.Golden_Fibonacci_Test_fib(M.Data_Ring_foreign.intSub(v)(1)))(M.Golden_Fibonacci_Test_fib(M.Data_Ring_foreign.intSub(v)(2)))
-    end
+    return M.Data_Semiring_foreign.intAdd(M.Golden_Fibonacci_Test_fib(M.Data_Ring_foreign.intSub(v)(1)))(M.Golden_Fibonacci_Test_fib(M.Data_Ring_foreign.intSub(v)(2)))
   end
 end
 return M.Effect_Console_foreign.log(M.Data_Show_foreign.showIntImpl(M.Golden_Fibonacci_Test_fib(32)))()

--- a/test/ps/output/Golden.FloatIn.Test/golden.lua
+++ b/test/ps/output/Golden.FloatIn.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -27,16 +25,15 @@ M.Data_Semiring_foreign = {
 }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
 M.Golden_FloatIn_Test_foreign = {
-  tick = function(n)
-      print("tick")
-      return n + n
-    end
+  tick = function(n) print("tick") return n + n end
 }
 M.Data_Semiring_semiringInt = {
   add = M.Data_Semiring_foreign.intAdd,

--- a/test/ps/output/Golden.Foreign.Lib/golden.lua
+++ b/test/ps/output/Golden.Foreign.Lib/golden.lua
@@ -1,5 +1,5 @@
 local M = {}
-M.Golden_Foreign_Lib_foreign = { dead = -100, alive = 100 }
+M.Golden_Foreign_Lib_foreign = { dead = -(100), alive = 100 }
 return {
   dead = M.Golden_Foreign_Lib_foreign.dead,
   alive = M.Golden_Foreign_Lib_foreign.alive

--- a/test/ps/output/Golden.ForeignSharing.Test/golden.lua
+++ b/test/ps/output/Golden.ForeignSharing.Test/golden.lua
@@ -4,11 +4,7 @@ M.Effect_Console_foreign = {
 }
 M.Golden_ForeignSharing_Token_foreign = { token = {} }
 M.Golden_ForeignSharing_Test_foreign = {
-  same = function(a)
-      return function(b)
-        return rawequal(a, b)
-      end
-    end
+  same = function(a) return function(b) return rawequal(a, b) end end
 }
 M.Golden_ForeignSharing_Test_sharedToken = function()
   return M.Golden_ForeignSharing_Token_foreign.token

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -25,7 +23,7 @@ M.Record_Unsafe_foreign = {
 M.Data_HeytingAlgebra_foreign = {
   boolConj = function(b1) return function(b2) return b1 and b2 end end,
   boolDisj = function(b1) return function(b2) return b1 or b2 end end,
-  boolNot = function(b) return not b end
+  boolNot = function(b) return not(b) end
 }
 M.Data_Eq_foreign = (function()
   local refEq = function(r1) return function(r2) return r1 == r2 end end
@@ -33,7 +31,9 @@ M.Data_Eq_foreign = (function()
 end)()
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
@@ -159,16 +159,14 @@ M.Golden_GenericEqTwoTypes_Test_genericEqSum = function(dictGenericEq1_S_5)
           else
             return false
           end
-        else
-          if "Data.Generic.Rep∷Sum.Inr" == v_S_7["$ctor"] then
-            if "Data.Generic.Rep∷Sum.Inr" == v1_S_8["$ctor"] then
-              return M.Data_Eq_Generic_genericEqPrime(dictGenericEq1_S_5)(v_S_7.value0)(v1_S_8.value0)
-            else
-              return false
-            end
+        elseif "Data.Generic.Rep∷Sum.Inr" == v_S_7["$ctor"] then
+          if "Data.Generic.Rep∷Sum.Inr" == v1_S_8["$ctor"] then
+            return M.Data_Eq_Generic_genericEqPrime(dictGenericEq1_S_5)(v_S_7.value0)(v1_S_8.value0)
           else
             return false
           end
+        else
+          return false
         end
       end
     end
@@ -187,12 +185,10 @@ M.Golden_GenericEqTwoTypes_Test_logShow = function(a_S_2)
   return M.Effect_Console_foreign.log((function()
     if a_S_2 then
       return "true"
+    elseif false == a_S_2 then
+      return "false"
     else
-      if false == a_S_2 then
-        return "false"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end)())
 end
@@ -229,23 +225,19 @@ M.Golden_GenericEqTwoTypes_Test_genericTree = {
   to = function(x)
     if "Data.Generic.Rep∷Sum.Inl" == x["$ctor"] then
       return M.Golden_GenericEqTwoTypes_Test_Leaf
+    elseif "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
+      return M.Golden_GenericEqTwoTypes_Test_Node(x.value0)
     else
-      if "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
-        return M.Golden_GenericEqTwoTypes_Test_Node(x.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end,
   from = function(x0)
     if "Golden.GenericEqTwoTypes.Test∷Tree.Leaf" == x0["$ctor"] then
       return M.Data_Generic_Rep_Inl(M.Data_Generic_Rep_NoArguments)
+    elseif "Golden.GenericEqTwoTypes.Test∷Tree.Node" == x0["$ctor"] then
+      return M.Data_Generic_Rep_Inr(x0.value0)
     else
-      if "Golden.GenericEqTwoTypes.Test∷Tree.Node" == x0["$ctor"] then
-        return M.Data_Generic_Rep_Inr(x0.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 }
@@ -253,23 +245,19 @@ M.Golden_GenericEqTwoTypes_Test_genericList = {
   to = function(x)
     if "Data.Generic.Rep∷Sum.Inl" == x["$ctor"] then
       return M.Golden_GenericEqTwoTypes_Test_Nil
+    elseif "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
+      return M.Golden_GenericEqTwoTypes_Test_Cons(x.value0)
     else
-      if "Data.Generic.Rep∷Sum.Inr" == x["$ctor"] then
-        return M.Golden_GenericEqTwoTypes_Test_Cons(x.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end,
   from = function(x0)
     if "Golden.GenericEqTwoTypes.Test∷List.Nil" == x0["$ctor"] then
       return M.Data_Generic_Rep_Inl(M.Data_Generic_Rep_NoArguments)
+    elseif "Golden.GenericEqTwoTypes.Test∷List.Cons" == x0["$ctor"] then
+      return M.Data_Generic_Rep_Inr(x0.value0)
     else
-      if "Golden.GenericEqTwoTypes.Test∷List.Cons" == x0["$ctor"] then
-        return M.Data_Generic_Rep_Inr(x0.value0)
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 }

--- a/test/ps/output/Golden.HelloPrelude.Test/golden.lua
+++ b/test/ps/output/Golden.HelloPrelude.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -22,7 +20,9 @@ local M = {}
 M.Data_Unit_foreign = { unit = {} }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Control_Applicative_pure = function(dict) return dict.pure end
 M.Effect_monadEffect = {

--- a/test/ps/output/Golden.Issue37.Test/golden.lua
+++ b/test/ps/output/Golden.Issue37.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -22,7 +20,9 @@ local M = {}
 M.Data_Unit_foreign = { unit = {} }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Control_Applicative_pure = function(dict) return dict.pure end
 M.Control_Bind_bind = function(dict) return dict.bind end

--- a/test/ps/output/Golden.LongApplyChain.Test/golden.lua
+++ b/test/ps/output/Golden.LongApplyChain.Test/golden.lua
@@ -28,12 +28,10 @@ M.Data_Maybe_applyMaybe = {
     return function(v1)
       if "Data.Maybe∷Maybe.Just" == v["$ctor"] then
         return M.Data_Functor_map(M.Data_Maybe_functorMaybe)(v.value0)(v1)
+      elseif "Data.Maybe∷Maybe.Nothing" == v["$ctor"] then
+        return M.Data_Maybe_Nothing
       else
-        if "Data.Maybe∷Maybe.Nothing" == v["$ctor"] then
-          return M.Data_Maybe_Nothing
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   end,
@@ -69,12 +67,10 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Just ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showIntImpl
       })(v_S_20_S_287.value0))(")"))
+    elseif "Data.Maybe∷Maybe.Nothing" == v_S_20_S_287["$ctor"] then
+      return "Nothing"
     else
-      if "Data.Maybe∷Maybe.Nothing" == v_S_20_S_287["$ctor"] then
-        return "Nothing"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongApplyChain_Test_compute))()

--- a/test/ps/output/Golden.LongBindFlipped.Test/golden.lua
+++ b/test/ps/output/Golden.LongBindFlipped.Test/golden.lua
@@ -17,12 +17,10 @@ M.Golden_LongBindFlipped_Test_bindFlipped = function(b_S_135_S_275)
   return function(a_S_136_S_276)
     if "Data.Maybe∷Maybe.Just" == a_S_136_S_276["$ctor"] then
       return b_S_135_S_275(a_S_136_S_276.value0)
+    elseif "Data.Maybe∷Maybe.Nothing" == a_S_136_S_276["$ctor"] then
+      return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
     else
-      if "Data.Maybe∷Maybe.Nothing" == a_S_136_S_276["$ctor"] then
-        return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 end
@@ -45,12 +43,10 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Just ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showIntImpl
       })(v_S_16_S_282.value0))(")"))
+    elseif "Data.Maybe∷Maybe.Nothing" == v_S_16_S_282["$ctor"] then
+      return "Nothing"
     else
-      if "Data.Maybe∷Maybe.Nothing" == v_S_16_S_282["$ctor"] then
-        return "Nothing"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongBindFlipped_Test_compute))()

--- a/test/ps/output/Golden.LongDoBlock.Test/golden.lua
+++ b/test/ps/output/Golden.LongDoBlock.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -21,7 +19,9 @@ end
 local M = {}
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end

--- a/test/ps/output/Golden.LongEitherBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongEitherBind.Test/golden.lua
@@ -5,44 +5,44 @@ M.Data_Semigroup_foreign = {
 M.Data_Show_foreign = {
   showIntImpl = function(n) return tostring(n) end,
   showStringImpl = function(s)
-      -- Mirror PureScript's `show`: wrap in double quotes and escape control
-      -- characters, '"' and '\' so the result round-trips to a String literal.
-      local out = {"\""}
-      local len = #s
-      local i = 1
-      while i <= len do
-        local c = s:sub(i, i)
-        local b = c:byte()
-        if c == "\"" or c == "\\" then
-          out[#out + 1] = "\\" .. c
-        elseif b == 0x07 then
-          out[#out + 1] = "\\a"
-        elseif b == 0x08 then
-          out[#out + 1] = "\\b"
-        elseif b == 0x0C then
-          out[#out + 1] = "\\f"
-        elseif b == 0x0A then
-          out[#out + 1] = "\\n"
-        elseif b == 0x0D then
-          out[#out + 1] = "\\r"
-        elseif b == 0x09 then
-          out[#out + 1] = "\\t"
-        elseif b == 0x0B then
-          out[#out + 1] = "\\v"
-        elseif b < 0x20 or b == 0x7F then
-          -- numeric escape; "\&" guards against a following digit being
-          -- swallowed into the escape (e.g. "\27\&5" /= "\275").
-          local nxt = s:sub(i + 1, i + 1)
-          local gap = (nxt >= "0" and nxt <= "9") and "\\&" or ""
-          out[#out + 1] = "\\" .. tostring(b) .. gap
-        else
-          out[#out + 1] = c
-        end
-        i = i + 1
+    -- Mirror PureScript's `show`: wrap in double quotes and escape control
+    -- characters, '"' and '\' so the result round-trips to a String literal.
+    local out = { "\"" }
+    local len = #(s)
+    local i = 1
+    while i <= len do
+      local c = s:sub(i, i)
+      local b = c:byte()
+      if c == "\"" or c == "\\" then
+        out[#(out) + 1] = "\\" .. c
+      elseif b == 7 then
+        out[#(out) + 1] = "\\a"
+      elseif b == 8 then
+        out[#(out) + 1] = "\\b"
+      elseif b == 12 then
+        out[#(out) + 1] = "\\f"
+      elseif b == 10 then
+        out[#(out) + 1] = "\\n"
+      elseif b == 13 then
+        out[#(out) + 1] = "\\r"
+      elseif b == 9 then
+        out[#(out) + 1] = "\\t"
+      elseif b == 11 then
+        out[#(out) + 1] = "\\v"
+      elseif b < 32 or b == 127 then
+        -- numeric escape; "\&" guards against a following digit being
+        -- swallowed into the escape (e.g. "\27\&5" /= "\275").
+        local nxt = s:sub(i + 1, i + 1)
+        local gap = nxt >= "0" and nxt <= "9" and "\\&" or ""
+        out[#(out) + 1] = "\\" .. tostring(b) .. gap
+      else
+        out[#(out) + 1] = c
       end
-      out[#out + 1] = "\""
-      return table.concat(out)
+      i = i + 1
     end
+    out[#(out) + 1] = "\""
+    return table.concat(out)
+  end
 }
 M.Data_Semiring_foreign = {
   intAdd = function(x) return function(y) return x + y end end
@@ -61,12 +61,10 @@ M.Golden_LongEitherBind_Test_bind = function(v2_S_288)
         return { ["$ctor"] = "Data.Either∷Either.Left", value0 = value0 }
       end)(v2_S_288.value0)
     end
+  elseif "Data.Either∷Either.Right" == v2_S_288["$ctor"] then
+    return function(f_S_285) return f_S_285(v2_S_288.value0) end
   else
-    if "Data.Either∷Either.Right" == v2_S_288["$ctor"] then
-      return function(f_S_285) return f_S_285(v2_S_288.value0) end
-    else
-      return error("No patterns matched")
-    end
+    return error("No patterns matched")
   end
 end
 M.Golden_LongEitherBind_Test_compute = (function()
@@ -721,14 +719,12 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Left ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showStringImpl
       })(v_S_7_S_294.value0))(")"))
+    elseif "Data.Either∷Either.Right" == v_S_7_S_294["$ctor"] then
+      return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
+        show = M.Data_Show_foreign.showIntImpl
+      })(v_S_7_S_294.value0))(")"))
     else
-      if "Data.Either∷Either.Right" == v_S_7_S_294["$ctor"] then
-        return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
-          show = M.Data_Show_foreign.showIntImpl
-        })(v_S_7_S_294.value0))(")"))
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongEitherBind_Test_compute))()

--- a/test/ps/output/Golden.LongExceptBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongExceptBind.Test/golden.lua
@@ -5,44 +5,44 @@ M.Data_Semigroup_foreign = {
 M.Data_Show_foreign = {
   showIntImpl = function(n) return tostring(n) end,
   showStringImpl = function(s)
-      -- Mirror PureScript's `show`: wrap in double quotes and escape control
-      -- characters, '"' and '\' so the result round-trips to a String literal.
-      local out = {"\""}
-      local len = #s
-      local i = 1
-      while i <= len do
-        local c = s:sub(i, i)
-        local b = c:byte()
-        if c == "\"" or c == "\\" then
-          out[#out + 1] = "\\" .. c
-        elseif b == 0x07 then
-          out[#out + 1] = "\\a"
-        elseif b == 0x08 then
-          out[#out + 1] = "\\b"
-        elseif b == 0x0C then
-          out[#out + 1] = "\\f"
-        elseif b == 0x0A then
-          out[#out + 1] = "\\n"
-        elseif b == 0x0D then
-          out[#out + 1] = "\\r"
-        elseif b == 0x09 then
-          out[#out + 1] = "\\t"
-        elseif b == 0x0B then
-          out[#out + 1] = "\\v"
-        elseif b < 0x20 or b == 0x7F then
-          -- numeric escape; "\&" guards against a following digit being
-          -- swallowed into the escape (e.g. "\27\&5" /= "\275").
-          local nxt = s:sub(i + 1, i + 1)
-          local gap = (nxt >= "0" and nxt <= "9") and "\\&" or ""
-          out[#out + 1] = "\\" .. tostring(b) .. gap
-        else
-          out[#out + 1] = c
-        end
-        i = i + 1
+    -- Mirror PureScript's `show`: wrap in double quotes and escape control
+    -- characters, '"' and '\' so the result round-trips to a String literal.
+    local out = { "\"" }
+    local len = #(s)
+    local i = 1
+    while i <= len do
+      local c = s:sub(i, i)
+      local b = c:byte()
+      if c == "\"" or c == "\\" then
+        out[#(out) + 1] = "\\" .. c
+      elseif b == 7 then
+        out[#(out) + 1] = "\\a"
+      elseif b == 8 then
+        out[#(out) + 1] = "\\b"
+      elseif b == 12 then
+        out[#(out) + 1] = "\\f"
+      elseif b == 10 then
+        out[#(out) + 1] = "\\n"
+      elseif b == 13 then
+        out[#(out) + 1] = "\\r"
+      elseif b == 9 then
+        out[#(out) + 1] = "\\t"
+      elseif b == 11 then
+        out[#(out) + 1] = "\\v"
+      elseif b < 32 or b == 127 then
+        -- numeric escape; "\&" guards against a following digit being
+        -- swallowed into the escape (e.g. "\27\&5" /= "\275").
+        local nxt = s:sub(i + 1, i + 1)
+        local gap = nxt >= "0" and nxt <= "9" and "\\&" or ""
+        out[#(out) + 1] = "\\" .. tostring(b) .. gap
+      else
+        out[#(out) + 1] = c
       end
-      out[#out + 1] = "\""
-      return table.concat(out)
+      i = i + 1
     end
+    out[#(out) + 1] = "\""
+    return table.concat(out)
+  end
 }
 M.Data_Semiring_foreign = {
   intAdd = function(x) return function(y) return x + y end end
@@ -111,12 +111,10 @@ M.Control_Monad_Except_Trans_bindExceptT = function(dictMonad)
         return M.Control_Bind_bind(dictMonad.Bind1())(v)(function(v2_S_506)
           if "Data.Either∷Either.Left" == v2_S_506["$ctor"] then
             return M.Control_Monad_Except_Trans_compose(M.Control_Applicative_pure(dictMonad.Applicative0()))(M.Data_Either_Left)(v2_S_506.value0)
+          elseif "Data.Either∷Either.Right" == v2_S_506["$ctor"] then
+            return k(v2_S_506.value0)
           else
-            if "Data.Either∷Either.Right" == v2_S_506["$ctor"] then
-              return k(v2_S_506.value0)
-            else
-              return error("No patterns matched")
-            end
+            return error("No patterns matched")
           end
         end)
       end
@@ -150,12 +148,10 @@ M.Control_Monad_Except_Trans_applyExceptT = function(dictMonad)
                 return function(m_S_508)
                   if "Data.Either∷Either.Left" == m_S_508["$ctor"] then
                     return M.Data_Either_Left(m_S_508.value0)
+                  elseif "Data.Either∷Either.Right" == m_S_508["$ctor"] then
+                    return M.Data_Either_Right(f_S_507(m_S_508.value0))
                   else
-                    if "Data.Either∷Either.Right" == m_S_508["$ctor"] then
-                      return M.Data_Either_Right(f_S_507(m_S_508.value0))
-                    else
-                      return error("No patterns matched")
-                    end
+                    return error("No patterns matched")
                   end
                 end
               end
@@ -608,14 +604,12 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Left ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showStringImpl
       })(v_S_189_S_517.value0))(")"))
+    elseif "Data.Either∷Either.Right" == v_S_189_S_517["$ctor"] then
+      return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
+        show = M.Data_Show_foreign.showIntImpl
+      })(v_S_189_S_517.value0))(")"))
     else
-      if "Data.Either∷Either.Right" == v_S_189_S_517["$ctor"] then
-        return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
-          show = M.Data_Show_foreign.showIntImpl
-        })(v_S_189_S_517.value0))(")"))
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongExceptBind_Test_compute))()

--- a/test/ps/output/Golden.LongMaybeBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongMaybeBind.Test/golden.lua
@@ -18,12 +18,10 @@ M.Golden_LongMaybeBind_Test_bind = function(v_S_270)
   return function(v1_S_271)
     if "Data.Maybe∷Maybe.Just" == v_S_270["$ctor"] then
       return v1_S_271(v_S_270.value0)
+    elseif "Data.Maybe∷Maybe.Nothing" == v_S_270["$ctor"] then
+      return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
     else
-      if "Data.Maybe∷Maybe.Nothing" == v_S_270["$ctor"] then
-        return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 end
@@ -677,12 +675,10 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Just ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showIntImpl
       })(v_S_16_S_278.value0))(")"))
+    elseif "Data.Maybe∷Maybe.Nothing" == v_S_16_S_278["$ctor"] then
+      return "Nothing"
     else
-      if "Data.Maybe∷Maybe.Nothing" == v_S_16_S_278["$ctor"] then
-        return "Nothing"
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongMaybeBind_Test_compute))()

--- a/test/ps/output/Golden.LongMaybeBindModule.Test/golden.lua
+++ b/test/ps/output/Golden.LongMaybeBindModule.Test/golden.lua
@@ -10,12 +10,10 @@ M.Golden_LongMaybeBindModule_Test_bind = function(v_S_545)
   return function(v1_S_546)
     if "Data.Maybe∷Maybe.Just" == v_S_545["$ctor"] then
       return v1_S_546(v_S_545.value0)
+    elseif "Data.Maybe∷Maybe.Nothing" == v_S_545["$ctor"] then
+      return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
     else
-      if "Data.Maybe∷Maybe.Nothing" == v_S_545["$ctor"] then
-        return { ["$ctor"] = "Data.Maybe∷Maybe.Nothing" }
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 end

--- a/test/ps/output/Golden.LongStackBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongStackBind.Test/golden.lua
@@ -6,44 +6,44 @@ M.Data_Semigroup_foreign = {
 M.Data_Show_foreign = {
   showIntImpl = function(n) return tostring(n) end,
   showStringImpl = function(s)
-      -- Mirror PureScript's `show`: wrap in double quotes and escape control
-      -- characters, '"' and '\' so the result round-trips to a String literal.
-      local out = {"\""}
-      local len = #s
-      local i = 1
-      while i <= len do
-        local c = s:sub(i, i)
-        local b = c:byte()
-        if c == "\"" or c == "\\" then
-          out[#out + 1] = "\\" .. c
-        elseif b == 0x07 then
-          out[#out + 1] = "\\a"
-        elseif b == 0x08 then
-          out[#out + 1] = "\\b"
-        elseif b == 0x0C then
-          out[#out + 1] = "\\f"
-        elseif b == 0x0A then
-          out[#out + 1] = "\\n"
-        elseif b == 0x0D then
-          out[#out + 1] = "\\r"
-        elseif b == 0x09 then
-          out[#out + 1] = "\\t"
-        elseif b == 0x0B then
-          out[#out + 1] = "\\v"
-        elseif b < 0x20 or b == 0x7F then
-          -- numeric escape; "\&" guards against a following digit being
-          -- swallowed into the escape (e.g. "\27\&5" /= "\275").
-          local nxt = s:sub(i + 1, i + 1)
-          local gap = (nxt >= "0" and nxt <= "9") and "\\&" or ""
-          out[#out + 1] = "\\" .. tostring(b) .. gap
-        else
-          out[#out + 1] = c
-        end
-        i = i + 1
+    -- Mirror PureScript's `show`: wrap in double quotes and escape control
+    -- characters, '"' and '\' so the result round-trips to a String literal.
+    local out = { "\"" }
+    local len = #(s)
+    local i = 1
+    while i <= len do
+      local c = s:sub(i, i)
+      local b = c:byte()
+      if c == "\"" or c == "\\" then
+        out[#(out) + 1] = "\\" .. c
+      elseif b == 7 then
+        out[#(out) + 1] = "\\a"
+      elseif b == 8 then
+        out[#(out) + 1] = "\\b"
+      elseif b == 12 then
+        out[#(out) + 1] = "\\f"
+      elseif b == 10 then
+        out[#(out) + 1] = "\\n"
+      elseif b == 13 then
+        out[#(out) + 1] = "\\r"
+      elseif b == 9 then
+        out[#(out) + 1] = "\\t"
+      elseif b == 11 then
+        out[#(out) + 1] = "\\v"
+      elseif b < 32 or b == 127 then
+        -- numeric escape; "\&" guards against a following digit being
+        -- swallowed into the escape (e.g. "\27\&5" /= "\275").
+        local nxt = s:sub(i + 1, i + 1)
+        local gap = nxt >= "0" and nxt <= "9" and "\\&" or ""
+        out[#(out) + 1] = "\\" .. tostring(b) .. gap
+      else
+        out[#(out) + 1] = c
       end
-      out[#out + 1] = "\""
-      return table.concat(out)
+      i = i + 1
     end
+    out[#(out) + 1] = "\""
+    return table.concat(out)
+  end
 }
 M.Data_Semiring_foreign = {
   intAdd = function(x) return function(y) return x + y end end
@@ -101,12 +101,10 @@ M.Control_Monad_Except_Trans_functorExceptT = function(dictFunctor)
             return function(m_S_552)
               if "Data.Either∷Either.Left" == m_S_552["$ctor"] then
                 return M.Data_Either_Left(m_S_552.value0)
+              elseif "Data.Either∷Either.Right" == m_S_552["$ctor"] then
+                return M.Data_Either_Right(f_S_551(m_S_552.value0))
               else
-                if "Data.Either∷Either.Right" == m_S_552["$ctor"] then
-                  return M.Data_Either_Right(f_S_551(m_S_552.value0))
-                else
-                  return error("No patterns matched")
-                end
+                return error("No patterns matched")
               end
             end
           end
@@ -132,12 +130,10 @@ M.Control_Monad_Except_Trans_bindExceptT = function(dictMonad)
         return M.Control_Bind_bind(dictMonad.Bind1())(v)(function(v2_S_550)
           if "Data.Either∷Either.Left" == v2_S_550["$ctor"] then
             return M.Control_Monad_Except_Trans_compose(M.Control_Applicative_pure(dictMonad.Applicative0()))(M.Data_Either_Left)(v2_S_550.value0)
+          elseif "Data.Either∷Either.Right" == v2_S_550["$ctor"] then
+            return k(v2_S_550.value0)
           else
-            if "Data.Either∷Either.Right" == v2_S_550["$ctor"] then
-              return k(v2_S_550.value0)
-            else
-              return error("No patterns matched")
-            end
+            return error("No patterns matched")
           end
         end)
       end
@@ -893,14 +889,12 @@ return M.Effect_Console_foreign.log(M.Data_Show_show({
       return M.Data_Semigroup_foreign.concatString("(Left ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
         show = M.Data_Show_foreign.showStringImpl
       })(v_S_228_S_557.value0))(")"))
+    elseif "Data.Either∷Either.Right" == v_S_228_S_557["$ctor"] then
+      return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
+        show = M.Data_Show_foreign.showIntImpl
+      })(v_S_228_S_557.value0))(")"))
     else
-      if "Data.Either∷Either.Right" == v_S_228_S_557["$ctor"] then
-        return M.Data_Semigroup_foreign.concatString("(Right ")(M.Data_Semigroup_foreign.concatString(M.Data_Show_show({
-          show = M.Data_Show_foreign.showIntImpl
-        })(v_S_228_S_557.value0))(")"))
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end
 })(M.Golden_LongStackBind_Test_compute))()

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.lua
@@ -2,16 +2,16 @@ local M = {}
 M.Data_Unit_foreign = { unit = {} }
 M.Data_Semigroup_foreign = {
   concatArray = function(xs)
-      return function(ys)
-        if #xs == 0 then return ys end
-        if #ys == 0 then return xs end
-        local result = {}
-        for index, value in ipairs(xs) do result[index] = value end
-        local offset = #result
-        for index, value in ipairs(ys) do result[index + offset] = value end
-        return result
-      end
+    return function(ys)
+      if #(xs) == 0 then return ys end
+      if #(ys) == 0 then return xs end
+      local result = {}
+      for index, value in ipairs(xs) do result[index] = value end
+      local offset = #(result)
+      for index, value in ipairs(ys) do result[index + offset] = value end
+      return result
     end
+  end
 }
 M.Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 M.Unsafe_Coerce_foreign = { unsafeCoerce = function(x) return x end }

--- a/test/ps/output/Golden.MaybeChain.Test/golden.lua
+++ b/test/ps/output/Golden.MaybeChain.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -22,7 +20,9 @@ local M = {}
 M.Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
@@ -38,12 +38,10 @@ M.Data_Maybe_maybe = function(v)
     return function(v2)
       if "Data.Maybe∷Maybe.Nothing" == v2["$ctor"] then
         return v
+      elseif "Data.Maybe∷Maybe.Just" == v2["$ctor"] then
+        return v1(v2.value0)
       else
-        if "Data.Maybe∷Maybe.Just" == v2["$ctor"] then
-          return v1(v2.value0)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   end

--- a/test/ps/output/Golden.MaybeChainModule.Test/golden.lua
+++ b/test/ps/output/Golden.MaybeChainModule.Test/golden.lua
@@ -8,12 +8,10 @@ M.Data_Maybe_maybe = function(v)
     return function(v2)
       if "Data.Maybe∷Maybe.Nothing" == v2["$ctor"] then
         return v
+      elseif "Data.Maybe∷Maybe.Just" == v2["$ctor"] then
+        return v1(v2.value0)
       else
-        if "Data.Maybe∷Maybe.Just" == v2["$ctor"] then
-          return v1(v2.value0)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   end

--- a/test/ps/output/Golden.NameShadowing.Test/golden.lua
+++ b/test/ps/output/Golden.NameShadowing.Test/golden.lua
@@ -1,7 +1,7 @@
 local M = {}
 M.Golden_NameShadowing_Test_f = function(v)
   return function(v1)
-    if 1 == v then return 1 else if 1 == v1 then return 2 else return 3 end end
+    if 1 == v then return 1 elseif 1 == v1 then return 2 else return 3 end
   end
 end
 return {

--- a/test/ps/output/Golden.Nested.Test/golden.lua
+++ b/test/ps/output/Golden.Nested.Test/golden.lua
@@ -7,8 +7,10 @@ return {
   main = (function()
     if M.Golden_Nested_Test_isZero(1) then
       if M.Golden_Nested_Test_isZero(1) then return "ok" else return "fine" end
+    elseif M.Golden_Nested_Test_isZero(0) then
+      return "ha"
     else
-      if M.Golden_Nested_Test_isZero(0) then return "ha" else return "cool" end
+      return "cool"
     end
   end)()
 }

--- a/test/ps/output/Golden.PatternMatching.Test1/golden.lua
+++ b/test/ps/output/Golden.PatternMatching.Test1/golden.lua
@@ -17,38 +17,32 @@ return {
       if "Golden.PatternMatching.Test1∷E.Num" == e_S_2.value0["$ctor"] then
         if "Golden.PatternMatching.Test1∷N.Succ" == e_S_2.value0.value0["$ctor"] then
           return 1
+        elseif "Golden.PatternMatching.Test1∷N.Zero" == e_S_2.value0.value0["$ctor"] then
+          return 2
         else
-          if "Golden.PatternMatching.Test1∷N.Zero" == e_S_2.value0.value0["$ctor"] then
-            return 2
-          else
-            return 6
-          end
+          return 6
         end
-      else
-        if "Golden.PatternMatching.Test1∷E.Not" == e_S_2.value0["$ctor"] then
-          if "Golden.PatternMatching.Test1∷E.Num" == e_S_2.value0.value0["$ctor"] then
-            if "Golden.PatternMatching.Test1∷N.Succ" == e_S_2.value0.value0.value0["$ctor"] then
-              return 3
-            else
-              return 6
-            end
+      elseif "Golden.PatternMatching.Test1∷E.Not" == e_S_2.value0["$ctor"] then
+        if "Golden.PatternMatching.Test1∷E.Num" == e_S_2.value0.value0["$ctor"] then
+          if "Golden.PatternMatching.Test1∷N.Succ" == e_S_2.value0.value0.value0["$ctor"] then
+            return 3
           else
             return 6
           end
         else
           return 6
         end
-      end
-    else
-      if "Golden.PatternMatching.Test1∷E.Num" == e_S_2["$ctor"] then
-        if "Golden.PatternMatching.Test1∷N.Succ" == e_S_2.value0["$ctor"] then
-          return 4
-        else
-          return 5
-        end
       else
         return 6
       end
+    elseif "Golden.PatternMatching.Test1∷E.Num" == e_S_2["$ctor"] then
+      if "Golden.PatternMatching.Test1∷N.Succ" == e_S_2.value0["$ctor"] then
+        return 4
+      else
+        return 5
+      end
+    else
+      return 6
     end
   end,
   T = function(value0)

--- a/test/ps/output/Golden.PatternMatching.Test2/golden.lua
+++ b/test/ps/output/Golden.PatternMatching.Test2/golden.lua
@@ -2,12 +2,10 @@ local M = {}
 M.Golden_PatternMatching_Test2_bat = function(n)
   if "Golden.PatternMatching.Test1∷N.Zero" == n["$ctor"] then
     return 1
+  elseif "Golden.PatternMatching.Test1∷N.Succ" == n["$ctor"] then
+    return M.Golden_PatternMatching_Test2_bat(n.value0)
   else
-    if "Golden.PatternMatching.Test1∷N.Succ" == n["$ctor"] then
-      return M.Golden_PatternMatching_Test2_bat(n.value0)
-    else
-      return error("No patterns matched")
-    end
+    return error("No patterns matched")
   end
 end
 return {
@@ -41,27 +39,19 @@ return {
       if "Golden.PatternMatching.Test2∷N.Zero" == e_S_0.value1["$ctor"] then
         if "Golden.PatternMatching.Test2∷N.Add" == e_S_0.value0["$ctor"] then
           return 1
+        elseif "Golden.PatternMatching.Test2∷N.Mul" == e_S_0.value0["$ctor"] then
+          return 2
         else
-          if "Golden.PatternMatching.Test2∷N.Mul" == e_S_0.value0["$ctor"] then
-            return 2
-          else
-            return 5
-          end
+          return 5
         end
+      elseif "Golden.PatternMatching.Test2∷N.Mul" == e_S_0.value1["$ctor"] then
+        return 3
+      elseif "Golden.PatternMatching.Test2∷N.Add" == e_S_0.value1["$ctor"] then
+        return 4
+      elseif "Golden.PatternMatching.Test2∷N.Zero" == e_S_0.value1["$ctor"] then
+        return 5
       else
-        if "Golden.PatternMatching.Test2∷N.Mul" == e_S_0.value1["$ctor"] then
-          return 3
-        else
-          if "Golden.PatternMatching.Test2∷N.Add" == e_S_0.value1["$ctor"] then
-            return 4
-          else
-            if "Golden.PatternMatching.Test2∷N.Zero" == e_S_0.value1["$ctor"] then
-              return 5
-            else
-              return 6
-            end
-          end
-        end
+        return 6
       end
     else
       return 6

--- a/test/ps/output/Golden.ProfunctorDictLens.Test/golden.lua
+++ b/test/ps/output/Golden.ProfunctorDictLens.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -30,7 +28,9 @@ M.Data_Ring_foreign = {
 M.Unsafe_Coerce_foreign = { unsafeCoerce = function(x) return x end }
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end

--- a/test/ps/output/Golden.RecGroupOrder.Test/golden.lua
+++ b/test/ps/output/Golden.RecGroupOrder.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end

--- a/test/ps/output/Golden.RecordsUpdate.Test/golden.lua
+++ b/test/ps/output/Golden.RecordsUpdate.Test/golden.lua
@@ -2,11 +2,7 @@ local function PSLUA_object_update(o, patches)
   local o_copy = {}
   for k, v in pairs(o) do
     local patch_v = patches[k]
-    if patch_v ~= nil then
-      o_copy[k] = patch_v
-    else
-      o_copy[k] = v
-    end
+    if patch_v ~= nil then o_copy[k] = patch_v else o_copy[k] = v end
   end
   return o_copy
 end

--- a/test/ps/output/Golden.RecursiveBindings.Test/golden.lua
+++ b/test/ps/output/Golden.RecursiveBindings.Test/golden.lua
@@ -5,23 +5,19 @@ return {
     yes_S_0 = function(v_S_2)
       if v_S_2 then
         return no_S_1(false)
+      elseif false == v_S_2 then
+        return no_S_1(true)
       else
-        if false == v_S_2 then
-          return no_S_1(true)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
     no_S_1 = function(v0_S_3)
       if v0_S_3 then
         return yes_S_0(false)
+      elseif false == v0_S_3 then
+        return yes_S_0(true)
       else
-        if false == v0_S_3 then
-          return yes_S_0(true)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
     return no_S_1(false)
@@ -32,23 +28,19 @@ return {
     yes_S_14 = function(v_S_16)
       if v_S_16 then
         return no_S_15(false)
+      elseif false == v_S_16 then
+        return no_S_15(true)
       else
-        if false == v_S_16 then
-          return no_S_15(true)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
     no_S_15 = function(v0_S_17)
       if v0_S_17 then
         return yes_S_14(false)
+      elseif false == v0_S_17 then
+        return yes_S_14(true)
       else
-        if false == v0_S_17 then
-          return yes_S_14(true)
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
     return no_S_15(false)

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -22,7 +20,7 @@ local M = {}
 M.Data_HeytingAlgebra_foreign = {
   boolConj = function(b1) return function(b2) return b1 and b2 end end,
   boolDisj = function(b1) return function(b2) return b1 or b2 end end,
-  boolNot = function(b) return not b end
+  boolNot = function(b) return not(b) end
 }
 M.Data_Eq_foreign = (function()
   local refEq = function(r1) return function(r2) return r1 == r2 end end
@@ -34,13 +32,13 @@ M.Data_Semigroup_foreign = {
 M.Data_Show_foreign = {
   showIntImpl = function(n) return tostring(n) end,
   showArrayImpl = function(f)
-      return function(xs)
-        local l = #xs
-        local ss = {}
-        for i = 1, l do ss[i] = f(xs[i]) end
-        return "[" .. table.concat(ss, ",") .. "]"
-      end
+    return function(xs)
+      local l = #(xs)
+      local ss = {}
+      for i = 1, l do ss[i] = f(xs[i]) end
+      return "[" .. table.concat(ss, ",") .. "]"
     end
+  end
 }
 M.Data_Semiring_foreign = {
   intAdd = function(x) return function(y) return x + y end end,
@@ -71,124 +69,124 @@ M.Data_Ord_foreign = (function()
 end)()
 M.Data_Functor_foreign = {
   arrayMap = function(f)
-      return function(arr)
-        local l = #arr
-        local result = {}
-        for i = 1, l do result[i] = f(arr[i]) end
-        return result
-      end
+    return function(arr)
+      local l = #(arr)
+      local result = {}
+      for i = 1, l do result[i] = f(arr[i]) end
+      return result
     end
+  end
 }
-M.Data_Bounded_foreign = (function()
+M.Data_Bounded_foreign = {
   -- Lua 5.1 compatibility:
   -- * math.maxinteger/math.mininteger appeared in Lua 5.3; PureScript Int
   --   is a 32-bit integer, so its bounds are spelled out literally.
   -- * "\u{...}" escapes appeared in Lua 5.3 (PUC Lua 5.1 silently reads
   --   "\u" as "u"). A Char is a single byte in pslua, so its bounds are
   --   the byte bounds.
-  return { topChar = "\255", bottomChar = "\0" }
-end)()
-M.Data_EuclideanRing_foreign = (function()
+  topChar = "\255",
+  bottomChar = "\0"
+}
+M.Data_EuclideanRing_foreign = {
   -- math.maxinteger is Lua 5.3+; PureScript Int is 32-bit, hence the
   -- literal bound in intDegree.
-  return {
-    intDegree = function(x) return math.min(math.abs(x), 2147483647) end,
-    intDiv = function(x)
-        return function(y)
-          if y == 0 then return 0 end
-          return y > 0 and math.floor(x / y) or -math.floor(x / -y)
-        end
-      end,
-    intMod = function(x)
-        return function(y)
-          if y == 0 then return 0 end
-          local yy = math.abs(y)
-          return ((x % yy) + yy) % yy
-        end
-      end
-  }
-end)()
+  intDegree = function(x) return math.min(math.abs(x), 2147483647) end,
+  intDiv = function(x)
+    return function(y)
+      if y == 0 then return 0 end
+      return y > 0 and math.floor(x / y) or -(math.floor(x / -(y)))
+    end
+  end,
+  intMod = function(x)
+    return function(y)
+      if y == 0 then return 0 end
+      local yy = math.abs(y)
+      return (x % yy + yy) % yy
+    end
+  end
+}
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end
 }
-M.Partial_Unsafe_foreign = { _unsafePartial = function(f) return f(); end }
+M.Partial_Unsafe_foreign = { _unsafePartial = function(f) return f() end }
 M.Data_Unfoldable_foreign = {
   unfoldrArrayImpl = function(isNothing)
-      return function(fromJust)
-        return function(fst)
-          return function(snd)
-            return function(f)
-              return function(b)
-                local result = {}
-                local value = b
-                while true do
-                  local maybe = f(value)
-                  if isNothing(maybe) then
-                    return result
-                  end
-                  local tuple = fromJust(maybe)
-                  table.insert(result, fst(tuple))
-                  value = snd(tuple)
-                end
+    return function(fromJust)
+      return function(fst)
+        return function(snd)
+          return function(f)
+            return function(b)
+              local result = {}
+              local value = b
+              while true do
+                local maybe = f(value)
+                if isNothing(maybe) then return result end
+                local tuple = fromJust(maybe)
+                table.insert(result, fst(tuple))
+                value = snd(tuple)
               end
             end
           end
         end
       end
     end
+  end
 }
-M.Data_Array_foreign = { length = function(xs) return #xs end }
+M.Data_Array_foreign = { length = function(xs) return #(xs) end }
 M.Data_Enum_foreign = {
   toCharCode = function(c)
-      -- pslua compiles a PureScript Char literal as a string of its UTF-8 bytes,
-      -- so decode the first code point (JS c.charCodeAt(0)) when the WHOLE
-      -- sequence is present. But Data.String.CodeUnits hands this single raw bytes
-      -- (it slices a String byte-wise and lets the CodePoints layer reassemble),
-      -- so a lone lead/continuation byte must return that byte rather than read a
-      -- missing c:byte(2) and crash on nil.
-      local n = #c
-      local b1 = c:byte(1)
-      if b1 < 0x80 then return b1 end
-      if b1 < 0xE0 and n >= 2 then return (b1 - 0xC0) * 0x40 + (c:byte(2) - 0x80) end
-      if b1 < 0xF0 and n >= 3 then return (b1 - 0xE0) * 0x1000 + (c:byte(2) - 0x80) * 0x40 + (c:byte(3) - 0x80) end
-      if b1 >= 0xF0 and n >= 4 then
-        return (b1 - 0xF0) * 0x40000 + (c:byte(2) - 0x80) * 0x1000 + (c:byte(3) - 0x80) * 0x40 + (c:byte(4) - 0x80)
-      end
-      return b1
-    end,
-  fromCharCode = function(n)
-      -- Encode the code point as UTF-8 (JS String.fromCharCode over 0..65535);
-      -- string.char alone errors above 255 and emits a raw byte for 128..255.
-      if n < 0x80 then return string.char(n) end
-      if n < 0x800 then return string.char(0xC0 + math.floor(n / 0x40), 0x80 + (n % 0x40)) end
-      if n < 0x10000 then
-        return string.char(0xE0 + math.floor(n / 0x1000), 0x80 + (math.floor(n / 0x40) % 0x40), 0x80 + (n % 0x40))
-      end
-      return string.char(0xF0 + math.floor(n / 0x40000), 0x80 + (math.floor(n / 0x1000) % 0x40),
-                         0x80 + (math.floor(n / 0x40) % 0x40), 0x80 + (n % 0x40))
+    -- pslua compiles a PureScript Char literal as a string of its UTF-8 bytes,
+    -- so decode the first code point (JS c.charCodeAt(0)) when the WHOLE
+    -- sequence is present. But Data.String.CodeUnits hands this single raw bytes
+    -- (it slices a String byte-wise and lets the CodePoints layer reassemble),
+    -- so a lone lead/continuation byte must return that byte rather than read a
+    -- missing c:byte(2) and crash on nil.
+    local n = #(c)
+    local b1 = c:byte(1)
+    if b1 < 128 then return b1 end
+    if b1 < 224 and n >= 2 then return (b1 - 192) * 64 + (c:byte(2) - 128) end
+    if b1 < 240 and n >= 3 then
+      return (b1 - 224) * 4096 + (c:byte(2) - 128) * 64 + (c:byte(3) - 128)
     end
+    if b1 >= 240 and n >= 4 then
+      return (b1 - 240) * 262144 + (c:byte(2) - 128) * 4096 + (c:byte(3) - 128) * 64 + (c:byte(4) - 128)
+    end
+    return b1
+  end,
+  fromCharCode = function(n)
+    -- Encode the code point as UTF-8 (JS String.fromCharCode over 0..65535);
+    -- string.char alone errors above 255 and emits a raw byte for 128..255.
+    if n < 128 then return string.char(n) end
+    if n < 2048 then
+      return string.char(192 + math.floor(n / 64), 128 + n % 64)
+    end
+    if n < 65536 then
+      return string.char(224 + math.floor(n / 4096), 128 + math.floor(n / 64) % 64, 128 + n % 64)
+    end
+    return string.char(240 + math.floor(n / 262144), 128 + math.floor(n / 4096) % 64, 128 + math.floor(n / 64) % 64, 128 + n % 64)
+  end
 }
 M.Data_String_Unsafe_foreign = {
   charAt = function(i)
-      return function(s)
-        if i >= 0 and i < #s then return s:sub(i + 1, i + 1) end
-        error("Data.String.Unsafe.charAt: Invalid index.")
-      end
+    return function(s)
+      if i >= 0 and i < #(s) then return s:sub(i + 1, i + 1) end
+      error("Data.String.Unsafe.charAt: Invalid index.")
     end
+  end
 }
-M.Data_String_CodeUnits_foreign = (function()
+M.Data_String_CodeUnits_foreign = {
   -- PureScript indices are 0-based, Lua string positions are 1-based;
   -- the exports below convert between the two. Pattern arguments are
   -- literal strings, hence string.find in plain mode. Index clamping
   -- mirrors the upstream JS implementation (String.prototype.indexOf,
   -- lastIndexOf, slice and substring).
-  return {
-    singleton = function(c) return c end,
-    length = function(s) return #s end,
-    drop = function(n) return function(s) return s:sub(math.max(n, 0) + 1) end end
-  }
-end)()
+  singleton = function(c) return c end,
+  length = function(s) return #(s) end,
+  drop = function(n) return function(s) return s:sub(math.max(n, 0) + 1) end end
+}
 M.Data_String_CodePoints_foreign = (function()
   -- In pslua a PureScript String is a Lua byte string holding UTF-8,
   -- so code-point operations decode/encode UTF-8 directly. The PureScript
@@ -196,122 +194,102 @@ M.Data_String_CodePoints_foreign = (function()
   -- under this representation; every export ignores them.
   --
   -- Lua 5.1: no utf8 library, no bit operators - plain arithmetic only.
-
   -- Decodes the code point starting at byte position i.
   -- Returns the code point and the position of the next one.
   -- An invalid leading byte is returned as-is (one byte consumed).
   local function decode(s, i)
     local b1 = s:byte(i)
-    if b1 < 0x80 then return b1, i + 1 end
-    if b1 >= 0xC2 and b1 <= 0xDF then
+    if b1 < 128 then return b1, i + 1 end
+    if b1 >= 194 and b1 <= 223 then
       local b2 = s:byte(i + 1)
-      if b2 and b2 >= 0x80 and b2 <= 0xBF then
-        return (b1 - 0xC0) * 0x40 + (b2 - 0x80), i + 2
+      if b2 and b2 >= 128 and b2 <= 191 then
+        return (b1 - 192) * 64 + (b2 - 128), i + 2
       end
-    elseif b1 >= 0xE0 and b1 <= 0xEF then
+    elseif b1 >= 224 and b1 <= 239 then
       local b2, b3 = s:byte(i + 1, i + 2)
-      if b2 and b2 >= 0x80 and b2 <= 0xBF
-        and b3 and b3 >= 0x80 and b3 <= 0xBF then
-        return (b1 - 0xE0) * 0x1000 + (b2 - 0x80) * 0x40 + (b3 - 0x80), i + 3
+      if b2 and b2 >= 128 and b2 <= 191 and b3 and b3 >= 128 and b3 <= 191 then
+        return (b1 - 224) * 4096 + (b2 - 128) * 64 + (b3 - 128), i + 3
       end
-    elseif b1 >= 0xF0 and b1 <= 0xF4 then
+    elseif b1 >= 240 and b1 <= 244 then
       local b2, b3, b4 = s:byte(i + 1, i + 3)
-      if b2 and b2 >= 0x80 and b2 <= 0xBF
-        and b3 and b3 >= 0x80 and b3 <= 0xBF
-        and b4 and b4 >= 0x80 and b4 <= 0xBF then
-        return (b1 - 0xF0) * 0x40000 + (b2 - 0x80) * 0x1000
-          + (b3 - 0x80) * 0x40 + (b4 - 0x80), i + 4
+      if b2 and b2 >= 128 and b2 <= 191 and b3 and b3 >= 128 and b3 <= 191 and b4 and b4 >= 128 and b4 <= 191 then
+        return (b1 - 240) * 262144 + (b2 - 128) * 4096 + (b3 - 128) * 64 + (b4 - 128), i + 4
       end
     end
     return b1, i + 1
   end
-
   -- Encodes a code point as a UTF-8 byte string.
   local function encode(cp)
-    if cp < 0x80 then return string.char(cp) end
-    if cp < 0x800 then
-      return string.char(0xC0 + math.floor(cp / 0x40), 0x80 + cp % 0x40)
+    if cp < 128 then return string.char(cp) end
+    if cp < 2048 then
+      return string.char(192 + math.floor(cp / 64), 128 + cp % 64)
     end
-    if cp < 0x10000 then
-      return string.char(
-        0xE0 + math.floor(cp / 0x1000),
-        0x80 + math.floor(cp / 0x40) % 0x40,
-        0x80 + cp % 0x40
-      )
+    if cp < 65536 then
+      return string.char(224 + math.floor(cp / 4096), 128 + math.floor(cp / 64) % 64, 128 + cp % 64)
     end
-    return string.char(
-      0xF0 + math.floor(cp / 0x40000),
-      0x80 + math.floor(cp / 0x1000) % 0x40,
-      0x80 + math.floor(cp / 0x40) % 0x40,
-      0x80 + cp % 0x40
-    )
+    return string.char(240 + math.floor(cp / 262144), 128 + math.floor(cp / 4096) % 64, 128 + math.floor(cp / 64) % 64, 128 + cp % 64)
   end
   return {
-    _singleton = function(_)
-        return function(cp) return encode(cp) end
-      end,
+    _singleton = function(_) return function(cp) return encode(cp) end end,
     _fromCodePointArray = function(_)
-        return function(cps)
-          local t = {}
-          for k = 1, #cps do t[k] = encode(cps[k]) end
-          return table.concat(t)
-        end
-      end,
+      return function(cps)
+        local t = {}
+        for k = 1, #(cps) do t[k] = encode(cps[k]) end
+        return table.concat(t)
+      end
+    end,
     _toCodePointArray = function(_)
-        return function(_)
-          return function(s)
-            local t, k, i = {}, 0, 1
-            while i <= #s do
-              local cp, j = decode(s, i)
-              k = k + 1
-              t[k] = cp
-              i = j
-            end
-            return t
+      return function(_)
+        return function(s)
+          local t, k, i = {}, 0, 1
+          while i <= #(s) do
+            local cp, j = decode(s, i)
+            k = k + 1
+            t[k] = cp
+            i = j
           end
+          return t
         end
-      end,
+      end
+    end,
     _codePointAt = function(_)
-        return function(just)
-          return function(nothing)
-            return function(_)
-              return function(n)
-                return function(s)
-                  local k, i = 0, 1
-                  while i <= #s do
-                    local cp, j = decode(s, i)
-                    if k == n then return just(cp) end
-                    k = k + 1
-                    i = j
-                  end
-                  return nothing
+      return function(just)
+        return function(nothing)
+          return function(_)
+            return function(n)
+              return function(s)
+                local k, i = 0, 1
+                while i <= #(s) do
+                  local cp, j = decode(s, i)
+                  if k == n then return just(cp) end
+                  k = k + 1
+                  i = j
                 end
+                return nothing
               end
             end
           end
         end
-      end,
+      end
+    end,
     _take = function(_)
-        return function(n)
-          return function(s)
-            if n < 1 then return "" end
-            local k, i = 0, 1
-            while i <= #s do
-              local _, j = decode(s, i)
-              k = k + 1
-              i = j
-              if k == n then break end
-            end
-            return s:sub(1, i - 1)
-          end
-        end
-      end,
-    _unsafeCodePointAt0 = function(_)
+      return function(n)
         return function(s)
-          local cp = decode(s, 1)
-          return cp
+          if n < 1 then return "" end
+          local k, i = 0, 1
+          while i <= #(s) do
+            local _, j = decode(s, i)
+            k = k + 1
+            i = j
+            if k == n then break end
+          end
+          return s:sub(1, i - 1)
         end
       end
+    end,
+    _unsafeCodePointAt0 = function(_)
+      return function(s) local cp = decode(s, 1) return cp end
+    end
   }
 end)()
 M.Effect_Console_foreign = {
@@ -429,12 +407,10 @@ M.Data_Maybe_showMaybe = function(dictShow)
     show = function(v)
       if "Data.Maybe∷Maybe.Just" == v["$ctor"] then
         return M.Data_Maybe_append("(Just ")(M.Data_Maybe_append(M.Data_Show_show(dictShow)(v.value0))(")"))
+      elseif "Data.Maybe∷Maybe.Nothing" == v["$ctor"] then
+        return "Nothing"
       else
-        if "Data.Maybe∷Maybe.Nothing" == v["$ctor"] then
-          return "Nothing"
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   }
@@ -568,16 +544,14 @@ M.Data_String_CodePoints_fromCharCode = M.Data_String_CodePoints_compose(M.Data_
   local v_S_63 = M.Data_Enum_toEnum(M.Data_Enum_boundedEnumChar)(x_S_62)
   if "Data.Maybe∷Maybe.Just" == v_S_63["$ctor"] then
     return v_S_63.value0
-  else
-    if "Data.Maybe∷Maybe.Nothing" == v_S_63["$ctor"] then
-      if M.Data_Ord_lessThan(M.Data_Ord_ordInt)(x_S_62)(M.Data_Enum_fromEnum(M.Data_Enum_boundedEnumChar)(M.Data_Bounded_bottom(M.Data_Enum_boundedEnumChar.Bounded0()))) then
-        return M.Data_Bounded_bottom(M.Data_Bounded_boundedChar)
-      else
-        return M.Data_Bounded_top(M.Data_Bounded_boundedChar)
-      end
+  elseif "Data.Maybe∷Maybe.Nothing" == v_S_63["$ctor"] then
+    if M.Data_Ord_lessThan(M.Data_Ord_ordInt)(x_S_62)(M.Data_Enum_fromEnum(M.Data_Enum_boundedEnumChar)(M.Data_Bounded_bottom(M.Data_Enum_boundedEnumChar.Bounded0()))) then
+      return M.Data_Bounded_bottom(M.Data_Bounded_boundedChar)
     else
-      return error("No patterns matched")
+      return M.Data_Bounded_top(M.Data_Bounded_boundedChar)
     end
+  else
+    return error("No patterns matched")
   end
 end)
 M.Data_String_CodePoints_singletonFallback = function(v)
@@ -640,12 +614,10 @@ M.Data_String_CodePoints_toCodePointArray = M.Data_String_CodePoints_foreign._to
   return M.Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1313_S_1335)
     if "Data.Maybe∷Maybe.Nothing" == v2_S_1313_S_1335["$ctor"] then
       return true
+    elseif "Data.Maybe∷Maybe.Just" == v2_S_1313_S_1335["$ctor"] then
+      return false
     else
-      if "Data.Maybe∷Maybe.Just" == v2_S_1313_S_1335["$ctor"] then
-        return false
-      else
-        return error("No patterns matched")
-      end
+      return error("No patterns matched")
     end
   end)(M.Partial_Unsafe_foreign._unsafePartial(function()
     return M.Data_Maybe_fromJust()
@@ -677,24 +649,18 @@ M.Data_String_CodePoints_codePointAt = function(v)
   return function(v1)
     if M.Data_String_CodePoints_lessThan(v)(0) then
       return M.Data_Maybe_Nothing
-    else
-      if 0 == v then
-        if "" == v1 then
-          return M.Data_Maybe_Nothing
-        else
-          if 0 == v then
-            return M.Data_Maybe_Just(M.Data_String_CodePoints_unsafeCodePointAt0(v1))
-          else
-            return M.Data_String_CodePoints_foreign._codePointAt(M.Data_String_CodePoints_codePointAtFallback)(M.Data_Maybe_Just)(M.Data_Maybe_Nothing)(M.Data_String_CodePoints_unsafeCodePointAt0)(v)(v1)
-          end
-        end
+    elseif 0 == v then
+      if "" == v1 then
+        return M.Data_Maybe_Nothing
+      elseif 0 == v then
+        return M.Data_Maybe_Just(M.Data_String_CodePoints_unsafeCodePointAt0(v1))
       else
-        if 0 == v then
-          return M.Data_Maybe_Just(M.Data_String_CodePoints_unsafeCodePointAt0(v1))
-        else
-          return M.Data_String_CodePoints_foreign._codePointAt(M.Data_String_CodePoints_codePointAtFallback)(M.Data_Maybe_Just)(M.Data_Maybe_Nothing)(M.Data_String_CodePoints_unsafeCodePointAt0)(v)(v1)
-        end
+        return M.Data_String_CodePoints_foreign._codePointAt(M.Data_String_CodePoints_codePointAtFallback)(M.Data_Maybe_Just)(M.Data_Maybe_Nothing)(M.Data_String_CodePoints_unsafeCodePointAt0)(v)(v1)
       end
+    elseif 0 == v then
+      return M.Data_Maybe_Just(M.Data_String_CodePoints_unsafeCodePointAt0(v1))
+    else
+      return M.Data_String_CodePoints_foreign._codePointAt(M.Data_String_CodePoints_codePointAtFallback)(M.Data_Maybe_Just)(M.Data_Maybe_Nothing)(M.Data_String_CodePoints_unsafeCodePointAt0)(v)(v1)
     end
   end
 end
@@ -764,12 +730,10 @@ return (function()
     show = function(v_S_1235)
       if v_S_1235 then
         return "true"
+      elseif false == v_S_1235 then
+        return "false"
       else
-        if false == v_S_1235 then
-          return "false"
-        else
-          return error("No patterns matched")
-        end
+        return error("No patterns matched")
       end
     end
   })(M.Data_Eq_eq({

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
@@ -5,15 +5,13 @@ local function PSLUA_runtime_lazy(name)
     return function()
       if state == 2 then
         return val
+      elseif state == 1 then
+        return error(name .. " was needed before it finished initializing")
       else
-        if state == 1 then
-          return error(name .. " was needed before it finished initializing")
-        else
-          state = 1
-          val = init()
-          state = 2
-          return val
-        end
+        state = 1
+        val = init()
+        state = 2
+        return val
       end
     end
   end
@@ -45,17 +43,19 @@ M.Data_Ord_foreign = (function()
 end)()
 M.Effect_foreign = {
   pureE = function(a) return function() return a end end,
-  bindE = function(a) return function(f) return function() return f(a())() end end end,
-  untilE = function(f) return function() while not f() do end end end
+  bindE = function(a)
+    return function(f) return function() return f(a())() end end
+  end,
+  untilE = function(f) return function() while not(f()) do  end end end
 }
 M.Effect_Ref_foreign = {
-  _new = function(val) return function() return {value = val} end end,
+  _new = function(val) return function() return { value = val } end end,
   read = function(ref) return function() return ref.value end end,
   write = function(val)
-      return function(ref) return function() ref.value = val end end
-    end
+    return function(ref) return function() ref.value = val end end
+  end
 }
-M.Partial_Unsafe_foreign = { _unsafePartial = function(f) return f(); end }
+M.Partial_Unsafe_foreign = { _unsafePartial = function(f) return f() end }
 M.Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
@@ -159,12 +159,10 @@ return (function()
                   local _ = M.Effect_Ref_foreign.write(e_S_19)(r_S_16)()
                   return M.Control_Monad_Rec_Class_pure(false)()
                 end
+              elseif "Control.Monad.Rec.Class∷Step.Done" == v0_S_17["$ctor"] then
+                return M.Control_Monad_Rec_Class_pure(true)
               else
-                if "Control.Monad.Rec.Class∷Step.Done" == v0_S_17["$ctor"] then
-                  return M.Control_Monad_Rec_Class_pure(true)
-                else
-                  return error("No patterns matched")
-                end
+                return error("No patterns matched")
               end
             end)()()
           end)()


### PR DESCRIPTION
Closes #173.

## What changed

`Lua.Linker.Foreign` no longer splits an FFI file lexically into text blobs. The whole file goes through a new complete Lua 5.1 parser (`Language.PureScript.Backend.Lua.Parser`, megaparsec) straight into the backend's Lua AST: header statements and export values become real AST nodes, visible to every Lua-level optimization, and a syntax error anywhere in a foreign file is now a compile-time error instead of a luacheck/runtime one. The balanced-paren scanner and the "wrap every export value in parens" contract are gone; comments are preserved through the existing annotation slots and reattached in the printed output.

To support this, the Lua AST grew the missing Lua 5.1 statement and expression forms (loops, `local function`, multiple assignment, method calls, varargs, array-part table rows, multi-value `return`), the printer learned to render nested `if`/`else`-of-`if` chains as `elseif`, and the runtime fixtures are parsed into the AST instead of being emitted as verbatim text.

## Parser design

Operator parsing is a transcription of `subexpr` from Lua 5.1's own lparser.c, priority table included, so associativity and unary binding levels are pinned to the reference. The parser also matches the reference's rejections, each verified against `luac` 5.1.5 before the corresponding test was written:

- an argument-list `(` on a different line than its callee is "ambiguous syntax (function call x new statement)", with a hint about `;`; string and table arguments stay legal across a line break, as in the reference;
- `...` outside a vararg function is an error (the main chunk counts as vararg);
- syntactic nesting is capped at 500 levels, above both the reference's 200 and the emitter's own `NestingCheck` limit of 180: the cap exists only to turn adversarially nested input into a clean parse error instead of a compiler stack overflow.

The one deliberate divergence is rejecting `goto` as an identifier, which Lua 5.1 itself allows. Note [Parsing foreign Lua sources] records the reason: parsed FFI names and generated names share one output chunk, and that chunk has to stay loadable on LuaJIT and Lua 5.2+, where `goto` is a keyword.

## Verification

A `parse . print ≡ id` round trip alone cannot see a matched pair of defects, where the parser misreads a construct exactly the way the printer misprints it. The suite therefore anchors to arbiters that cannot share a bug with the printer:

- `luac` must accept everything the printer emits: a property over generated chunks (with comments), plus a deterministic anchor that feeds every snippet of the hand-written round-trip corpus to `luac` in both source and printed form (new `Differential.Spec`, with a `Test.Lua` helper shared with the golden harness).
- A semantic differential renders a typed, runtime-error-free expression twice, once with the real printer and once with a local renderer that parenthesizes every node, then evaluates and compares the two inside `lua` itself (NaN accounted for). This is the only check of the precedence and associativity tables against the interpreter rather than against themselves.
- The round-trip property now runs on four page widths (1 / 40 / 80 / unbounded), generates comments into statement and table-row slots, and compares annotations too. The one-column layout is the main stress for `;` insertion and hardline comments.
- A new traversal identity property (`everywhereStat`/`everywhereExp` with `identity` must be `id`, comments included) pins the annotation-threading contract the rewrite rules rely on.
- Deterministic units cover the `;` separator, the `containsReturn` branches of `foldFieldProjectionThroughScopeCall`, and the parser's number, string, and comment edge cases (exponent padding, `\r\n` escapes, false long-bracket opens, a comment before `elseif` blocking resugaring in both directions).

Two printer correctness gaps surfaced by all this and are fixed here: a negative numeric literal now carries unary precedence (`(-2) ^ 2` used to print as `-2 ^ 2`, which Lua reads as `-(2 ^ 2)`), and a statement whose printed form starts with `(` is now separated from the previous statement with `;`.

Every golden module's rendered output is additionally re-read by the compiler's own parser inside the golden harness, so the whole corpus doubles as a round-trip fixture.

## Coverage

`hpc` over the full suite: `Lua.Parser` 100% of top-level definitions, 94% of expressions, 85% of alternatives. The remainder is six unreachable-by-design `binOpPriority` rows (5.3 operators absent from the grammar) and error-message thunks that tests trigger as branches but never force as strings.

## Goldens

35 `golden.lua` files move structurally (mostly `elseif` resugaring and comment placement); `golden.ir` and every `eval/golden.txt` oracle are untouched, so generated-code semantics are unchanged.
