### PR TITLE
Don't duplicate a local binding a sibling Let grouping references (#217)

### DIFF
--- a/changelog.d/20260709_153514_unisay_inline_local_sibling_ref.md
+++ b/changelog.d/20260709_153514_unisay_inline_local_sibling_ref.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `inlineLocalBinding` no longer duplicates a local binding that a sibling `Let`
+  grouping still references (#217). Its use-count looked at the `Let` body only,
+  missing the RHSs of later groupings that sequential scoping lets name an
+  earlier binder, so a non-trivial binding read once in the body and once in a
+  sibling RHS was inlined into the body and its RHS evaluated twice. When the RHS
+  performed an effect the effect was duplicated (for instance a `tailRecM` loop
+  allocating two mutable Refs instead of one). The rule now declines to inline a
+  non-trivial binding a sibling RHS references.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -954,7 +954,19 @@ removeUnreachableElseBranch e = pure case e of
 inlineLocalBindings ∷ RewriteRuleM SupplyM Ann
 inlineLocalBindings = \case
   Let ann groupings body → do
-    (body', inlined) ← foldrM inlineLocalBinding (body, Unmodified) groupings
+    -- References a binder receives from the RHSs of the Let's groupings.
+    -- Sequential scoping lets a later grouping name an earlier binder
+    -- (Note [Sequential scoping of Let bindings]), and inlining touches only
+    -- the body, so 'inlineLocalBinding' needs this to avoid pasting a second
+    -- copy of a binding a sibling still references (see there).
+    let siblingRhsRefs ∷ Qualified Name → Natural
+        siblingRhsRefs name =
+          sum
+            [ countFreeRef name rhs
+            | (_ann, _n, rhs) ← listGrouping =<< toList groupings
+            ]
+    (body', inlined) ←
+      foldrM (inlineLocalBinding siblingRhsRefs) (body, Unmodified) groupings
     pure case inlined of
       Rewritten → Just (Let ann groupings body')
       Unmodified → Nothing
@@ -978,17 +990,28 @@ a same-named reference in the RHS would be a duplicate binder upstream
 input, where the rule must decline rather than loop or capture.
 -}
 inlineLocalBinding
-  ∷ Grouping (Ann, Name, Exp)
+  ∷ (Qualified Name → Natural)
+  -- ^ Occurrences a binder receives from the Let's grouping RHSs
+  → Grouping (Ann, Name, Exp)
   → (Exp, WasRewritten)
   → SupplyM (Exp, WasRewritten)
-inlineLocalBinding grouping (body, inlined) =
+inlineLocalBinding siblingRhsRefs grouping (body, inlined) =
   case grouping of
     RecursiveGroup _grp → pure (body, inlined) -- Not inlining recursive bindings
     Standalone (_ann, Local → name, inlinee)
       | occurrences > 0
       , countFreeRef name inlinee == 0 -- no self-reference, see above
-      , -- See Note [Beta reduction and local inlining share an inlining guard]
-        isInlinableExpr inlinee || occurrences == 1 →
+      , -- See Note [Beta reduction and local inlining share an inlining guard].
+        -- A non-trivial inlinee a sibling grouping's RHS also references must
+        -- not be inlined: substitution reaches only the body, so the sibling
+        -- keeps its reference to the surviving binding, and a second copy in
+        -- the body would evaluate the RHS twice -- duplicating any effect it
+        -- performs (e.g. allocating a fresh mutable Ref, splitting one cell
+        -- into two). 'occurrences' counts only the body, so the sibling RHSs
+        -- are checked separately (own RHS contributes nothing, by the
+        -- self-reference guard above).
+        isInlinableExpr inlinee
+          || (occurrences == 1 && siblingRhsRefs name == 0) →
           -- The binding survives until DCE drops it, so the inserted copy
           -- must not reuse its binder names ('substituteCopyM').
           (,Rewritten) <$> substituteCopyM name inlinee body

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -954,19 +954,22 @@ removeUnreachableElseBranch e = pure case e of
 inlineLocalBindings ∷ RewriteRuleM SupplyM Ann
 inlineLocalBindings = \case
   Let ann groupings body → do
-    -- References a binder receives from the RHSs of the Let's groupings.
-    -- Sequential scoping lets a later grouping name an earlier binder
-    -- (Note [Sequential scoping of Let bindings]), and inlining touches only
-    -- the body, so 'inlineLocalBinding' needs this to avoid pasting a second
-    -- copy of a binding a sibling still references (see there).
-    let siblingRhsRefs ∷ Qualified Name → Natural
-        siblingRhsRefs name =
-          sum
-            [ countFreeRef name rhs
+    -- How many times each binder is referenced by the RHSs of the Let's
+    -- groupings. Sequential scoping lets a later grouping name an earlier
+    -- binder (Note [Sequential scoping of Let bindings]), and inlining touches
+    -- only the body, so 'inlineLocalBinding' consults this to avoid pasting a
+    -- second copy of a binding a sibling still references (see there). Counted
+    -- once and shared across the fold — the RHSs are invariant across it — and
+    -- lazy, so a Let whose bindings never reach the check pays nothing.
+    let rhsRefCounts ∷ Map (Qualified Name) Natural
+        rhsRefCounts =
+          Map.unionsWith
+            (+)
+            [ countFreeRefs rhs
             | (_ann, _n, rhs) ← listGrouping =<< toList groupings
             ]
     (body', inlined) ←
-      foldrM (inlineLocalBinding siblingRhsRefs) (body, Unmodified) groupings
+      foldrM (inlineLocalBinding rhsRefCounts) (body, Unmodified) groupings
     pure case inlined of
       Rewritten → Just (Let ann groupings body')
       Unmodified → Nothing
@@ -990,12 +993,12 @@ a same-named reference in the RHS would be a duplicate binder upstream
 input, where the rule must decline rather than loop or capture.
 -}
 inlineLocalBinding
-  ∷ (Qualified Name → Natural)
-  -- ^ Occurrences a binder receives from the Let's grouping RHSs
+  ∷ Map (Qualified Name) Natural
+  -- ^ How many times each binder is referenced by the Let's grouping RHSs
   → Grouping (Ann, Name, Exp)
   → (Exp, WasRewritten)
   → SupplyM (Exp, WasRewritten)
-inlineLocalBinding siblingRhsRefs grouping (body, inlined) =
+inlineLocalBinding rhsRefCounts grouping (body, inlined) =
   case grouping of
     RecursiveGroup _grp → pure (body, inlined) -- Not inlining recursive bindings
     Standalone (_ann, Local → name, inlinee)
@@ -1007,11 +1010,12 @@ inlineLocalBinding siblingRhsRefs grouping (body, inlined) =
         -- keeps its reference to the surviving binding, and a second copy in
         -- the body would evaluate the RHS twice -- duplicating any effect it
         -- performs (e.g. allocating a fresh mutable Ref, splitting one cell
-        -- into two). 'occurrences' counts only the body, so the sibling RHSs
-        -- are checked separately (own RHS contributes nothing, by the
-        -- self-reference guard above).
+        -- into two). 'occurrences' counts only the body, so the grouping RHSs
+        -- are checked separately: absence from 'rhsRefCounts' means no sibling
+        -- names it (the count map records no zero entries, and the binding's
+        -- own RHS is excluded by the self-reference guard above).
         isInlinableExpr inlinee
-          || (occurrences == 1 && siblingRhsRefs name == 0) →
+          || (occurrences == 1 && name `Map.notMember` rhsRefCounts) →
           -- The binding survives until DCE drops it, so the inserted copy
           -- must not reuse its binder names ('substituteCopyM').
           (,Rewritten) <$> substituteCopyM name inlinee body

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -705,6 +705,40 @@ spec = describe "IR Optimizer" do
               dataArgumentByIndex index (refLocal (Name "v"))
       unboundLocals (optimizedExpression original) === []
 
+  describe "does not duplicate a binding a sibling grouping reads" do
+    let m = moduleNameFromString "M"
+
+    prop "keeps a non-trivial binding a later grouping's RHS references" do
+      -- Regression: 'inlineLocalBinding' counted a binder's uses in the Let
+      -- body only, missing a later grouping's RHS -- which sequential scoping
+      -- lets name an earlier binder (Note [Sequential scoping of Let
+      -- bindings]). A non-trivial binding read once in the body and once in a
+      -- sibling RHS was then inlined into the body, evaluating its RHS a second
+      -- time and duplicating any effect it performs (e.g. allocating a fresh
+      -- mutable Ref, splitting one cell into two). Only the payload is random;
+      -- the RHS is an application (never inlinable) whose free references a
+      -- second copy would multiply, so the free-reference multiset must not
+      -- grow (as with FloatIn and the #177 fold, optimization only shrinks it).
+      payload ← forAll Gen.scalarExp
+      let rhs = application (refImported m (Name "mk")) payload
+          original =
+            lets
+              ( Standalone (noAnn, Name "r", rhs)
+                  :| [ Standalone
+                         ( noAnn
+                         , Name "s"
+                         , application
+                             (refImported m (Name "use"))
+                             (refLocal (Name "r"))
+                         )
+                     ]
+              )
+              (application (refImported m (Name "consume")) (refLocal (Name "r")))
+          optimized = optimizedExpression original
+      annotateShow optimized
+      Map.isSubmapOfBy (<=) (countFreeRefs optimized) (countFreeRefs original)
+        === True
+
   -- See Note [Folding primops follows Lua 5.1] in the optimizer.
   describe "folds primops (#178)" do
     it "folds integer arithmetic exactly" do

--- a/test/ps/output/Golden.Issue37.Test/golden.ir
+++ b/test/ps/output/Golden.Issue37.Test/golden.ir
@@ -320,23 +320,7 @@ UberModule
                                     ( Ref Nothing
                                       ( Imported ( ModuleName "Control.Bind" ) ( Name "bind" ) )
                                     )
-                                    ( AppN Nothing
-                                      ( ObjectProp Nothing
-                                        ( Ref Nothing
-                                          ( Imported
-                                            ( ModuleName "Effect" )
-                                            ( Name "monadEffect" )
-                                          )
-                                        )
-                                        ( PropName "Bind1" )
-                                      )
-                                      ( Ref Nothing
-                                        ( Imported
-                                          ( ModuleName "Prim" )
-                                          ( Name "undefined" )
-                                        ) :| []
-                                      ) :| []
-                                    )
+                                    ( Ref Nothing ( Local ( Name "Bind1$216" ) ) :| [] )
                                   )
                                   ( Ref Nothing ( Local ( Name "fn1$218" ) ) :| [] )
                                 )

--- a/test/ps/output/Golden.Issue37.Test/golden.lua
+++ b/test/ps/output/Golden.Issue37.Test/golden.lua
@@ -80,7 +80,7 @@ return {
             local Bind1_S_216 = M.Effect_monadEffect.Bind1()
             local discard1_S_217 = M.Golden_Issue37_Test_discard(Bind1_S_216)
             return function(fn1_S_218)
-              return M.Control_Bind_bind(M.Effect_monadEffect.Bind1())(fn1_S_218)(function(  )
+              return M.Control_Bind_bind(Bind1_S_216)(fn1_S_218)(function()
                 return discard1_S_217(fn1_S_218)(function()
                   return discard1_S_217(fn1_S_218)(function()
                     return fn1_S_218


### PR DESCRIPTION
Fixes #217. Prerequisite for #180.

`inlineLocalBinding` decides whether to inline a local `Let` binding into the body by counting the binder's uses with `countFreeRef name body`. That count sees only the body and misses the RHSs of the other groupings in the same `Let`, which sequential scoping lets reference an earlier binder. So a non-trivial binding read once in the body and once in a sibling grouping's RHS was treated as use-once and inlined into the body, while the sibling kept its reference to the surviving binding. The RHS then ran twice, duplicating any effect it performs.

## The fix

Decline to inline a non-trivial binding whose reference count across the sibling grouping RHSs is nonzero. A trivial inlinee (a `Ref`, a literal, or an `inline`-annotated node) stays inlinable, since duplicating it repeats no work.

## Impact

`Golden.Issue37` already hit this on `main`, benignly: `M.Effect_monadEffect.Bind1()` was recomputed in the body while the shared `Bind1_S_216` binding, kept because a sibling `discard` reads it, was already in scope. The accessor is pure, so this was harmless bloat; the golden now shares the binding (16 fewer IR lines, identical behaviour).

The same mechanism becomes a correctness bug once a pass flattens nested `Let`s around a shared effectful binder, which the dictionary-method inlining in #180 does: there it split `tailRecM`'s single mutable `Ref` into two, so the loop mutated one cell while the final read saw the other's initial value.

## Tests

A Hedgehog property builds the shared-binder shape (`let r = mk payload; s = use r in consume r`) with a random payload and asserts the optimizer never grows the free-reference multiset. It fails on `main` and passes with the fix.
