### PR TITLE
fix: reject declared foreign names missing from the FFI exports

### DIFF
--- a/changelog.d/20260712_142432_unisay_foreign_exports_missing.md
+++ b/changelog.d/20260712_142432_unisay_foreign_exports_missing.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- A name declared as a `foreign import` but missing from the table its FFI
+  file returns is now a compile-time error naming the module and the missing
+  names, instead of compiling to a field read that surfaces at runtime as a
+  `nil`. The check runs on the DCE-pruned name list, so only names the
+  emitted code would actually read are required; undeclared extra exports
+  are still dropped silently (#249).

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -4,6 +4,7 @@ import Cli (Args (luaOutputFile), ExtraOutput (..))
 import Cli qualified
 import Control.Monad.Oops qualified as Oops
 import Data.Tagged (Tagged (..))
+import Data.Text qualified as Text
 import Language.PureScript.Backend (CompilationResult (..))
 import Language.PureScript.Backend qualified as Backend
 import Language.PureScript.Backend.IR qualified as IR
@@ -140,6 +141,16 @@ handleLuaError =
   Oops.catch \case
     Lua.LinkerErrorForeign e →
       die $ "Linker error:\n" <> show e
+    Lua.ForeignExportsMissing modname names →
+      die . toString . unlines $
+        [ "The foreign module for "
+            <> runModuleName modname
+            <> " does not export: "
+            <> Text.intercalate ", " (IR.nameToText <$> toList names)
+            <> "."
+        , "Every name declared as a `foreign import` in PureScript must be a"
+        , "key of the table returned by the module's FFI file."
+        ]
     Lua.AppEntryPointNotFound modname ident →
       die . toString $
         "App entry point not found: "

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -53,6 +53,11 @@ instance Monoid UsesObjectUpdate where
 
 data Error
   = LinkerErrorForeign Foreign.Error
+  | {- | Names declared as @foreign import@s whose keys are missing from the
+    table the module's FFI file returns. Every such read would be @nil@ at
+    runtime, so lowering rejects the module instead. See issue #249.
+    -}
+    ForeignExportsMissing ModuleName (NonEmpty IR.Name)
   | AppEntryPointNotFound ModuleName PS.Ident
   | {- | The generated chunk nests more deeply than Lua 5.1's parser allows
     (~200 syntax levels), so it would fail to load. Carries the measured
@@ -327,13 +332,26 @@ fromIR foreigns topLevelNames modname ir = case ir of
     pure $ Left [Lua.ifThenElse condExp thenBranch elseBranch]
   IR.Exception _ann msg →
     pure . Right $ Lua.error msg
-  IR.ForeignImport _ann _moduleName path annotatedNames → do
+  IR.ForeignImport _ann foreignModuleName path annotatedNames → do
     let foreignNames = fromName <<$>> annotatedNames
     -- See Note [Foreign module source format] in ...Lua.Linker.Foreign
     Foreign.Source {header, returnComments, exports} ←
       Oops.hoistEither =<< liftIO do
         left LinkerErrorForeign
           <$> Foreign.parseForeignSource (untag foreigns) path
+    -- A declared name absent from the FFI exports would lower to a read of
+    -- a missing table field and fail only at runtime, as a nil. The carried
+    -- name list is DCE-pruned, so exactly the names the emitted accessors
+    -- will read are required to exist.
+    let exportedNames = [Key.toSafeName key | (key, _value) ← toList exports]
+    whenJust
+      ( nonEmpty
+          [ name
+          | (_nameAnn, name) ← annotatedNames
+          , fromName name `notElem` exportedNames
+          ]
+      )
+      (Oops.throw . ForeignExportsMissing foreignModuleName)
     let keptRows =
           [ (comments, Lua.TableRowNV name (Lua.ann value))
           | (key, (comments, value)) ← toList exports

--- a/lib/Language/PureScript/Backend/Lua.hs
+++ b/lib/Language/PureScript/Backend/Lua.hs
@@ -343,12 +343,13 @@ fromIR foreigns topLevelNames modname ir = case ir of
     -- a missing table field and fail only at runtime, as a nil. The carried
     -- name list is DCE-pruned, so exactly the names the emitted accessors
     -- will read are required to exist.
-    let exportedNames = [Key.toSafeName key | (key, _value) ← toList exports]
+    let exportedNames =
+          Set.fromList [Key.toSafeName key | (key, _value) ← toList exports]
     whenJust
       ( nonEmpty
           [ name
           | (_nameAnn, name) ← annotatedNames
-          , fromName name `notElem` exportedNames
+          , fromName name `Set.notMember` exportedNames
           ]
       )
       (Oops.throw . ForeignExportsMissing foreignModuleName)

--- a/test/Language/PureScript/Backend/Lua/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Spec.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Language.PureScript.Backend.Lua.Spec where
 
 import Control.Monad.Oops (Variant)
+import Control.Monad.Oops qualified as Oops
 import Data.Tagged (Tagged (..))
 import Data.Text qualified as Text
 import Language.PureScript.Backend.IR qualified as IR
@@ -9,10 +12,12 @@ import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.Printer qualified as Printer
 import Language.PureScript.Backend.Lua.Types qualified as Lua.Types
 import Language.PureScript.Backend.Types (AppOrModule (AsModule))
-import Path.IO (getCurrentDir)
+import Path (relfile, toFilePath, (</>))
+import Path.IO (getCurrentDir, withSystemTempDir)
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Test.Hspec (Spec, describe, expectationFailure, it, shouldSatisfy)
+import Test.Hspec.Expectations.Pretty (shouldBe)
 
 spec ∷ Spec
 spec = describe "Lua.fromUberModule" do
@@ -105,6 +110,23 @@ spec = describe "Lua.fromUberModule" do
           (shortCall topSelf (IR.App IR.noAnn (ref "g") (ref "x")))
       rendered `shouldSatisfy` (not . Text.isInfixOf "while true do")
 
+  describe "foreign export check (#249)" do
+    it "rejects a declared foreign name missing from the FFI exports" do
+      result ← compileForeignModule "return { foo = 42 }" ["foo", "bar"]
+      case result of
+        Left (Lua.ForeignExportsMissing modname missing) → do
+          modname `shouldBe` testModuleName
+          toList missing `shouldBe` [IR.Name "bar"]
+        Left err →
+          expectationFailure ("Unexpected error: " <> show err)
+        Right _chunk →
+          expectationFailure
+            "Expected ForeignExportsMissing, but compilation succeeded"
+
+    it "accepts an FFI file that exports every declared name" do
+      result ← compileForeignModule "return { foo = 42, bar = 1 }" ["foo"]
+      result `shouldSatisfy` isRight
+
 compileExportedExpr ∷ IR.Exp → IO Text
 compileExportedExpr expr =
   compileUberModule
@@ -149,6 +171,41 @@ compileUberModule uberModule = do
     Right chunk →
       pure . renderStrict $
         layoutPretty defaultLayoutOptions (Printer.printLuaChunk chunk)
+
+{- | Compile a module whose only content is a foreign import carrying
+@declaredNames@, resolved against an FFI file with the given source text.
+Mirrors the shape 'Language.PureScript.Backend.IR.Linker.foreignBindings'
+emits (see Note [Foreign bindings structure emitted by the Linker]).
+-}
+compileForeignModule ∷ String → [Text] → IO (Either Lua.Error Lua.Types.Chunk)
+compileForeignModule ffiSource declaredNames =
+  withSystemTempDir "foreigns" \foreigns → do
+    let path = toFilePath (foreigns </> [relfile|Foo.lua|])
+    writeFile path ffiSource
+    let uberModule =
+          UberModule
+            { uberModuleBindings = []
+            , uberModuleForeigns =
+                [
+                  ( IR.QName testModuleName (IR.Name "foreign")
+                  , IR.ForeignImport
+                      IR.noAnn
+                      testModuleName
+                      path
+                      [(IR.noAnn, IR.Name name) | name ← declaredNames]
+                  )
+                ]
+            , uberModuleExports = []
+            }
+    Oops.runOops $
+      ( Right
+          <$> Lua.fromUberModule
+            (Tagged foreigns)
+            (Tagged False)
+            (AsModule testModuleName)
+            uberModule
+      )
+        & Oops.catch \(e ∷ Lua.Error) → pure (Left e)
 
 absWithLetBody ∷ IR.Exp
 absWithLetBody =


### PR DESCRIPTION
A name declared as a `foreign import` in PureScript but absent from the table its FFI file returns used to compile without complaint. The generated accessor read a missing field, so the failure surfaced only at runtime, as an "attempt to call a nil value" or as a nil flowing into data. The JS backend rejects this mismatch at compile time; pslua now does too.

Lowering of `IR.ForeignImport` now checks the carried name list against the parsed export keys and fails with a new `ForeignExportsMissing` error naming the module and the missing names. The comparison happens in the same safe-name space the `keptRows` filter uses, so reserved-word keys like `["if"]` keep matching. Since the carried list is DCE-pruned, the check is exactly as strict as the emitted code: every name the generated accessors will read must exist, and a broken-but-unused declaration still compiles (whether to validate the full declared list earlier in the pipeline stays open on the issue). Undeclared extra rows in the FFI are still dropped, since that direction is per-name dead code elimination and intentional.

The motivating defect is `Data.Number.isNaN`, which has never worked on the Lua target because the FFI spells its key `isNan` (purescript-lua/purescript-lua-numbers#8, proxied as #250). With this check, a program that uses the function fails at compile time instead of at the first call.

Tests follow the bug shape: an FFI fixture exporting `foo` while `foo` and `bar` are declared fails with the error naming `bar` (verified red before the fix), and a fixture exporting more keys than are declared still compiles. The full suite passes, including the golden corpus, which confirms no shipped module trips the new check.

Closes #249.
