### PR TITLE
Freshen binders by stripping the trailing $<digits> tail

### DIFF
--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -12,11 +12,13 @@ import Control.Lens
   , traverseOf
   )
 import Control.Monad.Writer.CPS (runWriterT, tell)
+import Data.Char qualified as Char
 import Data.Deriving (deriveEq1, deriveOrd1)
 import Data.Map qualified as Map
 import Data.MonoidMap (MonoidMap)
 import Data.MonoidMap qualified as MMap
 import Data.Set qualified as Set
+import Data.Text qualified as Text
 import Data.Traversable (mapAccumM)
 import Language.PureScript.Backend.IR.Inliner qualified as Inliner
 import Language.PureScript.Backend.IR.Names
@@ -1122,7 +1124,22 @@ freshenBinders = go Map.empty
     other → traverseOf subexpressions (go renames) other
 
   freshNameFor ∷ Name → SupplyM Name
-  freshNameFor name = freshName (nameToText name <> "$")
+  freshNameFor name = freshName (stripFreshSuffix (nameToText name) <> "$")
+
+  -- Strip every trailing @$\<digits\>@ group before minting, so a
+  -- binder freshened across several paste generations grows one
+  -- @$\<n\>@ suffix total instead of one group per generation:
+  -- @x$1602$1686@ strips to @x@ before the next mint appends its own
+  -- counter. A bare digit-suffix name from 'uniquifyNames' (e.g. @x0@)
+  -- has no @$@ before its digits, so it passes through unchanged.
+  stripFreshSuffix ∷ Text → Text
+  stripFreshSuffix t
+    | Text.null digits = t
+    | Just t' ← Text.stripSuffix "$" prefix = stripFreshSuffix t'
+    | otherwise = t
+   where
+    digits = Text.takeWhileEnd Char.isDigit t
+    prefix = Text.dropEnd (Text.length digits) t
 
 {- | Substitution under the GUC discipline: replace every occurrence of
 the variable with the replacement. There is no scope threading: under

--- a/test/Language/PureScript/Backend/IR/Types/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Types/Spec.hs
@@ -277,6 +277,15 @@ spec = describe "Types" do
           (paramNamed (Name "x$0"))
           (application (refLocal (Name "x$0")) (refLocal y))
 
+    it "freshens a previously-freshened binder without compounding the suffix" do
+      -- Two paste generations of the same binder end in a single
+      -- \$<n> suffix, not one $<n> group per generation.
+      runSupply
+        ( freshenBinders (abstraction (paramNamed x) (refLocal x))
+            >>= freshenBinders
+        )
+        `shouldBe` abstraction (paramNamed (Name "x$1")) (refLocal (Name "x$1"))
+
     prop "is an alpha-renaming of GUC-shaped input" do
       e ← forAll Gen.scopedExp
       let guc = uniquifyNamesInExpr e

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.ir
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.ir
@@ -448,12 +448,12 @@ UberModule
                           ( PropName "foldl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "c$372$911" ) :| [] )
+                          ( ParamNamed Nothing ( Name "c$911" ) :| [] )
                           ( AbsN Nothing
                             ( ParamUnused Nothing :| [] )
                             ( PrimBinOp Nothing PrimAdd
                               ( LiteralInt Nothing 1 )
-                              ( Ref Nothing ( Local ( Name "c$372$911" ) ) )
+                              ( Ref Nothing ( Local ( Name "c$911" ) ) )
                             )
                           ) :| []
                         )

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
@@ -132,8 +132,8 @@ return (function()
     end)(Effect_pureE(Data_Unit_unit))(arr_S_0)()
     return Effect_Console_logShow_S_w({
       show = Data_Show_foreign.showIntImpl
-    }, Data_Foldable_foldableArray.foldl(function(c_S_372_S_911)
-      return function() return 1 + c_S_372_S_911 end
+    }, Data_Foldable_foldableArray.foldl(function(c_S_911)
+      return function() return 1 + c_S_911 end
     end)(0)(arr_S_0))()
   end
 end)()()

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
@@ -486,12 +486,12 @@ UberModule
           ( LiteralObject Nothing
             [
               ( PropName "eq", AbsN Nothing
-                ( ParamNamed Nothing ( Name "r1$222$233" ) :| [] )
+                ( ParamNamed Nothing ( Name "r1$233" ) :| [] )
                 ( AbsN Nothing
-                  ( ParamNamed Nothing ( Name "r2$223$234" ) :| [] )
+                  ( ParamNamed Nothing ( Name "r2$234" ) :| [] )
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "r1$222$233" ) ) )
-                    ( Ref Nothing ( Local ( Name "r2$223$234" ) ) )
+                    ( Ref Nothing ( Local ( Name "r1$233" ) ) )
+                    ( Ref Nothing ( Local ( Name "r2$234" ) ) )
                   )
                 )
               )
@@ -546,7 +546,7 @@ UberModule
             ( Nothing, Name "_", AppN Nothing
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "a$2$261", AppN Nothing
+                  ( Nothing, Name "a$261", AppN Nothing
                     ( AppN Nothing
                       ( Ref Nothing
                         ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
@@ -569,11 +569,11 @@ UberModule
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( IfThenElse Nothing
-                    ( Ref Nothing ( Local ( Name "a$2$261" ) ) )
+                    ( Ref Nothing ( Local ( Name "a$261" ) ) )
                     ( LiteralString Nothing "true" )
                     ( IfThenElse Nothing
                       ( Eq Nothing ( LiteralBool Nothing False )
-                        ( Ref Nothing ( Local ( Name "a$2$261" ) ) )
+                        ( Ref Nothing ( Local ( Name "a$261" ) ) )
                       )
                       ( LiteralString Nothing "false" )
                       ( Exception Nothing "No patterns matched" )
@@ -587,7 +587,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$262", AppN Nothing
+                    ( Nothing, Name "a$262", AppN Nothing
                       ( AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
@@ -650,11 +650,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$262" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$262" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$262" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$262" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -669,7 +669,7 @@ UberModule
           ( AppN Nothing
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "a$2$263", AppN Nothing
+                ( Nothing, Name "a$263", AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
@@ -700,11 +700,11 @@ UberModule
               ( AppN Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "a$2$263" ) ) )
+                  ( Ref Nothing ( Local ( Name "a$263" ) ) )
                   ( LiteralString Nothing "true" )
                   ( IfThenElse Nothing
                     ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "a$2$263" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$263" ) ) )
                     )
                     ( LiteralString Nothing "false" )
                     ( Exception Nothing "No patterns matched" )

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -128,8 +128,8 @@ Golden_BugListGenericEq_Test_eqList = function(dictEq)
   }
 end
 local Golden_BugListGenericEq_Test_eq = (Golden_BugListGenericEq_Test_eqList({
-  eq = function(r1_S_222_S_233)
-    return function(r2_S_223_S_234) return r1_S_222_S_233 == r2_S_223_S_234 end
+  eq = function(r1_S_233)
+    return function(r2_S_234) return r1_S_233 == r2_S_234 end
   end
 })).eq
 local Golden_BugListGenericEq_Test_cons_S_w = function(head, tail)
@@ -137,11 +137,11 @@ local Golden_BugListGenericEq_Test_cons_S_w = function(head, tail)
 end
 return (function()
   local _ = (function()
-    local a_S_2_S_261 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_Nil)(Golden_BugListGenericEq_Test_Nil)
+    local a_S_261 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_Nil)(Golden_BugListGenericEq_Test_Nil)
     return Effect_Console_log((function()
-      if a_S_2_S_261 then
+      if a_S_261 then
         return "true"
-      elseif false == a_S_2_S_261 then
+      elseif false == a_S_261 then
         return "false"
       else
         return error("No patterns matched")
@@ -149,11 +149,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_262 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))
+    local a_S_262 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))
     return Effect_Console_log((function()
-      if a_S_2_S_262 then
+      if a_S_262 then
         return "true"
-      elseif false == a_S_2_S_262 then
+      elseif false == a_S_262 then
         return "false"
       else
         return error("No patterns matched")
@@ -161,11 +161,11 @@ return (function()
     end)())
   end)()()
   return (function()
-    local a_S_2_S_263 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_Nil))(Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil))
+    local a_S_263 = Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_Nil))(Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil))
     return Effect_Console_log((function()
-      if a_S_2_S_263 then
+      if a_S_263 then
         return "true"
-      elseif false == a_S_2_S_263 then
+      elseif false == a_S_263 then
         return "false"
       else
         return error("No patterns matched")

--- a/test/ps/output/Golden.CharLiterals.Test/golden.ir
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.ir
@@ -118,7 +118,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "v$108$221", Eq Nothing
+                  ( Nothing, Name "v$221", Eq Nothing
                     ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
                     ( IfThenElse Nothing
                       ( PrimBinOp Nothing PrimLt
@@ -131,11 +131,11 @@ UberModule
                   ) :| []
                 )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "v$108$221" ) ) )
+                  ( Ref Nothing ( Local ( Name "v$221" ) ) )
                   ( LiteralString Nothing "true" )
                   ( IfThenElse Nothing
                     ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "v$108$221" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$221" ) ) )
                     )
                     ( LiteralString Nothing "false" )
                     ( Exception Nothing "No patterns matched" )

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -29,16 +29,16 @@ return (function()
   local _ = Effect_Console_log(Golden_CharLiterals_Test_show("a"))()
   local _ = Effect_Console_log("true")()
   return Effect_Console_log((function()
-    local v_S_108_S_221 = "Data.Ordering∷Ordering.LT" == (function()
+    local v_S_221 = "Data.Ordering∷Ordering.LT" == (function()
       if "\t" < "\n" then
         return "Data.Ordering∷Ordering.LT"
       else
         return "Data.Ordering∷Ordering.GT"
       end
     end)()
-    if v_S_108_S_221 then
+    if v_S_221 then
       return "true"
-    elseif false == v_S_108_S_221 then
+    elseif false == v_S_221 then
       return "false"
     else
       return error("No patterns matched")

--- a/test/ps/output/Golden.DirectivesFile.M1/golden.ir
+++ b/test/ps/output/Golden.DirectivesFile.M1/golden.ir
@@ -4,10 +4,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.DirectivesFile.M1", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$168$188" ) :| [ ParamNamed Nothing ( Name "y$169$189" ) ] )
+        ( ParamNamed Nothing ( Name "x$188" ) :| [ ParamNamed Nothing ( Name "y$189" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$168$188" ) ) )
-          ( Ref Nothing ( Local ( Name "y$169$189" ) ) )
+          ( Ref Nothing ( Local ( Name "x$188" ) ) )
+          ( Ref Nothing ( Local ( Name "y$189" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.DirectivesFile.M1/golden.lua
+++ b/test/ps/output/Golden.DirectivesFile.M1/golden.lua
@@ -1,5 +1,5 @@
-local Golden_DirectivesFile_M1_add_S_w = function(x_S_168_S_188, y_S_169_S_189)
-  return x_S_168_S_188 + y_S_169_S_189
+local Golden_DirectivesFile_M1_add_S_w = function(x_S_188, y_S_189)
+  return x_S_188 + y_S_189
 end
 local Golden_DirectivesFile_M1_keep = function(x)
   return Golden_DirectivesFile_M1_add_S_w(x, 2)

--- a/test/ps/output/Golden.EffectPureChain.Test/golden.ir
+++ b/test/ps/output/Golden.EffectPureChain.Test/golden.ir
@@ -28,13 +28,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.EffectPureChain.Test", qnameName = Name "append$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$192$212" ) :|
-          [ ParamNamed Nothing ( Name "s2$193$213" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$212" ) :| [ ParamNamed Nothing ( Name "s2$213" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$192$212" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$193$213" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$212" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$213" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.EffectPureChain.Test/golden.lua
+++ b/test/ps/output/Golden.EffectPureChain.Test/golden.lua
@@ -5,9 +5,8 @@ local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
 local Effect_Console_log = Effect_Console_foreign.log
-local Golden_EffectPureChain_Test_append_S_w = function( s1_S_192_S_212
-, s2_S_193_S_213 )
-  return s1_S_192_S_212 .. s2_S_193_S_213
+local Golden_EffectPureChain_Test_append_S_w = function(s1_S_212, s2_S_213)
+  return s1_S_212 .. s2_S_213
 end
 local Golden_EffectPureChain_Test_show = Data_Show_showIntImpl
 M.Golden_EffectPureChain_Test_count = function(n)

--- a/test/ps/output/Golden.Fibonacci.Test/golden.ir
+++ b/test/ps/output/Golden.Fibonacci.Test/golden.ir
@@ -16,10 +16,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Fibonacci.Test", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$185$208" ) :| [ ParamNamed Nothing ( Name "y$186$209" ) ] )
+        ( ParamNamed Nothing ( Name "x$208" ) :| [ ParamNamed Nothing ( Name "y$209" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$185$208" ) ) )
-          ( Ref Nothing ( Local ( Name "y$186$209" ) ) )
+          ( Ref Nothing ( Local ( Name "x$208" ) ) )
+          ( Ref Nothing ( Local ( Name "y$209" ) ) )
         )
       ), RecursiveGroup
       (

--- a/test/ps/output/Golden.Fibonacci.Test/golden.lua
+++ b/test/ps/output/Golden.Fibonacci.Test/golden.lua
@@ -2,8 +2,8 @@ local Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Golden_Fibonacci_Test_sub_S_w = function(x_S_185_S_208, y_S_186_S_209)
-  return x_S_185_S_208 - y_S_186_S_209
+local Golden_Fibonacci_Test_sub_S_w = function(x_S_208, y_S_209)
+  return x_S_208 - y_S_209
 end
 local Golden_Fibonacci_Test_fib
 Golden_Fibonacci_Test_fib = function(v)

--- a/test/ps/output/Golden.FieldCaching.Test/golden.ir
+++ b/test/ps/output/Golden.FieldCaching.Test/golden.ir
@@ -28,10 +28,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.FieldCaching.Test", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$185$214" ) :| [ ParamNamed Nothing ( Name "y$186$215" ) ] )
+        ( ParamNamed Nothing ( Name "x$214" ) :| [ ParamNamed Nothing ( Name "y$215" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$185$214" ) ) )
-          ( Ref Nothing ( Local ( Name "y$186$215" ) ) )
+          ( Ref Nothing ( Local ( Name "x$214" ) ) )
+          ( Ref Nothing ( Local ( Name "y$215" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.FieldCaching.Test/golden.lua
+++ b/test/ps/output/Golden.FieldCaching.Test/golden.lua
@@ -5,8 +5,8 @@ local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
 local Effect_Console_log = Effect_Console_foreign.log
-local Golden_FieldCaching_Test_sub_S_w = function(x_S_185_S_214, y_S_186_S_215)
-  return x_S_185_S_214 - y_S_186_S_215
+local Golden_FieldCaching_Test_sub_S_w = function(x_S_214, y_S_215)
+  return x_S_214 - y_S_215
 end
 local Golden_FieldCaching_Test_weigh = function(x) return x * 2 + 1 end
 local Golden_FieldCaching_Test_sumLoop_S_w = function(acc, n)

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
@@ -451,34 +451,32 @@ UberModule
                       [ LiteralObject Nothing
                         [
                           ( PropName "genericEq'", AbsN Nothing
-                            ( ParamNamed Nothing ( Name "v$7$271" ) :| [] )
+                            ( ParamNamed Nothing ( Name "v$271" ) :| [] )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "v1$8$272" ) :| [] )
+                              ( ParamNamed Nothing ( Name "v1$272" ) :| [] )
                               ( IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                  ( ReflectCtor Nothing
-                                    ( Ref Nothing ( Local ( Name "v$7$271" ) ) )
-                                  )
+                                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$271" ) ) ) )
                                 )
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
                                   ( ReflectCtor Nothing
-                                    ( Ref Nothing ( Local ( Name "v1$8$272" ) ) )
+                                    ( Ref Nothing ( Local ( Name "v1$272" ) ) )
                                   )
                                 )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                     ( ReflectCtor Nothing
-                                      ( Ref Nothing ( Local ( Name "v$7$271" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v$271" ) ) )
                                     )
                                   )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                       ( ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "v1$8$272" ) ) )
+                                        ( Ref Nothing ( Local ( Name "v1$272" ) ) )
                                       )
                                     )
                                     ( AppN Nothing
@@ -585,11 +583,11 @@ UberModule
                                           )
                                         )
                                         ( DataArgumentByIndex Nothing SumType 0
-                                          ( Ref Nothing ( Local ( Name "v$7$271" ) ) ) :| []
+                                          ( Ref Nothing ( Local ( Name "v$271" ) ) ) :| []
                                         )
                                       )
                                       ( DataArgumentByIndex Nothing SumType 0
-                                        ( Ref Nothing ( Local ( Name "v1$8$272" ) ) ) :| []
+                                        ( Ref Nothing ( Local ( Name "v1$272" ) ) ) :| []
                                       )
                                     ) ( LiteralBool Nothing False )
                                   ) ( LiteralBool Nothing False )
@@ -643,34 +641,32 @@ UberModule
                       [ LiteralObject Nothing
                         [
                           ( PropName "genericEq'", AbsN Nothing
-                            ( ParamNamed Nothing ( Name "v$7$249" ) :| [] )
+                            ( ParamNamed Nothing ( Name "v$249" ) :| [] )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "v1$8$250" ) :| [] )
+                              ( ParamNamed Nothing ( Name "v1$250" ) :| [] )
                               ( IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                  ( ReflectCtor Nothing
-                                    ( Ref Nothing ( Local ( Name "v$7$249" ) ) )
-                                  )
+                                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$249" ) ) ) )
                                 )
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
                                   ( ReflectCtor Nothing
-                                    ( Ref Nothing ( Local ( Name "v1$8$250" ) ) )
+                                    ( Ref Nothing ( Local ( Name "v1$250" ) ) )
                                   )
                                 )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                     ( ReflectCtor Nothing
-                                      ( Ref Nothing ( Local ( Name "v$7$249" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v$249" ) ) )
                                     )
                                   )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                       ( ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "v1$8$250" ) ) )
+                                        ( Ref Nothing ( Local ( Name "v1$250" ) ) )
                                       )
                                     )
                                     ( AppN Nothing
@@ -750,11 +746,11 @@ UberModule
                                           )
                                         )
                                         ( DataArgumentByIndex Nothing SumType 0
-                                          ( Ref Nothing ( Local ( Name "v$7$249" ) ) ) :| []
+                                          ( Ref Nothing ( Local ( Name "v$249" ) ) ) :| []
                                         )
                                       )
                                       ( DataArgumentByIndex Nothing SumType 0
-                                        ( Ref Nothing ( Local ( Name "v1$8$250" ) ) ) :| []
+                                        ( Ref Nothing ( Local ( Name "v1$250" ) ) ) :| []
                                       )
                                     ) ( LiteralBool Nothing False )
                                   ) ( LiteralBool Nothing False )
@@ -858,7 +854,7 @@ UberModule
             ( Nothing, Name "_", AppN Nothing
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "a$2$291", AppN Nothing
+                  ( Nothing, Name "a$291", AppN Nothing
                     ( AppN Nothing
                       ( Ref Nothing
                         ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
@@ -921,11 +917,11 @@ UberModule
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( IfThenElse Nothing
-                    ( Ref Nothing ( Local ( Name "a$2$291" ) ) )
+                    ( Ref Nothing ( Local ( Name "a$291" ) ) )
                     ( LiteralString Nothing "true" )
                     ( IfThenElse Nothing
                       ( Eq Nothing ( LiteralBool Nothing False )
-                        ( Ref Nothing ( Local ( Name "a$2$291" ) ) )
+                        ( Ref Nothing ( Local ( Name "a$291" ) ) )
                       )
                       ( LiteralString Nothing "false" )
                       ( Exception Nothing "No patterns matched" )
@@ -939,7 +935,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$292", AppN Nothing
+                    ( Nothing, Name "a$292", AppN Nothing
                       ( AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
@@ -982,11 +978,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$292" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$292" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$292" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$292" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -999,7 +995,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$293", AppN Nothing
+                    ( Nothing, Name "a$293", AppN Nothing
                       ( AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
@@ -1078,11 +1074,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$293" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$293" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$293" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$293" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -1097,7 +1093,7 @@ UberModule
           ( AppN Nothing
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "a$2$294", AppN Nothing
+                ( Nothing, Name "a$294", AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
@@ -1142,11 +1138,11 @@ UberModule
               ( AppN Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "a$2$294" ) ) )
+                  ( Ref Nothing ( Local ( Name "a$294" ) ) )
                   ( LiteralString Nothing "true" )
                   ( IfThenElse Nothing
                     ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "a$2$294" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$294" ) ) )
                     )
                     ( LiteralString Nothing "false" )
                     ( Exception Nothing "No patterns matched" )

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -119,12 +119,12 @@ Golden_GenericEqTwoTypes_Test_eqTree = function(dictEq)
     eq = function(x)
       return function(y)
         return Data_Eq_Generic_genericEq_S_w(Golden_GenericEqTwoTypes_Test_genericTree, {
-          genericEqPrime = function(v_S_7_S_271)
-            return function(v1_S_8_S_272)
-              if "Data.Generic.Rep∷Sum.Inl" == v_S_7_S_271[1] then
-                return "Data.Generic.Rep∷Sum.Inl" == v1_S_8_S_272[1]
-              elseif "Data.Generic.Rep∷Sum.Inr" == v_S_7_S_271[1] then
-                if "Data.Generic.Rep∷Sum.Inr" == v1_S_8_S_272[1] then
+          genericEqPrime = function(v_S_271)
+            return function(v1_S_272)
+              if "Data.Generic.Rep∷Sum.Inl" == v_S_271[1] then
+                return "Data.Generic.Rep∷Sum.Inl" == v1_S_272[1]
+              elseif "Data.Generic.Rep∷Sum.Inr" == v_S_271[1] then
+                if "Data.Generic.Rep∷Sum.Inr" == v1_S_272[1] then
                   return (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
                     eqRecord = function()
                       return function() return function() return true end end
@@ -135,7 +135,7 @@ Golden_GenericEqTwoTypes_Test_eqTree = function(dictEq)
                     reflectSymbol = function() return "right" end
                   }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq)), nil, {
                     reflectSymbol = function() return "left" end
-                  }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq))).eqRecord(Type_Proxy_Proxy)(v_S_7_S_271[2])(v1_S_8_S_272[2])
+                  }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq))).eqRecord(Type_Proxy_Proxy)(v_S_271[2])(v1_S_272[2])
                 else
                   return false
                 end
@@ -156,12 +156,12 @@ Golden_GenericEqTwoTypes_Test_eqList = function(dictEq)
     eq = function(x)
       return function(y)
         return Data_Eq_Generic_genericEq_S_w(Golden_GenericEqTwoTypes_Test_genericList, {
-          genericEqPrime = function(v_S_7_S_249)
-            return function(v1_S_8_S_250)
-              if "Data.Generic.Rep∷Sum.Inl" == v_S_7_S_249[1] then
-                return "Data.Generic.Rep∷Sum.Inl" == v1_S_8_S_250[1]
-              elseif "Data.Generic.Rep∷Sum.Inr" == v_S_7_S_249[1] then
-                if "Data.Generic.Rep∷Sum.Inr" == v1_S_8_S_250[1] then
+          genericEqPrime = function(v_S_249)
+            return function(v1_S_250)
+              if "Data.Generic.Rep∷Sum.Inl" == v_S_249[1] then
+                return "Data.Generic.Rep∷Sum.Inl" == v1_S_250[1]
+              elseif "Data.Generic.Rep∷Sum.Inr" == v_S_249[1] then
+                if "Data.Generic.Rep∷Sum.Inr" == v1_S_250[1] then
                   return (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
                     eqRecord = function()
                       return function() return function() return true end end
@@ -170,7 +170,7 @@ Golden_GenericEqTwoTypes_Test_eqList = function(dictEq)
                     reflectSymbol = function() return "tail" end
                   }, Golden_GenericEqTwoTypes_Test_eqList(dictEq)), nil, {
                     reflectSymbol = function() return "head" end
-                  }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_7_S_249[2])(v1_S_8_S_250[2])
+                  }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_249[2])(v1_S_250[2])
                 else
                   return false
                 end
@@ -190,11 +190,11 @@ local Golden_GenericEqTwoTypes_Test_cons_S_w = function(head, tail)
 end
 return (function()
   local _ = (function()
-    local a_S_2_S_291 = Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))
+    local a_S_291 = Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))
     return Effect_Console_log((function()
-      if a_S_2_S_291 then
+      if a_S_291 then
         return "true"
-      elseif false == a_S_2_S_291 then
+      elseif false == a_S_291 then
         return "false"
       else
         return error("No patterns matched")
@@ -202,11 +202,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_292 = Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_Nil))(Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil))
+    local a_S_292 = Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_Nil))(Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil))
     return Effect_Console_log((function()
-      if a_S_2_S_292 then
+      if a_S_292 then
         return "true"
-      elseif false == a_S_2_S_292 then
+      elseif false == a_S_292 then
         return "false"
       else
         return error("No patterns matched")
@@ -214,11 +214,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_293 = Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))
+    local a_S_293 = Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))
     return Effect_Console_log((function()
-      if a_S_2_S_293 then
+      if a_S_293 then
         return "true"
-      elseif false == a_S_2_S_293 then
+      elseif false == a_S_293 then
         return "false"
       else
         return error("No patterns matched")
@@ -226,11 +226,11 @@ return (function()
     end)())
   end)()()
   return (function()
-    local a_S_2_S_294 = Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_Leaf))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf))
+    local a_S_294 = Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_Leaf))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf))
     return Effect_Console_log((function()
-      if a_S_2_S_294 then
+      if a_S_294 then
         return "true"
-      elseif false == a_S_2_S_294 then
+      elseif false == a_S_294 then
         return "false"
       else
         return error("No patterns matched")

--- a/test/ps/output/Golden.LongApplyChain.Test/golden.ir
+++ b/test/ps/output/Golden.LongApplyChain.Test/golden.ir
@@ -15,13 +15,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Maybe", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$295$314" ) :|
-          [ ParamNamed Nothing ( Name "s2$296$315" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$314" ) :| [ ParamNamed Nothing ( Name "s2$315" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$295$314" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$296$315" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$314" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$315" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongApplyChain.Test/golden.lua
+++ b/test/ps/output/Golden.LongApplyChain.Test/golden.lua
@@ -2,8 +2,8 @@ local Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Maybe_append_S_w = function(s1_S_295_S_314, s2_S_296_S_315)
-  return s1_S_295_S_314 .. s2_S_296_S_315
+local Data_Maybe_append_S_w = function(s1_S_314, s2_S_315)
+  return s1_S_314 .. s2_S_315
 end
 local Data_Maybe_Nothing = { "Data.Maybe∷Maybe.Nothing" }
 local Data_Maybe_Just = function(value0)

--- a/test/ps/output/Golden.LongBindFlipped.Test/golden.ir
+++ b/test/ps/output/Golden.LongBindFlipped.Test/golden.ir
@@ -15,13 +15,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Maybe", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$286$318" ) :|
-          [ ParamNamed Nothing ( Name "s2$287$319" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$318" ) :| [ ParamNamed Nothing ( Name "s2$319" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$286$318" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$287$319" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$318" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$319" ) ) )
         )
       ), Standalone
       ( QName
@@ -35,22 +32,22 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongBindFlipped.Test", qnameName = Name "bindFlipped$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "b$135$308" ) :| [ ParamNamed Nothing ( Name "a$136$309" ) ] )
+        ( ParamNamed Nothing ( Name "b$308" ) :| [ ParamNamed Nothing ( Name "a$309" ) ] )
         ( IfThenElse Nothing
           ( Eq Nothing
             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$136$309" ) ) ) )
+            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$309" ) ) ) )
           )
           ( AppN Nothing
-            ( Ref Nothing ( Local ( Name "b$135$308" ) ) )
+            ( Ref Nothing ( Local ( Name "b$308" ) ) )
             ( DataArgumentByIndex Nothing SumType 0
-              ( Ref Nothing ( Local ( Name "a$136$309" ) ) ) :| []
+              ( Ref Nothing ( Local ( Name "a$309" ) ) ) :| []
             )
           )
           ( IfThenElse Nothing
             ( Eq Nothing
               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$136$309" ) ) ) )
+              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$309" ) ) ) )
             )
             ( Ctor Nothing SumType
               ( ModuleName "Data.Maybe" )

--- a/test/ps/output/Golden.LongBindFlipped.Test/golden.lua
+++ b/test/ps/output/Golden.LongBindFlipped.Test/golden.lua
@@ -2,17 +2,16 @@ local Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Maybe_append_S_w = function(s1_S_286_S_318, s2_S_287_S_319)
-  return s1_S_286_S_318 .. s2_S_287_S_319
+local Data_Maybe_append_S_w = function(s1_S_318, s2_S_319)
+  return s1_S_318 .. s2_S_319
 end
 local Data_Maybe_Just = function(value0)
   return { "Data.Maybe∷Maybe.Just", value0 }
 end
-local Golden_LongBindFlipped_Test_bindFlipped_S_w = function( b_S_135_S_308
-, a_S_136_S_309 )
-  if "Data.Maybe∷Maybe.Just" == a_S_136_S_309[1] then
-    return b_S_135_S_308(a_S_136_S_309[2])
-  elseif "Data.Maybe∷Maybe.Nothing" == a_S_136_S_309[1] then
+local Golden_LongBindFlipped_Test_bindFlipped_S_w = function(b_S_308, a_S_309)
+  if "Data.Maybe∷Maybe.Just" == a_S_309[1] then
+    return b_S_308(a_S_309[2])
+  elseif "Data.Maybe∷Maybe.Nothing" == a_S_309[1] then
     return { "Data.Maybe∷Maybe.Nothing" }
   else
     return error("No patterns matched")

--- a/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
+++ b/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
@@ -16,10 +16,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongCallbackChain.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$189$215" ) :| [ ParamNamed Nothing ( Name "y$190$216" ) ] )
+        ( ParamNamed Nothing ( Name "x$215" ) :| [ ParamNamed Nothing ( Name "y$216" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$189$215" ) ) )
-          ( Ref Nothing ( Local ( Name "y$190$216" ) ) )
+          ( Ref Nothing ( Local ( Name "x$215" ) ) )
+          ( Ref Nothing ( Local ( Name "y$216" ) ) )
         )
       ), RecursiveGroup
       (

--- a/test/ps/output/Golden.LongCallbackChain.Test/golden.lua
+++ b/test/ps/output/Golden.LongCallbackChain.Test/golden.lua
@@ -3,9 +3,8 @@ local Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Golden_LongCallbackChain_Test_add_S_w = function( x_S_189_S_215
-, y_S_190_S_216 )
-  return x_S_189_S_215 + y_S_190_S_216
+local Golden_LongCallbackChain_Test_add_S_w = function(x_S_215, y_S_216)
+  return x_S_215 + y_S_216
 end
 local Golden_LongCallbackChain_Test_withInc_S_w = function(n, k)
   while true do

--- a/test/ps/output/Golden.LongEitherBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongEitherBind.Test/golden.ir
@@ -15,13 +15,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Either", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$299$331" ) :|
-          [ ParamNamed Nothing ( Name "s2$300$332" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$331" ) :| [ ParamNamed Nothing ( Name "s2$332" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$299$331" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$300$332" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$331" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$332" ) ) )
         )
       ), Standalone
       ( QName
@@ -35,10 +32,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongEitherBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$297$326" ) :| [ ParamNamed Nothing ( Name "y$298$327" ) ] )
+        ( ParamNamed Nothing ( Name "x$326" ) :| [ ParamNamed Nothing ( Name "y$327" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$297$326" ) ) )
-          ( Ref Nothing ( Local ( Name "y$298$327" ) ) )
+          ( Ref Nothing ( Local ( Name "x$326" ) ) )
+          ( Ref Nothing ( Local ( Name "y$327" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongEitherBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongEitherBind.Test/golden.lua
@@ -43,15 +43,14 @@ local Data_Show_foreign = {
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Either_append_S_w = function(s1_S_299_S_331, s2_S_300_S_332)
-  return s1_S_299_S_331 .. s2_S_300_S_332
+local Data_Either_append_S_w = function(s1_S_331, s2_S_332)
+  return s1_S_331 .. s2_S_332
 end
 local Data_Either_Right = function(value0)
   return { "Data.Either∷Either.Right", value0 }
 end
-local Golden_LongEitherBind_Test_add_S_w = function( x_S_297_S_326
-, y_S_298_S_327 )
-  return x_S_297_S_326 + y_S_298_S_327
+local Golden_LongEitherBind_Test_add_S_w = function(x_S_326, y_S_327)
+  return x_S_326 + y_S_327
 end
 local Golden_LongEitherBind_Test_compute = (function()
   local x150 = (function()

--- a/test/ps/output/Golden.LongExceptBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongExceptBind.Test/golden.ir
@@ -21,13 +21,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Either", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$516$557" ) :|
-          [ ParamNamed Nothing ( Name "s2$517$558" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$557" ) :| [ ParamNamed Nothing ( Name "s2$558" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$516$557" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$517$558" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$557" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$558" ) ) )
         )
       ), Standalone
       ( QName
@@ -429,7 +426,7 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$578$591" ) :| [] )
+                  ( ParamNamed Nothing ( Name "x$591" ) :| [] )
                   ( AppN Nothing
                     ( ObjectProp Nothing
                       ( AppN Nothing
@@ -445,7 +442,7 @@ UberModule
                     )
                     ( AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Either" ) ( Name "Right" ) ) )
-                      ( Ref Nothing ( Local ( Name "x$578$591" ) ) :| [] ) :| []
+                      ( Ref Nothing ( Local ( Name "x$591" ) ) :| [] ) :| []
                     )
                   )
                 ),
@@ -480,10 +477,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongExceptBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$514$552" ) :| [ ParamNamed Nothing ( Name "y$515$553" ) ] )
+        ( ParamNamed Nothing ( Name "x$552" ) :| [ ParamNamed Nothing ( Name "y$553" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$514$552" ) ) )
-          ( Ref Nothing ( Local ( Name "y$515$553" ) ) )
+          ( Ref Nothing ( Local ( Name "x$552" ) ) )
+          ( Ref Nothing ( Local ( Name "y$553" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongExceptBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongExceptBind.Test/golden.lua
@@ -44,8 +44,8 @@ local Unsafe_Coerce_foreign = { unsafeCoerce = function(x) return x end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Either_append_S_w = function(s1_S_516_S_557, s2_S_517_S_558)
-  return s1_S_516_S_557 .. s2_S_517_S_558
+local Data_Either_append_S_w = function(s1_S_557, s2_S_558)
+  return s1_S_557 .. s2_S_558
 end
 local Data_Either_Left = function(value0)
   return { "Data.Either∷Either.Left", value0 }
@@ -147,8 +147,8 @@ Control_Monad_Except_Trans_applyExceptT = function(dictMonad)
 end
 Control_Monad_Except_Trans_applicativeExceptT = function(dictMonad)
   return {
-    pure = function(x_S_578_S_591)
-      return (dictMonad.Applicative0()).pure(Data_Either_Right(x_S_578_S_591))
+    pure = function(x_S_591)
+      return (dictMonad.Applicative0()).pure(Data_Either_Right(x_S_591))
     end,
     Apply0 = function()
       return Control_Monad_Except_Trans_applyExceptT(dictMonad)
@@ -156,9 +156,8 @@ Control_Monad_Except_Trans_applicativeExceptT = function(dictMonad)
   }
 end
 local Golden_LongExceptBind_Test_bind = (Control_Monad_Except_Trans_bindExceptT(Data_Identity_monadIdentity)).bind
-local Golden_LongExceptBind_Test_add_S_w = function( x_S_514_S_552
-, y_S_515_S_553 )
-  return x_S_514_S_552 + y_S_515_S_553
+local Golden_LongExceptBind_Test_add_S_w = function(x_S_552, y_S_553)
+  return x_S_552 + y_S_553
 end
 local Golden_LongExceptBind_Test_go = (function()
   local _S_kont796 = function(x1_S_797)

--- a/test/ps/output/Golden.LongMaybeBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongMaybeBind.Test/golden.ir
@@ -27,13 +27,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Maybe", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$286$314" ) :|
-          [ ParamNamed Nothing ( Name "s2$287$315" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$314" ) :| [ ParamNamed Nothing ( Name "s2$315" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$286$314" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$287$315" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$314" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$315" ) ) )
         )
       ), Standalone
       ( QName
@@ -76,10 +73,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongMaybeBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$284$309" ) :| [ ParamNamed Nothing ( Name "y$285$310" ) ] )
+        ( ParamNamed Nothing ( Name "x$309" ) :| [ ParamNamed Nothing ( Name "y$310" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$284$309" ) ) )
-          ( Ref Nothing ( Local ( Name "y$285$310" ) ) )
+          ( Ref Nothing ( Local ( Name "x$309" ) ) )
+          ( Ref Nothing ( Local ( Name "y$310" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongMaybeBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongMaybeBind.Test/golden.lua
@@ -4,8 +4,8 @@ local Data_Show_foreign = { showIntImpl = function(n) return tostring(n) end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Maybe_append_S_w = function(s1_S_286_S_314, s2_S_287_S_315)
-  return s1_S_286_S_314 .. s2_S_287_S_315
+local Data_Maybe_append_S_w = function(s1_S_314, s2_S_315)
+  return s1_S_314 .. s2_S_315
 end
 local Data_Maybe_Just = function(value0)
   return { "Data.Maybe∷Maybe.Just", value0 }
@@ -19,8 +19,8 @@ local Golden_LongMaybeBind_Test_bind_S_w = function(v_S_303, v1_S_304)
     return error("No patterns matched")
   end
 end
-local Golden_LongMaybeBind_Test_add_S_w = function(x_S_284_S_309, y_S_285_S_310)
-  return x_S_284_S_309 + y_S_285_S_310
+local Golden_LongMaybeBind_Test_add_S_w = function(x_S_309, y_S_310)
+  return x_S_309 + y_S_310
 end
 local Golden_LongMaybeBind_Test_compute = (function()
   local _S_kont320 = function(x1_S_321)

--- a/test/ps/output/Golden.LongMaybeBindModule.Test/golden.ir
+++ b/test/ps/output/Golden.LongMaybeBindModule.Test/golden.ir
@@ -53,10 +53,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongMaybeBindModule.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$559$584" ) :| [ ParamNamed Nothing ( Name "y$560$585" ) ] )
+        ( ParamNamed Nothing ( Name "x$584" ) :| [ ParamNamed Nothing ( Name "y$585" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$559$584" ) ) )
-          ( Ref Nothing ( Local ( Name "y$560$585" ) ) )
+          ( Ref Nothing ( Local ( Name "x$584" ) ) )
+          ( Ref Nothing ( Local ( Name "y$585" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =

--- a/test/ps/output/Golden.LongMaybeBindModule.Test/golden.lua
+++ b/test/ps/output/Golden.LongMaybeBindModule.Test/golden.lua
@@ -12,9 +12,8 @@ local Golden_LongMaybeBindModule_Test_bind_S_w = function(v_S_578, v1_S_579)
     return error("No patterns matched")
   end
 end
-local Golden_LongMaybeBindModule_Test_add_S_w = function( x_S_559_S_584
-, y_S_560_S_585 )
-  return x_S_559_S_584 + y_S_560_S_585
+local Golden_LongMaybeBindModule_Test_add_S_w = function(x_S_584, y_S_585)
+  return x_S_584 + y_S_585
 end
 return {
   compute = (function()

--- a/test/ps/output/Golden.LongReaderBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongReaderBind.Test/golden.ir
@@ -22,16 +22,16 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongReaderBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$472$504" ) :| [ ParamNamed Nothing ( Name "y$473$505" ) ] )
+        ( ParamNamed Nothing ( Name "x$504" ) :| [ ParamNamed Nothing ( Name "y$505" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$472$504" ) ) )
-          ( Ref Nothing ( Local ( Name "y$473$505" ) ) )
+          ( Ref Nothing ( Local ( Name "x$504" ) ) )
+          ( Ref Nothing ( Local ( Name "y$505" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.LongReaderBind.Test", qnameName = Name "go"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "r$515$554" ) :| [] )
+        ( ParamNamed Nothing ( Name "r$554" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Golden.LongReaderBind.Test" ) ( Name "add$w" ) ) )
           ( AppN Nothing
@@ -39,10 +39,10 @@ UberModule
               ( Imported ( ModuleName "Golden.LongReaderBind.Test" ) ( Name "add$w" ) )
             )
             ( Ref Nothing
-              ( Local ( Name "r$515$554" ) ) :|
-              [ Ref Nothing ( Local ( Name "r$515$554" ) ) ]
+              ( Local ( Name "r$554" ) ) :|
+              [ Ref Nothing ( Local ( Name "r$554" ) ) ]
             ) :|
-            [ Ref Nothing ( Local ( Name "r$515$554" ) ) ]
+            [ Ref Nothing ( Local ( Name "r$554" ) ) ]
           )
         )
       ), Standalone

--- a/test/ps/output/Golden.LongReaderBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongReaderBind.Test/golden.lua
@@ -4,12 +4,11 @@ local Unsafe_Coerce_foreign = { unsafeCoerce = function(x) return x end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Golden_LongReaderBind_Test_add_S_w = function( x_S_472_S_504
-, y_S_473_S_505 )
-  return x_S_472_S_504 + y_S_473_S_505
+local Golden_LongReaderBind_Test_add_S_w = function(x_S_504, y_S_505)
+  return x_S_504 + y_S_505
 end
-M.Golden_LongReaderBind_Test_go = function(r_S_515_S_554)
-  return Golden_LongReaderBind_Test_add_S_w(Golden_LongReaderBind_Test_add_S_w(r_S_515_S_554, r_S_515_S_554), r_S_515_S_554)
+M.Golden_LongReaderBind_Test_go = function(r_S_554)
+  return Golden_LongReaderBind_Test_add_S_w(Golden_LongReaderBind_Test_add_S_w(r_S_554, r_S_554), r_S_554)
 end
 local Golden_LongReaderBind_Test_compute = Unsafe_Coerce_foreign.unsafeCoerce(Golden_LongReaderBind_Test_add_S_w(Golden_LongReaderBind_Test_add_S_w(3, 3), 3))
 return Effect_Console_foreign.log(Data_Show_foreign.showIntImpl(Golden_LongReaderBind_Test_compute))()

--- a/test/ps/output/Golden.LongStackBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongStackBind.Test/golden.ir
@@ -33,13 +33,10 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Either", qnameName = Name "append$w" }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "s1$552$594" ) :|
-          [ ParamNamed Nothing ( Name "s2$553$595" ) ]
-        )
+        ( ParamNamed Nothing ( Name "s1$594" ) :| [ ParamNamed Nothing ( Name "s2$595" ) ] )
         ( PrimBinOp Nothing PrimConcat
-          ( Ref Nothing ( Local ( Name "s1$552$594" ) ) )
-          ( Ref Nothing ( Local ( Name "s2$553$595" ) ) )
+          ( Ref Nothing ( Local ( Name "s1$594" ) ) )
+          ( Ref Nothing ( Local ( Name "s2$595" ) ) )
         )
       ), Standalone
       ( QName
@@ -309,7 +306,7 @@ UberModule
                       ( PropName "map", AbsN Nothing
                         ( ParamNamed Nothing ( Name "f$1855" ) :| [] )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$575$1856" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$1856" ) :| [] )
                           ( AppN Nothing
                             ( AppN Nothing
                               ( ObjectProp Nothing
@@ -347,12 +344,12 @@ UberModule
                                 ( PropName "map" )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "m$585$1858" ) :| [] )
+                                ( ParamNamed Nothing ( Name "m$1858" ) :| [] )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Data.Either∷Either.Left" )
                                     ( ReflectCtor Nothing
-                                      ( Ref Nothing ( Local ( Name "m$585$1858" ) ) )
+                                      ( Ref Nothing ( Local ( Name "m$1858" ) ) )
                                     )
                                   )
                                   ( AppN Nothing
@@ -360,14 +357,14 @@ UberModule
                                       ( Imported ( ModuleName "Data.Either" ) ( Name "Left" ) )
                                     )
                                     ( DataArgumentByIndex Nothing SumType 0
-                                      ( Ref Nothing ( Local ( Name "m$585$1858" ) ) ) :| []
+                                      ( Ref Nothing ( Local ( Name "m$1858" ) ) ) :| []
                                     )
                                   )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Either∷Either.Right" )
                                       ( ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "m$585$1858" ) ) )
+                                        ( Ref Nothing ( Local ( Name "m$1858" ) ) )
                                       )
                                     )
                                     ( AppN Nothing
@@ -377,7 +374,7 @@ UberModule
                                       ( AppN Nothing
                                         ( Ref Nothing ( Local ( Name "f$1855" ) ) )
                                         ( DataArgumentByIndex Nothing SumType 0
-                                          ( Ref Nothing ( Local ( Name "m$585$1858" ) ) ) :| []
+                                          ( Ref Nothing ( Local ( Name "m$1858" ) ) ) :| []
                                         ) :| []
                                       )
                                     )
@@ -386,7 +383,7 @@ UberModule
                                 ) :| []
                               )
                             )
-                            ( Ref Nothing ( Local ( Name "v$575$1856" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "v$1856" ) ) :| [] )
                           )
                         )
                       )
@@ -403,7 +400,7 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$1867$1878" ) :| [] )
+                  ( ParamNamed Nothing ( Name "x$1878" ) :| [] )
                   ( AppN Nothing
                     ( ObjectProp Nothing
                       ( AppN Nothing
@@ -419,7 +416,7 @@ UberModule
                     )
                     ( AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Either" ) ( Name "Right" ) ) )
-                      ( Ref Nothing ( Local ( Name "x$1867$1878" ) ) :| [] ) :| []
+                      ( Ref Nothing ( Local ( Name "x$1878" ) ) :| [] ) :| []
                     )
                   )
                 ),
@@ -770,12 +767,12 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "bind", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "v$128$577" ) :| [] )
+                    ( ParamNamed Nothing ( Name "v$577" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$129$578" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$578" ) :| [] )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "f$129$578" ) ) )
-                        ( Ref Nothing ( Local ( Name "v$128$577" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "f$578" ) ) )
+                        ( Ref Nothing ( Local ( Name "v$577" ) ) :| [] )
                       )
                     )
                   ),
@@ -846,10 +843,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStackBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$550$589" ) :| [ ParamNamed Nothing ( Name "y$551$590" ) ] )
+        ( ParamNamed Nothing ( Name "x$589" ) :| [ ParamNamed Nothing ( Name "y$590" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$550$589" ) ) )
-          ( Ref Nothing ( Local ( Name "y$551$590" ) ) )
+          ( Ref Nothing ( Local ( Name "x$589" ) ) )
+          ( Ref Nothing ( Local ( Name "y$590" ) ) )
         )
       ), Standalone
       ( QName
@@ -13985,7 +13982,7 @@ UberModule
         )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "v$575$603", AppN Nothing
+            ( Nothing, Name "v$603", AppN Nothing
               ( Ref Nothing ( Imported ( ModuleName "Golden.LongStackBind.Test" ) ( Name "go" ) ) )
               ( LiteralInt Nothing 0 :| [] )
             ) :| []
@@ -13993,24 +13990,24 @@ UberModule
           ( IfThenElse Nothing
             ( Eq Nothing
               ( LiteralString Nothing "Data.Either∷Either.Left" )
-              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$575$603" ) ) ) )
+              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$603" ) ) ) )
             )
             ( AppN Nothing
               ( Ref Nothing ( Imported ( ModuleName "Data.Either" ) ( Name "Left" ) ) )
               ( DataArgumentByIndex Nothing SumType 0
-                ( Ref Nothing ( Local ( Name "v$575$603" ) ) ) :| []
+                ( Ref Nothing ( Local ( Name "v$603" ) ) ) :| []
               )
             )
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Data.Either∷Either.Right" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$575$603" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$603" ) ) ) )
               )
               ( AppN Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Data.Either" ) ( Name "Right" ) ) )
                 ( DataArgumentByIndex Nothing ProductType 0
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "v$575$603" ) ) )
+                    ( Ref Nothing ( Local ( Name "v$603" ) ) )
                   ) :| []
                 )
               )

--- a/test/ps/output/Golden.LongStackBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongStackBind.Test/golden.lua
@@ -46,8 +46,8 @@ local Unsafe_Coerce_foreign = { unsafeCoerce = function(x) return x end }
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Either_append_S_w = function(s1_S_552_S_594, s2_S_553_S_595)
-  return s1_S_552_S_594 .. s2_S_553_S_595
+local Data_Either_append_S_w = function(s1_S_594, s2_S_595)
+  return s1_S_594 .. s2_S_595
 end
 local Data_Either_Left = function(value0)
   return { "Data.Either∷Either.Left", value0 }
@@ -116,16 +116,16 @@ Control_Monad_Except_Trans_applyExceptT = function(dictMonad)
     Functor0 = function()
       return {
         map = function(f_S_1855)
-          return function(v_S_575_S_1856)
-            return (((dictMonad.Bind1()).Apply0()).Functor0()).map(function( m_S_585_S_1858 )
-              if "Data.Either∷Either.Left" == m_S_585_S_1858[1] then
-                return Data_Either_Left(m_S_585_S_1858[2])
-              elseif "Data.Either∷Either.Right" == m_S_585_S_1858[1] then
-                return Data_Either_Right(f_S_1855(m_S_585_S_1858[2]))
+          return function(v_S_1856)
+            return (((dictMonad.Bind1()).Apply0()).Functor0()).map(function( m_S_1858 )
+              if "Data.Either∷Either.Left" == m_S_1858[1] then
+                return Data_Either_Left(m_S_1858[2])
+              elseif "Data.Either∷Either.Right" == m_S_1858[1] then
+                return Data_Either_Right(f_S_1855(m_S_1858[2]))
               else
                 return error("No patterns matched")
               end
-            end)(v_S_575_S_1856)
+            end)(v_S_1856)
           end
         end
       }
@@ -134,8 +134,8 @@ Control_Monad_Except_Trans_applyExceptT = function(dictMonad)
 end
 Control_Monad_Except_Trans_applicativeExceptT = function(dictMonad)
   return {
-    pure = function(x_S_1867_S_1878)
-      return (dictMonad.Applicative0()).pure(Data_Either_Right(x_S_1867_S_1878))
+    pure = function(x_S_1878)
+      return (dictMonad.Applicative0()).pure(Data_Either_Right(x_S_1878))
     end,
     Apply0 = function()
       return Control_Monad_Except_Trans_applyExceptT(dictMonad)
@@ -222,8 +222,8 @@ local Golden_LongStackBind_Test_monadExceptT = Control_Monad_Except_Trans_monadE
   end,
   Bind1 = function()
     return {
-      bind = function(v_S_128_S_577)
-        return function(f_S_129_S_578) return f_S_129_S_578(v_S_128_S_577) end
+      bind = function(v_S_577)
+        return function(f_S_578) return f_S_578(v_S_577) end
       end,
       Apply0 = function() return Data_Identity_applyIdentity end
     }
@@ -235,8 +235,8 @@ local Golden_LongStackBind_Test_get = function(x_S_1825)
   return (Golden_LongStackBind_Test_monadExceptT.Applicative0()).pure(Data_Tuple_Tuple(x_S_1825)(x_S_1825))
 end
 local Golden_LongStackBind_Test_discard = Golden_LongStackBind_Test_bindStateT.bind
-local Golden_LongStackBind_Test_add_S_w = function(x_S_550_S_589, y_S_551_S_590)
-  return x_S_550_S_589 + y_S_551_S_590
+local Golden_LongStackBind_Test_add_S_w = function(x_S_589, y_S_590)
+  return x_S_589 + y_S_590
 end
 local Golden_LongStackBind_Test_go = (function()
   local _S_kont1882 = function(x1_S_1883)
@@ -1165,11 +1165,11 @@ local Golden_LongStackBind_Test_go = (function()
   end)
 end)()
 local Golden_LongStackBind_Test_compute = Unsafe_Coerce_foreign.unsafeCoerce((function(  )
-  local v_S_575_S_603 = Golden_LongStackBind_Test_go(0)
-  if "Data.Either∷Either.Left" == v_S_575_S_603[1] then
-    return Data_Either_Left(v_S_575_S_603[2])
-  elseif "Data.Either∷Either.Right" == v_S_575_S_603[1] then
-    return Data_Either_Right(v_S_575_S_603[2][1])
+  local v_S_603 = Golden_LongStackBind_Test_go(0)
+  if "Data.Either∷Either.Left" == v_S_603[1] then
+    return Data_Either_Left(v_S_603[2])
+  elseif "Data.Either∷Either.Right" == v_S_603[1] then
+    return Data_Either_Right(v_S_603[2][1])
   else
     return error("No patterns matched")
   end

--- a/test/ps/output/Golden.LongStateBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongStateBind.Test/golden.ir
@@ -431,13 +431,13 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStateBind.Test", qnameName = Name "get"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$540$1450" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$1450" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Tuple" ) ( Name "Tuple" ) ) )
-            ( Ref Nothing ( Local ( Name "x$540$1450" ) ) :| [] )
+            ( Ref Nothing ( Local ( Name "x$1450" ) ) :| [] )
           )
-          ( Ref Nothing ( Local ( Name "x$540$1450" ) ) :| [] )
+          ( Ref Nothing ( Local ( Name "x$1450" ) ) :| [] )
         )
       ), Standalone
       ( QName
@@ -451,10 +451,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStateBind.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$495$532" ) :| [ ParamNamed Nothing ( Name "y$496$533" ) ] )
+        ( ParamNamed Nothing ( Name "x$532" ) :| [ ParamNamed Nothing ( Name "y$533" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$495$532" ) ) )
-          ( Ref Nothing ( Local ( Name "y$496$533" ) ) )
+          ( Ref Nothing ( Local ( Name "x$532" ) ) )
+          ( Ref Nothing ( Local ( Name "y$533" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongStateBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongStateBind.Test/golden.lua
@@ -106,12 +106,12 @@ Control_Monad_State_Trans_applicativeStateT = function(dictMonad)
 end
 local Golden_LongStateBind_Test_bindStateT = Control_Monad_State_Trans_bindStateT(Data_Identity_monadIdentity)
 local Golden_LongStateBind_Test_bind = Golden_LongStateBind_Test_bindStateT.bind
-local Golden_LongStateBind_Test_get = function(x_S_540_S_1450)
-  return Data_Tuple_Tuple(x_S_540_S_1450)(x_S_540_S_1450)
+local Golden_LongStateBind_Test_get = function(x_S_1450)
+  return Data_Tuple_Tuple(x_S_1450)(x_S_1450)
 end
 local Golden_LongStateBind_Test_discard = Golden_LongStateBind_Test_bindStateT.bind
-local Golden_LongStateBind_Test_add_S_w = function(x_S_495_S_532, y_S_496_S_533)
-  return x_S_495_S_532 + y_S_496_S_533
+local Golden_LongStateBind_Test_add_S_w = function(x_S_532, y_S_533)
+  return x_S_532 + y_S_533
 end
 local Golden_LongStateBind_Test_go = (function()
   local _S_kont1460 = function(x1_S_1461)

--- a/test/ps/output/Golden.Loopification.Test/golden.ir
+++ b/test/ps/output/Golden.Loopification.Test/golden.ir
@@ -28,10 +28,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Loopification.Test", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$185$216" ) :| [ ParamNamed Nothing ( Name "y$186$217" ) ] )
+        ( ParamNamed Nothing ( Name "x$216" ) :| [ ParamNamed Nothing ( Name "y$217" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$185$216" ) ) )
-          ( Ref Nothing ( Local ( Name "y$186$217" ) ) )
+          ( Ref Nothing ( Local ( Name "x$216" ) ) )
+          ( Ref Nothing ( Local ( Name "y$217" ) ) )
         )
       ), RecursiveGroup
       (

--- a/test/ps/output/Golden.Loopification.Test/golden.lua
+++ b/test/ps/output/Golden.Loopification.Test/golden.lua
@@ -5,8 +5,8 @@ local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
 local Effect_Console_log = Effect_Console_foreign.log
-local Golden_Loopification_Test_sub_S_w = function(x_S_185_S_216, y_S_186_S_217)
-  return x_S_185_S_216 - y_S_186_S_217
+local Golden_Loopification_Test_sub_S_w = function(x_S_216, y_S_217)
+  return x_S_216 - y_S_217
 end
 local Golden_Loopification_Test_sumTo_S_w = function(acc, n)
   while true do

--- a/test/ps/output/Golden.MixedEffectSTDo.Test/golden.ir
+++ b/test/ps/output/Golden.MixedEffectSTDo.Test/golden.ir
@@ -173,22 +173,20 @@ UberModule
                                 )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "s$8$458" ) :| [] )
+                                ( ParamNamed Nothing ( Name "s$458" ) :| [] )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "s'$9$459", PrimBinOp Nothing PrimMul
-                                      ( Ref Nothing ( Local ( Name "s$8$458" ) ) )
+                                    ( Nothing, Name "s'$459", PrimBinOp Nothing PrimMul
+                                      ( Ref Nothing ( Local ( Name "s$458" ) ) )
                                       ( LiteralInt Nothing 2 )
                                     ) :| []
                                   )
                                   ( LiteralObject Nothing
                                     [
                                       ( PropName "state", Ref Nothing
-                                        ( Local ( Name "s'$9$459" ) )
+                                        ( Local ( Name "s'$459" ) )
                                       ),
-                                      ( PropName "value", Ref Nothing
-                                        ( Local ( Name "s'$9$459" ) )
-                                      )
+                                      ( PropName "value", Ref Nothing ( Local ( Name "s'$459" ) ) )
                                     ]
                                   )
                                 ) :| []

--- a/test/ps/output/Golden.MixedEffectSTDo.Test/golden.lua
+++ b/test/ps/output/Golden.MixedEffectSTDo.Test/golden.lua
@@ -41,9 +41,9 @@ return (function()
   local _ = Effect_Console_log("mixing Effect and ST")()
   local x_S_0 = Control_Monad_ST_Internal_run(function()
     local ref_S_456 = Control_Monad_ST_Internal_new(2)()
-    local _ = Control_Monad_ST_Internal_modifyImpl(function(s_S_8_S_458)
-      local sPrime_S_9_S_459 = s_S_8_S_458 * 2
-      return { state = sPrime_S_9_S_459, value = sPrime_S_9_S_459 }
+    local _ = Control_Monad_ST_Internal_modifyImpl(function(s_S_458)
+      local sPrime_S_459 = s_S_458 * 2
+      return { state = sPrime_S_459, value = sPrime_S_459 }
     end)(ref_S_456)()
     local n_S_457 = Control_Monad_ST_Internal_read(ref_S_456)()
     return n_S_457 + 3

--- a/test/ps/output/Golden.NumberIsNaN.Test/golden.ir
+++ b/test/ps/output/Golden.NumberIsNaN.Test/golden.ir
@@ -56,7 +56,7 @@ UberModule
             ( Nothing, Name "_", AppN Nothing
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "a$2$316", AppN Nothing
+                  ( Nothing, Name "a$316", AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                     ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "nan" ) ) :| [] )
                   ) :| []
@@ -64,11 +64,11 @@ UberModule
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( IfThenElse Nothing
-                    ( Ref Nothing ( Local ( Name "a$2$316" ) ) )
+                    ( Ref Nothing ( Local ( Name "a$316" ) ) )
                     ( LiteralString Nothing "true" )
                     ( IfThenElse Nothing
                       ( Eq Nothing ( LiteralBool Nothing False )
-                        ( Ref Nothing ( Local ( Name "a$2$316" ) ) )
+                        ( Ref Nothing ( Local ( Name "a$316" ) ) )
                       )
                       ( LiteralString Nothing "false" )
                       ( Exception Nothing "No patterns matched" )
@@ -82,7 +82,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$318", AppN Nothing
+                    ( Nothing, Name "a$318", AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                       ( AppN Nothing
                         ( AppN Nothing
@@ -98,11 +98,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$318" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$318" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$318" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$318" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -115,7 +115,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$320", AppN Nothing
+                    ( Nothing, Name "a$320", AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                       ( AppN Nothing
                         ( AppN Nothing
@@ -133,11 +133,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$320" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$320" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$320" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$320" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -150,7 +150,7 @@ UberModule
               ( Nothing, Name "_", AppN Nothing
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "a$2$321", AppN Nothing
+                    ( Nothing, Name "a$321", AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                       ( LiteralFloat Nothing 42.0 :| [] )
                     ) :| []
@@ -158,11 +158,11 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "a$2$321" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$321" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "a$2$321" ) ) )
+                          ( Ref Nothing ( Local ( Name "a$321" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )
@@ -177,7 +177,7 @@ UberModule
           ( AppN Nothing
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "a$2$322", AppN Nothing
+                ( Nothing, Name "a$322", AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
@@ -187,11 +187,11 @@ UberModule
               ( AppN Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "a$2$322" ) ) )
+                  ( Ref Nothing ( Local ( Name "a$322" ) ) )
                   ( LiteralString Nothing "true" )
                   ( IfThenElse Nothing
                     ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "a$2$322" ) ) )
+                      ( Ref Nothing ( Local ( Name "a$322" ) ) )
                     )
                     ( LiteralString Nothing "false" )
                     ( Exception Nothing "No patterns matched" )

--- a/test/ps/output/Golden.NumberIsNaN.Test/golden.lua
+++ b/test/ps/output/Golden.NumberIsNaN.Test/golden.lua
@@ -16,11 +16,11 @@ local Effect_Console_foreign = {
 local Effect_Console_log = Effect_Console_foreign.log
 return (function()
   local _ = (function()
-    local a_S_2_S_316 = Data_Number_isNaN(Data_Number_nan)
+    local a_S_316 = Data_Number_isNaN(Data_Number_nan)
     return Effect_Console_log((function()
-      if a_S_2_S_316 then
+      if a_S_316 then
         return "true"
-      elseif false == a_S_2_S_316 then
+      elseif false == a_S_316 then
         return "false"
       else
         return error("No patterns matched")
@@ -28,11 +28,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_318 = Data_Number_isNaN(Data_Ring_numSub(0.0)(Data_Number_nan))
+    local a_S_318 = Data_Number_isNaN(Data_Ring_numSub(0.0)(Data_Number_nan))
     return Effect_Console_log((function()
-      if a_S_2_S_318 then
+      if a_S_318 then
         return "true"
-      elseif false == a_S_2_S_318 then
+      elseif false == a_S_318 then
         return "false"
       else
         return error("No patterns matched")
@@ -40,11 +40,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_320 = Data_Number_isNaN(Data_Ring_numSub(Data_Number_infinity)(Data_Number_infinity))
+    local a_S_320 = Data_Number_isNaN(Data_Ring_numSub(Data_Number_infinity)(Data_Number_infinity))
     return Effect_Console_log((function()
-      if a_S_2_S_320 then
+      if a_S_320 then
         return "true"
-      elseif false == a_S_2_S_320 then
+      elseif false == a_S_320 then
         return "false"
       else
         return error("No patterns matched")
@@ -52,11 +52,11 @@ return (function()
     end)())
   end)()()
   local _ = (function()
-    local a_S_2_S_321 = Data_Number_isNaN(42.0)
+    local a_S_321 = Data_Number_isNaN(42.0)
     return Effect_Console_log((function()
-      if a_S_2_S_321 then
+      if a_S_321 then
         return "true"
-      elseif false == a_S_2_S_321 then
+      elseif false == a_S_321 then
         return "false"
       else
         return error("No patterns matched")
@@ -64,11 +64,11 @@ return (function()
     end)())
   end)()()
   return (function()
-    local a_S_2_S_322 = Data_Number_isNaN(Data_Number_infinity)
+    local a_S_322 = Data_Number_isNaN(Data_Number_infinity)
     return Effect_Console_log((function()
-      if a_S_2_S_322 then
+      if a_S_322 then
         return "true"
-      elseif false == a_S_2_S_322 then
+      elseif false == a_S_322 then
         return "false"
       else
         return error("No patterns matched")

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -191,13 +191,13 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$114$241" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$241" ) :| [] )
                         ( IfThenElse Nothing
-                          ( Ref Nothing ( Local ( Name "v$114$241" ) ) )
+                          ( Ref Nothing ( Local ( Name "v$241" ) ) )
                           ( LiteralString Nothing "true" )
                           ( IfThenElse Nothing
                             ( Eq Nothing ( LiteralBool Nothing False )
-                              ( Ref Nothing ( Local ( Name "v$114$241" ) ) )
+                              ( Ref Nothing ( Local ( Name "v$241" ) ) )
                             )
                             ( LiteralString Nothing "false" )
                             ( Exception Nothing "No patterns matched" )
@@ -215,13 +215,13 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$114$245" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$245" ) :| [] )
                         ( IfThenElse Nothing
-                          ( Ref Nothing ( Local ( Name "v$114$245" ) ) )
+                          ( Ref Nothing ( Local ( Name "v$245" ) ) )
                           ( LiteralString Nothing "true" )
                           ( IfThenElse Nothing
                             ( Eq Nothing ( LiteralBool Nothing False )
-                              ( Ref Nothing ( Local ( Name "v$114$245" ) ) )
+                              ( Ref Nothing ( Local ( Name "v$245" ) ) )
                             )
                             ( LiteralString Nothing "false" )
                             ( Exception Nothing "No patterns matched" )
@@ -288,13 +288,13 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "show", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "v$114$251" ) :| [] )
+                    ( ParamNamed Nothing ( Name "v$251" ) :| [] )
                     ( IfThenElse Nothing
-                      ( Ref Nothing ( Local ( Name "v$114$251" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$251" ) ) )
                       ( LiteralString Nothing "true" )
                       ( IfThenElse Nothing
                         ( Eq Nothing ( LiteralBool Nothing False )
-                          ( Ref Nothing ( Local ( Name "v$114$251" ) ) )
+                          ( Ref Nothing ( Local ( Name "v$251" ) ) )
                         )
                         ( LiteralString Nothing "false" )
                         ( Exception Nothing "No patterns matched" )

--- a/test/ps/output/Golden.Primops.Test/golden.lua
+++ b/test/ps/output/Golden.Primops.Test/golden.lua
@@ -51,10 +51,10 @@ return (function()
     show = Data_Show_foreign.showIntImpl
   }, Golden_Primops_Test_sumTo_S_w(0, 5))()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_114_S_241)
-      if v_S_114_S_241 then
+    show = function(v_S_241)
+      if v_S_241 then
         return "true"
-      elseif false == v_S_114_S_241 then
+      elseif false == v_S_241 then
         return "false"
       else
         return error("No patterns matched")
@@ -62,10 +62,10 @@ return (function()
     end
   }, true)()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_114_S_245)
-      if v_S_114_S_245 then
+    show = function(v_S_245)
+      if v_S_245 then
         return "true"
-      elseif false == v_S_114_S_245 then
+      elseif false == v_S_245 then
         return "false"
       else
         return error("No patterns matched")
@@ -87,10 +87,10 @@ return (function()
   }, { "Data.Ordering∷Ordering.LT" })()
   local _ = Effect_Console_log("foobar")()
   return Effect_Console_logShow_S_w({
-    show = function(v_S_114_S_251)
-      if v_S_114_S_251 then
+    show = function(v_S_251)
+      if v_S_251 then
         return "true"
-      elseif false == v_S_114_S_251 then
+      elseif false == v_S_251 then
         return "false"
       else
         return error("No patterns matched")

--- a/test/ps/output/Golden.STDoBlock.Test/golden.ir
+++ b/test/ps/output/Golden.STDoBlock.Test/golden.ir
@@ -53,10 +53,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.STDoBlock.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$425$445" ) :| [ ParamNamed Nothing ( Name "y$426$446" ) ] )
+        ( ParamNamed Nothing ( Name "x$445" ) :| [ ParamNamed Nothing ( Name "y$446" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$425$445" ) ) )
-          ( Ref Nothing ( Local ( Name "y$426$446" ) ) )
+          ( Ref Nothing ( Local ( Name "x$445" ) ) )
+          ( Ref Nothing ( Local ( Name "y$446" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.STDoBlock.Test/golden.lua
+++ b/test/ps/output/Golden.STDoBlock.Test/golden.lua
@@ -25,8 +25,8 @@ local Control_Monad_ST_Internal_run = Control_Monad_ST_Internal_foreign.run
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Golden_STDoBlock_Test_add_S_w = function(x_S_425_S_445, y_S_426_S_446)
-  return x_S_425_S_445 + y_S_426_S_446
+local Golden_STDoBlock_Test_add_S_w = function(x_S_445, y_S_446)
+  return x_S_445 + y_S_446
 end
 M.Golden_STDoBlock_Test_sumTwice = function(n)
   return Control_Monad_ST_Internal_run(function()

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.ir
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.ir
@@ -466,7 +466,7 @@ UberModule
                     ( AppN Nothing
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "x$1474$1588", AppN Nothing
+                          ( Nothing, Name "x$1588", AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "length" ) )
                             )
@@ -474,19 +474,19 @@ UberModule
                           ) :| []
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "y$1475$1589" ) :| [] )
+                          ( ParamNamed Nothing ( Name "y$1589" ) :| [] )
                           ( IfThenElse Nothing
                             ( PrimBinOp Nothing PrimLt
-                              ( Ref Nothing ( Local ( Name "x$1474$1588" ) ) )
-                              ( Ref Nothing ( Local ( Name "y$1475$1589" ) ) )
+                              ( Ref Nothing ( Local ( Name "x$1588" ) ) )
+                              ( Ref Nothing ( Local ( Name "y$1589" ) ) )
                             )
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Ordering" ) ( Name "LT" ) )
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
-                                ( Ref Nothing ( Local ( Name "x$1474$1588" ) ) )
-                                ( Ref Nothing ( Local ( Name "y$1475$1589" ) ) )
+                                ( Ref Nothing ( Local ( Name "x$1588" ) ) )
+                                ( Ref Nothing ( Local ( Name "y$1589" ) ) )
                               )
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Ordering" ) ( Name "EQ" ) )
@@ -588,7 +588,7 @@ UberModule
             )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "v$63$1749", IfThenElse Nothing
+                ( Nothing, Name "v$1749", IfThenElse Nothing
                   ( AppN Nothing
                     ( AppN Nothing
                       ( ObjectProp Nothing
@@ -651,15 +651,15 @@ UberModule
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1749" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1749" ) ) ) )
                 )
                 ( DataArgumentByIndex Nothing SumType 0
-                  ( Ref Nothing ( Local ( Name "v$63$1749" ) ) )
+                  ( Ref Nothing ( Local ( Name "v$1749" ) ) )
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1749" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1749" ) ) ) )
                   )
                   ( IfThenElse Nothing
                     ( AppN Nothing
@@ -690,7 +690,7 @@ UberModule
           ( PrimBinOp Nothing PrimConcat
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "x$1602$1686$1750", PrimBinOp Nothing PrimAdd
+                ( Nothing, Name "x$1750", PrimBinOp Nothing PrimAdd
                   ( AppN Nothing
                     ( AppN Nothing
                       ( ObjectProp Nothing
@@ -715,7 +715,7 @@ UberModule
                 )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "v$63$1751", IfThenElse Nothing
+                    ( Nothing, Name "v$1751", IfThenElse Nothing
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -734,7 +734,7 @@ UberModule
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                               [ Ref Nothing
-                                ( Local ( Name "x$1602$1686$1750" ) ), AppN Nothing
+                                ( Local ( Name "x$1750" ) ), AppN Nothing
                                 ( Ref Nothing
                                   ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                                 )
@@ -752,7 +752,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                             [ Ref Nothing
-                              ( Local ( Name "x$1602$1686$1750" ) ), AppN Nothing
+                              ( Local ( Name "x$1750" ) ), AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                               )
@@ -769,7 +769,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Enum" ) ( Name "fromCharCode" ) )
                           )
-                          ( Ref Nothing ( Local ( Name "x$1602$1686$1750" ) ) :| [] ) :| []
+                          ( Ref Nothing ( Local ( Name "x$1750" ) ) :| [] ) :| []
                         )
                       )
                       ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
@@ -778,15 +778,15 @@ UberModule
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1751" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1751" ) ) ) )
                     )
                     ( DataArgumentByIndex Nothing SumType 0
-                      ( Ref Nothing ( Local ( Name "v$63$1751" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$1751" ) ) )
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1751" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1751" ) ) ) )
                       )
                       ( IfThenElse Nothing
                         ( AppN Nothing
@@ -796,7 +796,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                             [ Ref Nothing
-                              ( Local ( Name "x$1602$1686$1750" ) ), AppN Nothing
+                              ( Local ( Name "x$1750" ) ), AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                               )
@@ -824,7 +824,7 @@ UberModule
             )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "x$1602$1686$1752", PrimBinOp Nothing PrimAdd
+                ( Nothing, Name "x$1752", PrimBinOp Nothing PrimAdd
                   ( AppN Nothing
                     ( AppN Nothing
                       ( ObjectProp Nothing
@@ -849,7 +849,7 @@ UberModule
                 )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "v$63$1753", IfThenElse Nothing
+                    ( Nothing, Name "v$1753", IfThenElse Nothing
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -868,7 +868,7 @@ UberModule
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                               [ Ref Nothing
-                                ( Local ( Name "x$1602$1686$1752" ) ), AppN Nothing
+                                ( Local ( Name "x$1752" ) ), AppN Nothing
                                 ( Ref Nothing
                                   ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                                 )
@@ -886,7 +886,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                             [ Ref Nothing
-                              ( Local ( Name "x$1602$1686$1752" ) ), AppN Nothing
+                              ( Local ( Name "x$1752" ) ), AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                               )
@@ -903,7 +903,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Enum" ) ( Name "fromCharCode" ) )
                           )
-                          ( Ref Nothing ( Local ( Name "x$1602$1686$1752" ) ) :| [] ) :| []
+                          ( Ref Nothing ( Local ( Name "x$1752" ) ) :| [] ) :| []
                         )
                       )
                       ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
@@ -912,15 +912,15 @@ UberModule
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1753" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1753" ) ) ) )
                     )
                     ( DataArgumentByIndex Nothing SumType 0
-                      ( Ref Nothing ( Local ( Name "v$63$1753" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$1753" ) ) )
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$63$1753" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1753" ) ) ) )
                       )
                       ( IfThenElse Nothing
                         ( AppN Nothing
@@ -930,7 +930,7 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                             [ Ref Nothing
-                              ( Local ( Name "x$1602$1686$1752" ) ), AppN Nothing
+                              ( Local ( Name "x$1752" ) ), AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                               )
@@ -1215,20 +1215,16 @@ UberModule
                           ( PropName "unfoldrArrayImpl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v2$1504$1519" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v2$1519" ) :| [] )
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                              ( ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v2$1504$1519" ) ) )
-                              )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1519" ) ) ) )
                             ) ( LiteralBool Nothing True )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                ( ReflectCtor Nothing
-                                  ( Ref Nothing ( Local ( Name "v2$1504$1519" ) ) )
-                                )
+                                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1519" ) ) ) )
                               ) ( LiteralBool Nothing False )
                               ( Exception Nothing "No patterns matched" )
                             )
@@ -1721,7 +1717,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "cp"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1546$1653" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$1653" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Partial.Unsafe" ) ( Name "_unsafePartial" ) ) )
@@ -1749,14 +1745,14 @@ UberModule
               )
               ( PropName "toEnum" )
             )
-            ( Ref Nothing ( Local ( Name "x$1546$1653" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$1653" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "codes"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1546$1650" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$1650" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Functor" ) ( Name "arrayMap" ) ) )
@@ -1768,7 +1764,7 @@ UberModule
             ( Ref Nothing
               ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "toCodePointArray" ) )
             )
-            ( Ref Nothing ( Local ( Name "x$1546$1650" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$1650" ) ) :| [] ) :| []
           )
         )
       )
@@ -1940,11 +1936,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1533$1706" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$1706" ) :| [] )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1533$1706" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1706" ) ) ) )
                           )
                           ( PrimBinOp Nothing PrimConcat
                             ( LiteralString Nothing "(Just " )
@@ -1954,7 +1950,7 @@ UberModule
                                   ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$1533$1706" ) ) ) :| []
+                                  ( Ref Nothing ( Local ( Name "v$1706" ) ) ) :| []
                                 )
                               )
                               ( LiteralString Nothing ")" )
@@ -1963,9 +1959,7 @@ UberModule
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                              ( ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v$1533$1706" ) ) )
-                              )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1706" ) ) ) )
                             )
                             ( LiteralString Nothing "Nothing" )
                             ( Exception Nothing "No patterns matched" )
@@ -1975,7 +1969,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$1531$1704", AppN Nothing
+                        ( Nothing, Name "v1$1704", AppN Nothing
                           ( Ref Nothing
                             ( Imported
                               ( ModuleName "Data.String.CodePoints" )
@@ -1988,7 +1982,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1531$1704" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1704" ) ) ) )
                         )
                         ( AppN Nothing
                           ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -2000,7 +1994,7 @@ UberModule
                               )
                             )
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1531$1704" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v1$1704" ) ) ) :| []
                             ) :| []
                           )
                         )
@@ -2017,11 +2011,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1533$1714" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$1714" ) :| [] )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1533$1714" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1714" ) ) ) )
                           )
                           ( PrimBinOp Nothing PrimConcat
                             ( LiteralString Nothing "(Just " )
@@ -2031,7 +2025,7 @@ UberModule
                                   ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$1533$1714" ) ) ) :| []
+                                  ( Ref Nothing ( Local ( Name "v$1714" ) ) ) :| []
                                 )
                               )
                               ( LiteralString Nothing ")" )
@@ -2040,9 +2034,7 @@ UberModule
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                              ( ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v$1533$1714" ) ) )
-                              )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1714" ) ) ) )
                             )
                             ( LiteralString Nothing "Nothing" )
                             ( Exception Nothing "No patterns matched" )
@@ -2052,7 +2044,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$1531$1712", AppN Nothing
+                        ( Nothing, Name "v1$1712", AppN Nothing
                           ( Ref Nothing
                             ( Imported
                               ( ModuleName "Data.String.CodePoints" )
@@ -2065,7 +2057,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1531$1712" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1712" ) ) ) )
                         )
                         ( AppN Nothing
                           ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -2077,7 +2069,7 @@ UberModule
                               )
                             )
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1531$1712" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v1$1712" ) ) ) :| []
                             ) :| []
                           )
                         )
@@ -2094,11 +2086,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1533$1722" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$1722" ) :| [] )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1533$1722" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1722" ) ) ) )
                           )
                           ( PrimBinOp Nothing PrimConcat
                             ( LiteralString Nothing "(Just " )
@@ -2108,7 +2100,7 @@ UberModule
                                   ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$1533$1722" ) ) ) :| []
+                                  ( Ref Nothing ( Local ( Name "v$1722" ) ) ) :| []
                                 )
                               )
                               ( LiteralString Nothing ")" )
@@ -2117,9 +2109,7 @@ UberModule
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                              ( ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v$1533$1722" ) ) )
-                              )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1722" ) ) ) )
                             )
                             ( LiteralString Nothing "Nothing" )
                             ( Exception Nothing "No patterns matched" )
@@ -2129,7 +2119,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$1531$1720", AppN Nothing
+                        ( Nothing, Name "v1$1720", AppN Nothing
                           ( Ref Nothing
                             ( Imported
                               ( ModuleName "Data.String.CodePoints" )
@@ -2142,7 +2132,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1531$1720" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1720" ) ) ) )
                         )
                         ( AppN Nothing
                           ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -2154,7 +2144,7 @@ UberModule
                               )
                             )
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1531$1720" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v1$1720" ) ) ) :| []
                             ) :| []
                           )
                         )
@@ -2171,11 +2161,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1533$1733" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$1733" ) :| [] )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1533$1733" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1733" ) ) ) )
                           )
                           ( PrimBinOp Nothing PrimConcat
                             ( LiteralString Nothing "(Just " )
@@ -2185,7 +2175,7 @@ UberModule
                                   ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$1533$1733" ) ) ) :| []
+                                  ( Ref Nothing ( Local ( Name "v$1733" ) ) ) :| []
                                 )
                               )
                               ( LiteralString Nothing ")" )
@@ -2194,9 +2184,7 @@ UberModule
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                              ( ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v$1533$1733" ) ) )
-                              )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1733" ) ) ) )
                             )
                             ( LiteralString Nothing "Nothing" )
                             ( Exception Nothing "No patterns matched" )
@@ -2206,7 +2194,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$1531$1731", AppN Nothing
+                        ( Nothing, Name "v1$1731", AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                           )
@@ -2216,7 +2204,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1531$1731" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1731" ) ) ) )
                         )
                         ( AppN Nothing
                           ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -2229,7 +2217,7 @@ UberModule
                             )
                             ( ObjectProp Nothing
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$1531$1731" ) ) )
+                                ( Ref Nothing ( Local ( Name "v1$1731" ) ) )
                               )
                               ( PropName "head" ) :| []
                             ) :| []
@@ -2289,7 +2277,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$1531$1746", AppN Nothing
+                        ( Nothing, Name "v1$1746", AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                           )
@@ -2299,7 +2287,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1531$1746" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1746" ) ) ) )
                         )
                         ( AppN Nothing
                           ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -2324,7 +2312,7 @@ UberModule
                               )
                               ( ObjectProp Nothing
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v1$1531$1746" ) ) )
+                                  ( Ref Nothing ( Local ( Name "v1$1746" ) ) )
                                 )
                                 ( PropName "tail" ) :| []
                               ) :| []
@@ -2429,16 +2417,16 @@ UberModule
                           ( AbsN Nothing
                             ( ParamUnused Nothing :| [] )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "v$1527$1759" ) :| [] )
+                              ( ParamNamed Nothing ( Name "v$1759" ) :| [] )
                               ( IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
                                   ( ReflectCtor Nothing
-                                    ( Ref Nothing ( Local ( Name "v$1527$1759" ) ) )
+                                    ( Ref Nothing ( Local ( Name "v$1759" ) ) )
                                   )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$1527$1759" ) ) )
+                                  ( Ref Nothing ( Local ( Name "v$1759" ) ) )
                                 )
                                 ( Exception Nothing "No patterns matched" )
                               )

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -322,11 +322,11 @@ local Data_String_CodePoints_fromEnum = Data_Enum_toCharCode
 local Data_String_CodePoints_unsafeCodePointAt0 = Data_String_CodePoints_foreign._unsafeCodePointAt0(function( s_S_27 )
   local cu0_S_28 = Data_String_CodePoints_fromEnum(Data_String_Unsafe_charAt(0)(s_S_27))
   if Data_String_CodePoints_conj(Data_String_CodePoints_conj(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, 55296, cu0_S_28))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, cu0_S_28, 56319)))("Data.Ordering∷Ordering.GT" == ((function(  )
-    local x_S_1474_S_1588 = Data_String_CodeUnits_length(s_S_27)
-    return function(y_S_1475_S_1589)
-      if x_S_1474_S_1588 < y_S_1475_S_1589 then
+    local x_S_1588 = Data_String_CodeUnits_length(s_S_27)
+    return function(y_S_1589)
+      if x_S_1588 < y_S_1589 then
         return Data_Ordering_LT
-      elseif x_S_1474_S_1588 == y_S_1475_S_1589 then
+      elseif x_S_1588 == y_S_1589 then
         return Data_Ordering_EQ
       else
         return Data_Ordering_GT
@@ -346,16 +346,16 @@ end)
 local Data_String_CodePoints_singletonFallback = function(v)
   if Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, v, 65535) then
     return Data_String_CodeUnits_singleton((function()
-      local v_S_63_S_1749 = (function()
+      local v_S_1749 = (function()
         if Data_HeytingAlgebra_heytingAlgebraBoolean.conj(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_top1))) then
           return Data_Maybe_Just(Data_Enum_fromCharCode(v))
         else
           return Data_Maybe_Nothing
         end
       end)()
-      if "Data.Maybe∷Maybe.Just" == v_S_63_S_1749[1] then
-        return v_S_63_S_1749[2]
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_63_S_1749[1] then
+      if "Data.Maybe∷Maybe.Just" == v_S_1749[1] then
+        return v_S_1749[2]
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1749[1] then
         if Data_Ord_lessThan_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
           return Data_Bounded_bottomChar
         else
@@ -367,19 +367,19 @@ local Data_String_CodePoints_singletonFallback = function(v)
     end)())
   else
     return (function()
-      local x_S_1602_S_1686_S_1750 = Data_EuclideanRing_foreign.intDiv(v - 65536)(1024) + 55296
+      local x_S_1750 = Data_EuclideanRing_foreign.intDiv(v - 65536)(1024) + 55296
       return Data_String_CodeUnits_singleton((function()
-        local v_S_63_S_1751 = (function()
-          if Data_HeytingAlgebra_heytingAlgebraBoolean.conj(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1750, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1750, Data_Enum_toCharCode(Data_Enum_top1))) then
-            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1602_S_1686_S_1750))
+        local v_S_1751 = (function()
+          if Data_HeytingAlgebra_heytingAlgebraBoolean.conj(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1750, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1750, Data_Enum_toCharCode(Data_Enum_top1))) then
+            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1750))
           else
             return Data_Maybe_Nothing
           end
         end)()
-        if "Data.Maybe∷Maybe.Just" == v_S_63_S_1751[1] then
-          return v_S_63_S_1751[2]
-        elseif "Data.Maybe∷Maybe.Nothing" == v_S_63_S_1751[1] then
-          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1750, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
+        if "Data.Maybe∷Maybe.Just" == v_S_1751[1] then
+          return v_S_1751[2]
+        elseif "Data.Maybe∷Maybe.Nothing" == v_S_1751[1] then
+          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1750, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
             return Data_Bounded_bottomChar
           else
             return Data_Bounded_topChar
@@ -389,19 +389,19 @@ local Data_String_CodePoints_singletonFallback = function(v)
         end
       end)())
     end)() .. (function()
-      local x_S_1602_S_1686_S_1752 = Data_EuclideanRing_foreign.intMod(v - 65536)(1024) + 56320
+      local x_S_1752 = Data_EuclideanRing_foreign.intMod(v - 65536)(1024) + 56320
       return Data_String_CodeUnits_singleton((function()
-        local v_S_63_S_1753 = (function()
-          if Data_HeytingAlgebra_heytingAlgebraBoolean.conj(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1752, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1752, Data_Enum_toCharCode(Data_Enum_top1))) then
-            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1602_S_1686_S_1752))
+        local v_S_1753 = (function()
+          if Data_HeytingAlgebra_heytingAlgebraBoolean.conj(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1752, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1752, Data_Enum_toCharCode(Data_Enum_top1))) then
+            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1752))
           else
             return Data_Maybe_Nothing
           end
         end)()
-        if "Data.Maybe∷Maybe.Just" == v_S_63_S_1753[1] then
-          return v_S_63_S_1753[2]
-        elseif "Data.Maybe∷Maybe.Nothing" == v_S_63_S_1753[1] then
-          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1602_S_1686_S_1752, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
+        if "Data.Maybe∷Maybe.Just" == v_S_1753[1] then
+          return v_S_1753[2]
+        elseif "Data.Maybe∷Maybe.Nothing" == v_S_1753[1] then
+          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1752, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
             return Data_Bounded_bottomChar
           else
             return Data_Bounded_topChar
@@ -470,10 +470,10 @@ Data_String_CodePoints_drop_S_w = function(n, s)
   return Data_String_CodeUnits_foreign.drop(Data_String_CodeUnits_length(Data_String_CodePoints_take_S_w(n, s)))(s)
 end
 local Data_String_CodePoints_toCodePointArray = Data_String_CodePoints_foreign._toCodePointArray(function( s_S_10 )
-  return Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1504_S_1519)
-    if "Data.Maybe∷Maybe.Nothing" == v2_S_1504_S_1519[1] then
+  return Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1519)
+    if "Data.Maybe∷Maybe.Nothing" == v2_S_1519[1] then
       return true
-    elseif "Data.Maybe∷Maybe.Just" == v2_S_1504_S_1519[1] then
+    elseif "Data.Maybe∷Maybe.Just" == v2_S_1519[1] then
       return false
     else
       return error("No patterns matched")
@@ -573,7 +573,7 @@ local Golden_StringCodePoints_Test_fromEnum = Data_String_CodePoints_boundedEnum
 local Golden_StringCodePoints_Test_showArray = {
   show = Data_Show_showArrayImpl(Data_Show_showIntImpl)
 }
-M.Golden_StringCodePoints_Test_cp = function(x_S_1546_S_1653)
+M.Golden_StringCodePoints_Test_cp = function(x_S_1653)
   return Partial_Unsafe__unsafePartial(function()
     return function(v_S_1527)
       if "Data.Maybe∷Maybe.Just" == v_S_1527[1] then
@@ -582,10 +582,10 @@ M.Golden_StringCodePoints_Test_cp = function(x_S_1546_S_1653)
         return error("No patterns matched")
       end
     end
-  end)(Data_String_CodePoints_boundedEnumCodePoint.toEnum(x_S_1546_S_1653))
+  end)(Data_String_CodePoints_boundedEnumCodePoint.toEnum(x_S_1653))
 end
-M.Golden_StringCodePoints_Test_codes = function(x_S_1546_S_1650)
-  return Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(x_S_1546_S_1650))
+M.Golden_StringCodePoints_Test_codes = function(x_S_1650)
+  return Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(x_S_1650))
 end
 return (function()
   local _ = Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray("aéЯ𝐀z")))()
@@ -594,73 +594,73 @@ return (function()
   local _ = Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_take_S_w(2, "aéЯ𝐀z"))))()
   local _ = Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_drop_S_w(2, "aéЯ𝐀z"))))()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_1533_S_1706)
-      if "Data.Maybe∷Maybe.Just" == v_S_1533_S_1706[1] then
-        return "(Just " .. Data_Show_showIntImpl(v_S_1533_S_1706[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1533_S_1706[1] then
+    show = function(v_S_1706)
+      if "Data.Maybe∷Maybe.Just" == v_S_1706[1] then
+        return "(Just " .. Data_Show_showIntImpl(v_S_1706[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1706[1] then
         return "Nothing"
       else
         return error("No patterns matched")
       end
     end
   }, (function()
-    local v1_S_1531_S_1704 = Data_String_CodePoints_codePointAt_S_w(0, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1531_S_1704[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1531_S_1704[2]))
+    local v1_S_1704 = Data_String_CodePoints_codePointAt_S_w(0, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1704[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1704[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_1533_S_1714)
-      if "Data.Maybe∷Maybe.Just" == v_S_1533_S_1714[1] then
-        return "(Just " .. Data_Show_showIntImpl(v_S_1533_S_1714[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1533_S_1714[1] then
+    show = function(v_S_1714)
+      if "Data.Maybe∷Maybe.Just" == v_S_1714[1] then
+        return "(Just " .. Data_Show_showIntImpl(v_S_1714[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1714[1] then
         return "Nothing"
       else
         return error("No patterns matched")
       end
     end
   }, (function()
-    local v1_S_1531_S_1712 = Data_String_CodePoints_codePointAt_S_w(3, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1531_S_1712[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1531_S_1712[2]))
+    local v1_S_1712 = Data_String_CodePoints_codePointAt_S_w(3, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1712[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1712[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_1533_S_1722)
-      if "Data.Maybe∷Maybe.Just" == v_S_1533_S_1722[1] then
-        return "(Just " .. Data_Show_showIntImpl(v_S_1533_S_1722[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1533_S_1722[1] then
+    show = function(v_S_1722)
+      if "Data.Maybe∷Maybe.Just" == v_S_1722[1] then
+        return "(Just " .. Data_Show_showIntImpl(v_S_1722[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1722[1] then
         return "Nothing"
       else
         return error("No patterns matched")
       end
     end
   }, (function()
-    local v1_S_1531_S_1720 = Data_String_CodePoints_codePointAt_S_w(5, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1531_S_1720[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1531_S_1720[2]))
+    local v1_S_1720 = Data_String_CodePoints_codePointAt_S_w(5, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1720[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1720[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_1533_S_1733)
-      if "Data.Maybe∷Maybe.Just" == v_S_1533_S_1733[1] then
-        return "(Just " .. Data_Show_showIntImpl(v_S_1533_S_1733[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1533_S_1733[1] then
+    show = function(v_S_1733)
+      if "Data.Maybe∷Maybe.Just" == v_S_1733[1] then
+        return "(Just " .. Data_Show_showIntImpl(v_S_1733[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1733[1] then
         return "Nothing"
       else
         return error("No patterns matched")
       end
     end
   }, (function()
-    local v1_S_1531_S_1731 = Data_String_CodePoints_uncons("aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1531_S_1731[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1531_S_1731[2].head))
+    local v1_S_1731 = Data_String_CodePoints_uncons("aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1731[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1731[2].head))
     else
       return Data_Maybe_Nothing
     end
@@ -676,9 +676,9 @@ return (function()
       end
     end
   }, (function()
-    local v1_S_1531_S_1746 = Data_String_CodePoints_uncons("aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1531_S_1746[1] then
-      return Data_Maybe_Just(Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(v1_S_1531_S_1746[2].tail)))
+    local v1_S_1746 = Data_String_CodePoints_uncons("aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1746[1] then
+      return Data_Maybe_Just(Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(v1_S_1746[2].tail)))
     else
       return Data_Maybe_Nothing
     end
@@ -695,9 +695,9 @@ return (function()
     end
   }, Data_String_CodePoints_foreign._fromCodePointArray(Data_String_CodePoints_singletonFallback)(Data_String_CodePoints_toCodePointArray("aéЯ𝐀z")) == "aéЯ𝐀z")()
   return Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_singleton(Partial_Unsafe__unsafePartial(function(  )
-    return function(v_S_1527_S_1759)
-      if "Data.Maybe∷Maybe.Just" == v_S_1527_S_1759[1] then
-        return v_S_1527_S_1759[2]
+    return function(v_S_1759)
+      if "Data.Maybe∷Maybe.Just" == v_S_1759[1] then
+        return v_S_1759[2]
       else
         return error("No patterns matched")
       end

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
@@ -241,10 +241,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.TailRecM2Shadow.Test", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$454$488" ) :| [ ParamNamed Nothing ( Name "y$455$489" ) ] )
+        ( ParamNamed Nothing ( Name "x$488" ) :| [ ParamNamed Nothing ( Name "y$489" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$454$488" ) ) )
-          ( Ref Nothing ( Local ( Name "y$455$489" ) ) )
+          ( Ref Nothing ( Local ( Name "x$488" ) ) )
+          ( Ref Nothing ( Local ( Name "y$489" ) ) )
         )
       ), Standalone
       ( QName
@@ -591,16 +591,16 @@ UberModule
                                           ( AbsN Nothing
                                             ( ParamUnused Nothing :| [] )
                                             ( AbsN Nothing
-                                              ( ParamNamed Nothing ( Name "v$9$20" ) :| [] )
+                                              ( ParamNamed Nothing ( Name "v$20" ) :| [] )
                                               ( IfThenElse Nothing
                                                 ( Eq Nothing
                                                   ( LiteralString Nothing "Control.Monad.Rec.Class∷Step.Done" )
                                                   ( ReflectCtor Nothing
-                                                    ( Ref Nothing ( Local ( Name "v$9$20" ) ) )
+                                                    ( Ref Nothing ( Local ( Name "v$20" ) ) )
                                                   )
                                                 )
                                                 ( DataArgumentByIndex Nothing SumType 0
-                                                  ( Ref Nothing ( Local ( Name "v$9$20" ) ) )
+                                                  ( Ref Nothing ( Local ( Name "v$20" ) ) )
                                                 )
                                                 ( Exception Nothing "No patterns matched" )
                                               )
@@ -669,14 +669,14 @@ UberModule
                                 ( PropName "tailRecM" )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "o$480$507" ) :| [] )
+                                ( ParamNamed Nothing ( Name "o$507" ) :| [] )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
                                     ( IfThenElse Nothing
                                       ( PrimBinOp Nothing PrimLt
                                         ( ObjectProp Nothing
-                                          ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                          ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                           ( PropName "b" )
                                         )
                                         ( Ref Nothing ( Local ( Name "n$506" ) ) )
@@ -685,7 +685,7 @@ UberModule
                                       ( IfThenElse Nothing
                                         ( Eq Nothing
                                           ( ObjectProp Nothing
-                                            ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                            ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                             ( PropName "b" )
                                           )
                                           ( Ref Nothing ( Local ( Name "n$506" ) ) )
@@ -714,10 +714,10 @@ UberModule
                                               )
                                             )
                                             ( ObjectProp Nothing
-                                              ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                              ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                               ( PropName "a" ) :|
                                               [ ObjectProp Nothing
-                                                ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                                ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                                 ( PropName "b" )
                                               ]
                                             )
@@ -730,7 +730,7 @@ UberModule
                                               )
                                             )
                                             ( ObjectProp Nothing
-                                              ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                              ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                               ( PropName "b" ) :|
                                               [ LiteralInt Nothing 1 ]
                                             )
@@ -749,7 +749,7 @@ UberModule
                                         [ FieldName "value0" ]
                                       )
                                       ( ObjectProp Nothing
-                                        ( Ref Nothing ( Local ( Name "o$480$507" ) ) )
+                                        ( Ref Nothing ( Local ( Name "o$507" ) ) )
                                         ( PropName "a" ) :| []
                                       ) :| []
                                     )

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
@@ -81,9 +81,8 @@ Effect_Lazy_applyEffect = PSLUA_runtime_lazy("applyEffect")(function()
   }
 end)
 local Effect_functorEffect = Effect_Lazy_functorEffect(0)
-local Golden_TailRecM2Shadow_Test_add_S_w = function( x_S_454_S_488
-, y_S_455_S_489 )
-  return x_S_454_S_488 + y_S_455_S_489
+local Golden_TailRecM2Shadow_Test_add_S_w = function(x_S_488, y_S_489)
+  return x_S_488 + y_S_489
 end
 M.Golden_TailRecM2Shadow_Test_sumFrom = function(dictMonadRec)
   local pure = ((dictMonadRec.Monad0()).Applicative0()).pure
@@ -138,9 +137,9 @@ return (function()
               end)()()
             end)()
             return Effect_functorEffect.map(Partial_Unsafe_foreign._unsafePartial(function(  )
-              return function(v_S_9_S_20)
-                if "Control.Monad.Rec.Class∷Step.Done" == v_S_9_S_20[1] then
-                  return v_S_9_S_20[2]
+              return function(v_S_20)
+                if "Control.Monad.Rec.Class∷Step.Done" == v_S_20[1] then
+                  return v_S_20[2]
                 else
                   return error("No patterns matched")
                 end
@@ -154,11 +153,11 @@ return (function()
     local pure_S_504 = ((dictMonadRec_S_503.Monad0()).Applicative0()).pure
     return function(b_S_505)
       return function(n_S_506)
-        return dictMonadRec_S_503.tailRecM(function(o_S_480_S_507)
+        return dictMonadRec_S_503.tailRecM(function(o_S_507)
           if "Data.Ordering∷Ordering.LT" == (function()
-            if o_S_480_S_507.b < n_S_506 then
+            if o_S_507.b < n_S_506 then
               return "Data.Ordering∷Ordering.LT"
-            elseif o_S_480_S_507.b == n_S_506 then
+            elseif o_S_507.b == n_S_506 then
               return "Data.Ordering∷Ordering.EQ"
             else
               return "Data.Ordering∷Ordering.GT"
@@ -167,13 +166,13 @@ return (function()
             return pure_S_504((function(value0)
               return { "Control.Monad.Rec.Class∷Step.Loop", value0 }
             end)({
-              a = Golden_TailRecM2Shadow_Test_add_S_w(o_S_480_S_507.a, o_S_480_S_507.b),
-              b = Golden_TailRecM2Shadow_Test_add_S_w(o_S_480_S_507.b, 1)
+              a = Golden_TailRecM2Shadow_Test_add_S_w(o_S_507.a, o_S_507.b),
+              b = Golden_TailRecM2Shadow_Test_add_S_w(o_S_507.b, 1)
             }))
           else
             return pure_S_504((function(value0)
               return { "Control.Monad.Rec.Class∷Step.Done", value0 }
-            end)(o_S_480_S_507.a))
+            end)(o_S_507.a))
           end
         end)({ a = b_S_505, b = 0 })
       end

--- a/test/ps/output/Golden.Uncurry.Test/golden.ir
+++ b/test/ps/output/Golden.Uncurry.Test/golden.ir
@@ -55,22 +55,19 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "eq$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "r1$198$213" ) :|
-          [ ParamNamed Nothing ( Name "r2$199$214" ) ]
-        )
+        ( ParamNamed Nothing ( Name "r1$213" ) :| [ ParamNamed Nothing ( Name "r2$214" ) ] )
         ( Eq Nothing
-          ( Ref Nothing ( Local ( Name "r1$198$213" ) ) )
-          ( Ref Nothing ( Local ( Name "r2$199$214" ) ) )
+          ( Ref Nothing ( Local ( Name "r1$213" ) ) )
+          ( Ref Nothing ( Local ( Name "r2$214" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$184$208" ) :| [ ParamNamed Nothing ( Name "y$185$209" ) ] )
+        ( ParamNamed Nothing ( Name "x$208" ) :| [ ParamNamed Nothing ( Name "y$209" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$184$208" ) ) )
-          ( Ref Nothing ( Local ( Name "y$185$209" ) ) )
+          ( Ref Nothing ( Local ( Name "x$208" ) ) )
+          ( Ref Nothing ( Local ( Name "y$209" ) ) )
         )
       ), Standalone
       ( QName
@@ -216,13 +213,13 @@ UberModule
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "x" ) :| [ ParamNamed Nothing ( Name "y" ) ] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "y$189$229" ) :| [] )
+          ( ParamNamed Nothing ( Name "y$229" ) :| [] )
           ( PrimBinOp Nothing PrimAdd
             ( PrimBinOp Nothing PrimAdd
               ( Ref Nothing ( Local ( Name "x" ) ) )
               ( Ref Nothing ( Local ( Name "y" ) ) )
             )
-            ( Ref Nothing ( Local ( Name "y$189$229" ) ) )
+            ( Ref Nothing ( Local ( Name "y$229" ) ) )
           )
         )
       ), Standalone

--- a/test/ps/output/Golden.Uncurry.Test/golden.lua
+++ b/test/ps/output/Golden.Uncurry.Test/golden.lua
@@ -28,11 +28,11 @@ local Data_Show_showInt = { show = Data_Show_showIntImpl }
 local Effect_Console_logShow_S_w = function(dictShow, a)
   return Effect_Console_foreign.log(dictShow.show(a))
 end
-local Golden_Uncurry_Test_eq_S_w = function(r1_S_198_S_213, r2_S_199_S_214)
-  return r1_S_198_S_213 == r2_S_199_S_214
+local Golden_Uncurry_Test_eq_S_w = function(r1_S_213, r2_S_214)
+  return r1_S_213 == r2_S_214
 end
-local Golden_Uncurry_Test_sub_S_w = function(x_S_184_S_208, y_S_185_S_209)
-  return x_S_184_S_208 - y_S_185_S_209
+local Golden_Uncurry_Test_sub_S_w = function(x_S_208, y_S_209)
+  return x_S_208 - y_S_209
 end
 M.Golden_Uncurry_Test_sumTo = function(m)
   local go_S_w
@@ -74,7 +74,7 @@ M.Golden_Uncurry_Test_evenSteps = function(evenSteps_S_p1)
 end
 local Golden_Uncurry_Test_alwaysFirst_S_w = function(x) return x end
 local Golden_Uncurry_Test_adderOf_S_w = function(x, y)
-  return function(y_S_189_S_229) return x + y + y_S_189_S_229 end
+  return function(y_S_229) return x + y + y_S_229 end
 end
 local Golden_Uncurry_Test_add3_S_w = function(x, y, z) return x + y + z end
 M.Golden_Uncurry_Test_add3 = function(add3_S_p1)


### PR DESCRIPTION
Fixes #260

`freshNameFor` minted `<name>$<counter>` by appending to the full name rather than its root, so a binder freshened across several paste generations (use-once inlining, call-site inlining, dictionary-method resolution) grew one `$<n>` group per generation instead of one total: `x` became `x$1602`, then `x$1602$1686`, then `x$1602$1686$1750`. The Lua printer turns each `$` into `_S_`, so the noise tripled in the generated names too.

The fix strips the trailing `$<digits>` groups from the name before appending the next mint, so a freshened copy always ends in a single `$<n>` suffix no matter how many prior generations it passed through. Uniqueness holds by the same reasoning the original scheme relied on: `$` still cannot occur in a source identifier, so mints never collide with source names; `uniquifyNames`' bare-digit names (`x0`) have no `$` before the digits, so they pass through the strip unchanged; and the supply counter stays monotonic across a pipeline run, so two mints of the same root still differ.

## Test plan

- Added a regression test in `Types/Spec.hs` that threads one binder through `freshenBinders` twice on the same supply; confirmed it went red against the old code (`x$0$1`) before applying the fix, then green (`x$1`) after.
- `cabal test all` turned up exactly the predicted churn: 52 `golden.ir`/`golden.lua` name-only diffs, no `eval/golden.txt` oracle moved. Accepted with `PSLUA_GOLDEN_ACCEPT=1` and confirmed a clean re-run is stable.
