### PR TITLE
test(ps): repoint the golden set at psc-0.15.15-20260714

### DIFF
--- a/test/ps/output/Golden.StringCodePoints.Test/golden.ir
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.ir
@@ -76,7 +76,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Data.Array", qnameName = Name "foreign"
         }, ForeignImport Nothing
-        ( ModuleName "Data.Array" ) ".spago/p/arrays/f92475f4560c7fed9d4c5fb5787db246db6b270d/src/Data/Array.purs"
+        ( ModuleName "Data.Array" ) ".spago/p/arrays/4641b4b5ee19c3b472151da585f4676147a7cd74/src/Data/Array.purs"
         [ ( Nothing, Name "length" ) ]
       ), Standalone
       ( QName
@@ -186,28 +186,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
+              ( ParamNamed Nothing ( Name "b1$1496" ) :| [] )
+              ( AbsN Nothing
+                ( ParamNamed Nothing ( Name "b2$1497" ) :| [] )
+                ( PrimBinOp Nothing PrimAnd
+                  ( Ref Nothing ( Local ( Name "b1$1496" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1497" ) ) )
+                )
+              )
+            ),
+            ( PropName "disj", AbsN Nothing
               ( ParamNamed Nothing ( Name "b1$1494" ) :| [] )
               ( AbsN Nothing
                 ( ParamNamed Nothing ( Name "b2$1495" ) :| [] )
-                ( PrimBinOp Nothing PrimAnd
+                ( PrimBinOp Nothing PrimOr
                   ( Ref Nothing ( Local ( Name "b1$1494" ) ) )
                   ( Ref Nothing ( Local ( Name "b2$1495" ) ) )
                 )
               )
             ),
-            ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$1492" ) :| [] )
-              ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$1493" ) :| [] )
-                ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$1492" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$1493" ) ) )
-                )
-              )
-            ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$1491" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$1491" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$1493" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$1493" ) ) ) )
             )
           ]
         ) :| []
@@ -216,12 +216,12 @@ UberModule
         { qnameModuleName = ModuleName "Data.Eq", qnameName = Name "eqInt" }, LiteralObject Nothing
         [
           ( PropName "eq", AbsN Nothing
-            ( ParamNamed Nothing ( Name "r1$1487" ) :| [] )
+            ( ParamNamed Nothing ( Name "r1$1489" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "r2$1488" ) :| [] )
+              ( ParamNamed Nothing ( Name "r2$1490" ) :| [] )
               ( Eq Nothing
-                ( Ref Nothing ( Local ( Name "r1$1487" ) ) )
-                ( Ref Nothing ( Local ( Name "r2$1488" ) ) )
+                ( Ref Nothing ( Local ( Name "r1$1489" ) ) )
+                ( Ref Nothing ( Local ( Name "r2$1490" ) ) )
               )
             )
           )
@@ -262,19 +262,19 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "compare", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$1471" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$1473" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "y$1472" ) :| [] )
+              ( ParamNamed Nothing ( Name "y$1474" ) :| [] )
               ( IfThenElse Nothing
                 ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "x$1471" ) ) )
-                  ( Ref Nothing ( Local ( Name "y$1472" ) ) )
+                  ( Ref Nothing ( Local ( Name "x$1473" ) ) )
+                  ( Ref Nothing ( Local ( Name "y$1474" ) ) )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "LT" ) ) )
                 ( IfThenElse Nothing
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "x$1471" ) ) )
-                    ( Ref Nothing ( Local ( Name "y$1472" ) ) )
+                    ( Ref Nothing ( Local ( Name "x$1473" ) ) )
+                    ( Ref Nothing ( Local ( Name "y$1474" ) ) )
                   )
                   ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "EQ" ) ) )
                   ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "GT" ) ) )
@@ -460,7 +460,7 @@ UberModule
                     ( AppN Nothing
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "x$1585", AppN Nothing
+                          ( Nothing, Name "x$1587", AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "length" ) )
                             )
@@ -468,19 +468,19 @@ UberModule
                           ) :| []
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "y$1586" ) :| [] )
+                          ( ParamNamed Nothing ( Name "y$1588" ) :| [] )
                           ( IfThenElse Nothing
                             ( PrimBinOp Nothing PrimLt
-                              ( Ref Nothing ( Local ( Name "x$1585" ) ) )
-                              ( Ref Nothing ( Local ( Name "y$1586" ) ) )
+                              ( Ref Nothing ( Local ( Name "x$1587" ) ) )
+                              ( Ref Nothing ( Local ( Name "y$1588" ) ) )
                             )
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Ordering" ) ( Name "LT" ) )
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
-                                ( Ref Nothing ( Local ( Name "x$1585" ) ) )
-                                ( Ref Nothing ( Local ( Name "y$1586" ) ) )
+                                ( Ref Nothing ( Local ( Name "x$1587" ) ) )
+                                ( Ref Nothing ( Local ( Name "y$1588" ) ) )
                               )
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Ordering" ) ( Name "EQ" ) )
@@ -570,7 +570,7 @@ UberModule
         ( ParamNamed Nothing ( Name "v" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse1758", ObjectProp Nothing
+            ( Nothing, Name "$cse1760", ObjectProp Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Data.HeytingAlgebra" ) ( Name "heytingAlgebraBoolean" ) )
               )
@@ -591,10 +591,10 @@ UberModule
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "v$1746", IfThenElse Nothing
+                  ( Nothing, Name "v$1748", IfThenElse Nothing
                     ( AppN Nothing
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "$cse1758" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse1760" ) ) )
                         ( AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Ord" ) ( Name "greaterThanOrEq$w" ) )
@@ -646,15 +646,15 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1746" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1748" ) ) ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "v$1746" ) ) )
+                    ( Ref Nothing ( Local ( Name "v$1748" ) ) )
                   )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1746" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1748" ) ) ) )
                     )
                     ( IfThenElse Nothing
                       ( AppN Nothing
@@ -687,7 +687,7 @@ UberModule
             ( PrimBinOp Nothing PrimConcat
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "x$1747", PrimBinOp Nothing PrimAdd
+                  ( Nothing, Name "x$1749", PrimBinOp Nothing PrimAdd
                     ( AppN Nothing
                       ( AppN Nothing
                         ( ObjectProp Nothing
@@ -712,136 +712,10 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v$1748", IfThenElse Nothing
-                        ( AppN Nothing
-                          ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "$cse1758" ) ) )
-                            ( AppN Nothing
-                              ( Ref Nothing
-                                ( Imported ( ModuleName "Data.Ord" ) ( Name "greaterThanOrEq$w" ) )
-                              )
-                              ( Ref Nothing
-                                ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                                [ Ref Nothing
-                                  ( Local ( Name "x$1747" ) ), AppN Nothing
-                                  ( Ref Nothing
-                                    ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
-                                  )
-                                  ( Ref Nothing
-                                    ( Imported ( ModuleName "Data.Enum" ) ( Name "bottom1" ) ) :| []
-                                  )
-                                ]
-                              ) :| []
-                            )
-                          )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Data.Ord" ) ( Name "lessThanOrEq$w" ) )
-                            )
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                              [ Ref Nothing
-                                ( Local ( Name "x$1747" ) ), AppN Nothing
-                                ( Ref Nothing
-                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
-                                )
-                                ( Ref Nothing
-                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "top1" ) ) :| []
-                                )
-                              ]
-                            ) :| []
-                          )
-                        )
-                        ( AppN Nothing
-                          ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Data.Enum" ) ( Name "fromCharCode" ) )
-                            )
-                            ( Ref Nothing ( Local ( Name "x$1747" ) ) :| [] ) :| []
-                          )
-                        )
-                        ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
-                      ) :| []
-                    )
-                    ( IfThenElse Nothing
-                      ( Eq Nothing
-                        ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1748" ) ) ) )
-                      )
-                      ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "v$1748" ) ) )
-                      )
-                      ( IfThenElse Nothing
-                        ( Eq Nothing
-                          ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1748" ) ) ) )
-                        )
-                        ( IfThenElse Nothing
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Data.Ord" ) ( Name "lessThan$w" ) )
-                            )
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                              [ Ref Nothing
-                                ( Local ( Name "x$1747" ) ), AppN Nothing
-                                ( Ref Nothing
-                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
-                                )
-                                ( Ref Nothing
-                                  ( Imported
-                                    ( ModuleName "Data.Bounded" )
-                                    ( Name "bottomChar" )
-                                  ) :| []
-                                )
-                              ]
-                            )
-                          )
-                          ( Ref Nothing
-                            ( Imported ( ModuleName "Data.Bounded" ) ( Name "bottomChar" ) )
-                          )
-                          ( Ref Nothing
-                            ( Imported ( ModuleName "Data.Bounded" ) ( Name "topChar" ) )
-                          )
-                        )
-                        ( Exception Nothing "No patterns matched" )
-                      )
-                    ) :| []
-                  )
-                )
-              )
-              ( Let Nothing
-                ( Standalone
-                  ( Nothing, Name "x$1749", PrimBinOp Nothing PrimAdd
-                    ( AppN Nothing
-                      ( AppN Nothing
-                        ( ObjectProp Nothing
-                          ( Ref Nothing
-                            ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "foreign" ) )
-                          )
-                          ( PropName "intMod" )
-                        )
-                        ( PrimBinOp Nothing PrimSub
-                          ( Ref Nothing ( Local ( Name "v" ) ) )
-                          ( LiteralInt Nothing 65536 ) :| []
-                        )
-                      )
-                      ( LiteralInt Nothing 1024 :| [] )
-                    )
-                    ( LiteralInt Nothing 56320 )
-                  ) :| []
-                )
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "singleton" ) )
-                  )
-                  ( Let Nothing
-                    ( Standalone
                       ( Nothing, Name "v$1750", IfThenElse Nothing
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "$cse1758" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse1760" ) ) )
                             ( AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Ord" ) ( Name "greaterThanOrEq$w" ) )
@@ -912,6 +786,132 @@ UberModule
                               ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                               [ Ref Nothing
                                 ( Local ( Name "x$1749" ) ), AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
+                                )
+                                ( Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Data.Bounded" )
+                                    ( Name "bottomChar" )
+                                  ) :| []
+                                )
+                              ]
+                            )
+                          )
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Bounded" ) ( Name "bottomChar" ) )
+                          )
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Bounded" ) ( Name "topChar" ) )
+                          )
+                        )
+                        ( Exception Nothing "No patterns matched" )
+                      )
+                    ) :| []
+                  )
+                )
+              )
+              ( Let Nothing
+                ( Standalone
+                  ( Nothing, Name "x$1751", PrimBinOp Nothing PrimAdd
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( ObjectProp Nothing
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "foreign" ) )
+                          )
+                          ( PropName "intMod" )
+                        )
+                        ( PrimBinOp Nothing PrimSub
+                          ( Ref Nothing ( Local ( Name "v" ) ) )
+                          ( LiteralInt Nothing 65536 ) :| []
+                        )
+                      )
+                      ( LiteralInt Nothing 1024 :| [] )
+                    )
+                    ( LiteralInt Nothing 56320 )
+                  ) :| []
+                )
+                ( AppN Nothing
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "singleton" ) )
+                  )
+                  ( Let Nothing
+                    ( Standalone
+                      ( Nothing, Name "v$1752", IfThenElse Nothing
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing ( Local ( Name "$cse1760" ) ) )
+                            ( AppN Nothing
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Ord" ) ( Name "greaterThanOrEq$w" ) )
+                              )
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
+                                [ Ref Nothing
+                                  ( Local ( Name "x$1751" ) ), AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
+                                  )
+                                  ( Ref Nothing
+                                    ( Imported ( ModuleName "Data.Enum" ) ( Name "bottom1" ) ) :| []
+                                  )
+                                ]
+                              ) :| []
+                            )
+                          )
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Ord" ) ( Name "lessThanOrEq$w" ) )
+                            )
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
+                              [ Ref Nothing
+                                ( Local ( Name "x$1751" ) ), AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
+                                )
+                                ( Ref Nothing
+                                  ( Imported ( ModuleName "Data.Enum" ) ( Name "top1" ) ) :| []
+                                )
+                              ]
+                            ) :| []
+                          )
+                        )
+                        ( AppN Nothing
+                          ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Enum" ) ( Name "fromCharCode" ) )
+                            )
+                            ( Ref Nothing ( Local ( Name "x$1751" ) ) :| [] ) :| []
+                          )
+                        )
+                        ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
+                      ) :| []
+                    )
+                    ( IfThenElse Nothing
+                      ( Eq Nothing
+                        ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1752" ) ) ) )
+                      )
+                      ( DataArgumentByIndex Nothing SumType 0
+                        ( Ref Nothing ( Local ( Name "v$1752" ) ) )
+                      )
+                      ( IfThenElse Nothing
+                        ( Eq Nothing
+                          ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1752" ) ) ) )
+                        )
+                        ( IfThenElse Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Ord" ) ( Name "lessThan$w" ) )
+                            )
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
+                              [ Ref Nothing
+                                ( Local ( Name "x$1751" ) ), AppN Nothing
                                 ( Ref Nothing
                                   ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                                 )
@@ -1197,22 +1197,22 @@ UberModule
                           ( PropName "unfoldrArrayImpl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v2$1516" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v2$1518" ) :| [] )
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "$cse1759", ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v2$1516" ) ) )
+                              ( Nothing, Name "$cse1761", ReflectCtor Nothing
+                                ( Ref Nothing ( Local ( Name "v2$1518" ) ) )
                               ) :| []
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                                ( Ref Nothing ( Local ( Name "$cse1759" ) ) )
+                                ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
                               ) ( LiteralBool Nothing True )
                               ( IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                  ( Ref Nothing ( Local ( Name "$cse1759" ) ) )
+                                  ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
                                 ) ( LiteralBool Nothing False )
                                 ( Exception Nothing "No patterns matched" )
                               )
@@ -1227,14 +1227,14 @@ UberModule
                         ( AbsN Nothing
                           ( ParamUnused Nothing :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "v$1562" ) :| [] )
+                            ( ParamNamed Nothing ( Name "v$1564" ) :| [] )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1562" ) ) ) )
+                                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1564" ) ) ) )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v$1562" ) ) )
+                                ( Ref Nothing ( Local ( Name "v$1564" ) ) )
                               )
                               ( Exception Nothing "No patterns matched" )
                             )
@@ -1243,16 +1243,16 @@ UberModule
                       )
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "v$1514" ) :| [] )
+                      ( ParamNamed Nothing ( Name "v$1516" ) :| [] )
                       ( DataArgumentByIndex Nothing ProductType 0
-                        ( Ref Nothing ( Local ( Name "v$1514" ) ) )
+                        ( Ref Nothing ( Local ( Name "v$1516" ) ) )
                       ) :| []
                     )
                   )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "v$1515" ) :| [] )
+                    ( ParamNamed Nothing ( Name "v$1517" ) :| [] )
                     ( DataArgumentByIndex Nothing ProductType 1
-                      ( Ref Nothing ( Local ( Name "v$1515" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$1517" ) ) )
                     ) :| []
                   )
                 )
@@ -1260,7 +1260,7 @@ UberModule
                   ( ParamNamed Nothing ( Name "s$8" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$1565", AppN Nothing
+                      ( Nothing, Name "v1$1567", AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                         )
@@ -1270,7 +1270,7 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1565" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1567" ) ) ) )
                       )
                       ( AppN Nothing
                         ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Just" ) ) )
@@ -1284,14 +1284,14 @@ UberModule
                             )
                             ( ObjectProp Nothing
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$1565" ) ) )
+                                ( Ref Nothing ( Local ( Name "v1$1567" ) ) )
                               )
                               ( PropName "head" ) :| []
                             )
                           )
                           ( ObjectProp Nothing
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1565" ) ) )
+                              ( Ref Nothing ( Local ( Name "v1$1567" ) ) )
                             )
                             ( PropName "tail" ) :| []
                           ) :| []
@@ -1540,7 +1540,7 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "succ", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "a$1550" ) :| [] )
+                    ( ParamNamed Nothing ( Name "a$1552" ) :| [] )
                     ( AppN Nothing
                       ( ObjectProp Nothing
                         ( Ref Nothing
@@ -1562,14 +1562,14 @@ UberModule
                             )
                             ( PropName "fromEnum" )
                           )
-                          ( Ref Nothing ( Local ( Name "a$1550" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "a$1552" ) ) :| [] )
                         )
                         ( LiteralInt Nothing 1 ) :| []
                       )
                     )
                   ),
                   ( PropName "pred", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "a$1558" ) :| [] )
+                    ( ParamNamed Nothing ( Name "a$1560" ) :| [] )
                     ( AppN Nothing
                       ( ObjectProp Nothing
                         ( Ref Nothing
@@ -1591,7 +1591,7 @@ UberModule
                             )
                             ( PropName "fromEnum" )
                           )
-                          ( Ref Nothing ( Local ( Name "a$1558" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "a$1560" ) ) :| [] )
                         )
                         ( LiteralInt Nothing 1 ) :| []
                       )
@@ -1648,21 +1648,21 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "cp"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1650" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$1652" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Partial.Unsafe" ) ( Name "_unsafePartial" ) ) )
             ( AbsN Nothing
               ( ParamUnused Nothing :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "v$1524" ) :| [] )
+                ( ParamNamed Nothing ( Name "v$1526" ) :| [] )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1524" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1526" ) ) ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "v$1524" ) ) )
+                    ( Ref Nothing ( Local ( Name "v$1526" ) ) )
                   )
                   ( Exception Nothing "No patterns matched" )
                 )
@@ -1676,14 +1676,14 @@ UberModule
               )
               ( PropName "toEnum" )
             )
-            ( Ref Nothing ( Local ( Name "x$1650" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$1652" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "codes"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1647" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$1649" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Functor" ) ( Name "arrayMap" ) ) )
@@ -1695,7 +1695,7 @@ UberModule
             ( Ref Nothing
               ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "toCodePointArray" ) )
             )
-            ( Ref Nothing ( Local ( Name "x$1647" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$1649" ) ) :| [] ) :| []
           )
         )
       )
@@ -1709,20 +1709,20 @@ UberModule
         ( ParamUnused Nothing :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse1760", LiteralObject Nothing
+            ( Nothing, Name "$cse1762", LiteralObject Nothing
               [
                 ( PropName "show", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "v$1703" ) :| [] )
+                  ( ParamNamed Nothing ( Name "v$1705" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse1761", ReflectCtor Nothing
-                        ( Ref Nothing ( Local ( Name "v$1703" ) ) )
+                      ( Nothing, Name "$cse1763", ReflectCtor Nothing
+                        ( Ref Nothing ( Local ( Name "v$1705" ) ) )
                       ) :| []
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse1763" ) ) )
                       )
                       ( PrimBinOp Nothing PrimConcat
                         ( LiteralString Nothing "(Just " )
@@ -1732,7 +1732,7 @@ UberModule
                               ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                             )
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v$1703" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v$1705" ) ) ) :| []
                             )
                           )
                           ( LiteralString Nothing ")" )
@@ -1741,7 +1741,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                          ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse1763" ) ) )
                         )
                         ( LiteralString Nothing "Nothing" )
                         ( Exception Nothing "No patterns matched" )
@@ -1922,10 +1922,10 @@ UberModule
                       ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) )
                     )
                     ( Ref Nothing
-                      ( Local ( Name "$cse1760" ) ) :|
+                      ( Local ( Name "$cse1762" ) ) :|
                       [ Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v1$1701", AppN Nothing
+                          ( Nothing, Name "v1$1703", AppN Nothing
                             ( Ref Nothing
                               ( Imported
                                 ( ModuleName "Data.String.CodePoints" )
@@ -1938,7 +1938,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1701" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1703" ) ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing
@@ -1952,7 +1952,7 @@ UberModule
                                 )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$1701" ) ) ) :| []
+                                ( Ref Nothing ( Local ( Name "v1$1703" ) ) ) :| []
                               ) :| []
                             )
                           )
@@ -1971,10 +1971,10 @@ UberModule
                       ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) )
                     )
                     ( Ref Nothing
-                      ( Local ( Name "$cse1760" ) ) :|
+                      ( Local ( Name "$cse1762" ) ) :|
                       [ Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v1$1709", AppN Nothing
+                          ( Nothing, Name "v1$1711", AppN Nothing
                             ( Ref Nothing
                               ( Imported
                                 ( ModuleName "Data.String.CodePoints" )
@@ -1987,7 +1987,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1709" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1711" ) ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing
@@ -2001,7 +2001,7 @@ UberModule
                                 )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$1709" ) ) ) :| []
+                                ( Ref Nothing ( Local ( Name "v1$1711" ) ) ) :| []
                               ) :| []
                             )
                           )
@@ -2020,10 +2020,10 @@ UberModule
                       ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) )
                     )
                     ( Ref Nothing
-                      ( Local ( Name "$cse1760" ) ) :|
+                      ( Local ( Name "$cse1762" ) ) :|
                       [ Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v1$1717", AppN Nothing
+                          ( Nothing, Name "v1$1719", AppN Nothing
                             ( Ref Nothing
                               ( Imported
                                 ( ModuleName "Data.String.CodePoints" )
@@ -2036,7 +2036,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1717" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1719" ) ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing
@@ -2050,7 +2050,7 @@ UberModule
                                 )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$1717" ) ) ) :| []
+                                ( Ref Nothing ( Local ( Name "v1$1719" ) ) ) :| []
                               ) :| []
                             )
                           )
@@ -2069,10 +2069,10 @@ UberModule
                       ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) )
                     )
                     ( Ref Nothing
-                      ( Local ( Name "$cse1760" ) ) :|
+                      ( Local ( Name "$cse1762" ) ) :|
                       [ Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v1$1728", AppN Nothing
+                          ( Nothing, Name "v1$1730", AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                             )
@@ -2082,7 +2082,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1728" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1730" ) ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing
@@ -2097,7 +2097,7 @@ UberModule
                               )
                               ( ObjectProp Nothing
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v1$1728" ) ) )
+                                  ( Ref Nothing ( Local ( Name "v1$1730" ) ) )
                                 )
                                 ( PropName "head" ) :| []
                               ) :| []
@@ -2120,17 +2120,17 @@ UberModule
                     ( LiteralObject Nothing
                       [
                         ( PropName "show", AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$1641" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$1643" ) :| [] )
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "$cse1762", ReflectCtor Nothing
-                                ( Ref Nothing ( Local ( Name "v$1641" ) ) )
+                              ( Nothing, Name "$cse1764", ReflectCtor Nothing
+                                ( Ref Nothing ( Local ( Name "v$1643" ) ) )
                               ) :| []
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                ( Ref Nothing ( Local ( Name "$cse1762" ) ) )
+                                ( Ref Nothing ( Local ( Name "$cse1764" ) ) )
                               )
                               ( PrimBinOp Nothing PrimConcat
                                 ( LiteralString Nothing "(Just " )
@@ -2151,7 +2151,7 @@ UberModule
                                       )
                                     )
                                     ( DataArgumentByIndex Nothing SumType 0
-                                      ( Ref Nothing ( Local ( Name "v$1641" ) ) ) :| []
+                                      ( Ref Nothing ( Local ( Name "v$1643" ) ) ) :| []
                                     )
                                   )
                                   ( LiteralString Nothing ")" )
@@ -2160,7 +2160,7 @@ UberModule
                               ( IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                                  ( Ref Nothing ( Local ( Name "$cse1762" ) ) )
+                                  ( Ref Nothing ( Local ( Name "$cse1764" ) ) )
                                 )
                                 ( LiteralString Nothing "Nothing" )
                                 ( Exception Nothing "No patterns matched" )
@@ -2171,7 +2171,7 @@ UberModule
                       ] :|
                       [ Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v1$1743", AppN Nothing
+                          ( Nothing, Name "v1$1745", AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                             )
@@ -2181,7 +2181,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1743" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1745" ) ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing
@@ -2208,7 +2208,7 @@ UberModule
                                 )
                                 ( ObjectProp Nothing
                                   ( DataArgumentByIndex Nothing SumType 0
-                                    ( Ref Nothing ( Local ( Name "v1$1743" ) ) )
+                                    ( Ref Nothing ( Local ( Name "v1$1745" ) ) )
                                   )
                                   ( PropName "tail" ) :| []
                                 ) :| []
@@ -2322,16 +2322,16 @@ UberModule
                             ( AbsN Nothing
                               ( ParamUnused Nothing :| [] )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "v$1756" ) :| [] )
+                                ( ParamNamed Nothing ( Name "v$1758" ) :| [] )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
                                     ( ReflectCtor Nothing
-                                      ( Ref Nothing ( Local ( Name "v$1756" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v$1758" ) ) )
                                     )
                                   )
                                   ( DataArgumentByIndex Nothing SumType 0
-                                    ( Ref Nothing ( Local ( Name "v$1756" ) ) )
+                                    ( Ref Nothing ( Local ( Name "v$1758" ) ) )
                                   )
                                   ( Exception Nothing "No patterns matched" )
                                 )

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -270,17 +270,17 @@ Data_HeytingAlgebra_heytingAlgebraBoolean = {
       return Data_HeytingAlgebra_heytingAlgebraBoolean.disj(Data_HeytingAlgebra_heytingAlgebraBoolean._not_(a))(b)
     end
   end,
-  conj = function(b1_S_1494)
-    return function(b2_S_1495) return b1_S_1494 and b2_S_1495 end
+  conj = function(b1_S_1496)
+    return function(b2_S_1497) return b1_S_1496 and b2_S_1497 end
   end,
-  disj = function(b1_S_1492)
-    return function(b2_S_1493) return b1_S_1492 or b2_S_1493 end
+  disj = function(b1_S_1494)
+    return function(b2_S_1495) return b1_S_1494 or b2_S_1495 end
   end,
-  _not_ = function(b_S_1491) return not(b_S_1491) end
+  _not_ = function(b_S_1493) return not(b_S_1493) end
 }
 local Data_Eq_eqInt = {
-  eq = function(r1_S_1487)
-    return function(r2_S_1488) return r1_S_1487 == r2_S_1488 end
+  eq = function(r1_S_1489)
+    return function(r2_S_1490) return r1_S_1489 == r2_S_1490 end
   end
 }
 local Data_Show_showInt = { show = Data_Show_showIntImpl }
@@ -288,11 +288,11 @@ local Data_Ordering_LT = { "Data.Ordering∷Ordering.LT" }
 local Data_Ordering_GT = { "Data.Ordering∷Ordering.GT" }
 local Data_Ordering_EQ = { "Data.Ordering∷Ordering.EQ" }
 local Data_Ord_ordInt = {
-  compare = function(x_S_1471)
-    return function(y_S_1472)
-      if x_S_1471 < y_S_1472 then
+  compare = function(x_S_1473)
+    return function(y_S_1474)
+      if x_S_1473 < y_S_1474 then
         return Data_Ordering_LT
-      elseif x_S_1471 == y_S_1472 then
+      elseif x_S_1473 == y_S_1474 then
         return Data_Ordering_EQ
       else
         return Data_Ordering_GT
@@ -321,11 +321,11 @@ local Data_String_CodePoints_fromEnum = Data_Enum_toCharCode
 local Data_String_CodePoints_unsafeCodePointAt0 = Data_String_CodePoints_foreign._unsafeCodePointAt0(function( s_S_24 )
   local cu0_S_25 = Data_String_CodePoints_fromEnum(Data_String_Unsafe_charAt(0)(s_S_24))
   if Data_String_CodePoints_conj(Data_String_CodePoints_conj(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, 55296, cu0_S_25))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, cu0_S_25, 56319)))("Data.Ordering∷Ordering.GT" == ((function(  )
-    local x_S_1585 = Data_String_CodeUnits_length(s_S_24)
-    return function(y_S_1586)
-      if x_S_1585 < y_S_1586 then
+    local x_S_1587 = Data_String_CodeUnits_length(s_S_24)
+    return function(y_S_1588)
+      if x_S_1587 < y_S_1588 then
         return Data_Ordering_LT
-      elseif x_S_1585 == y_S_1586 then
+      elseif x_S_1587 == y_S_1588 then
         return Data_Ordering_EQ
       else
         return Data_Ordering_GT
@@ -343,19 +343,19 @@ local Data_String_CodePoints_unsafeCodePointAt0 = Data_String_CodePoints_foreign
   end
 end)
 local Data_String_CodePoints_singletonFallback = function(v)
-  local _S_cse1758 = Data_HeytingAlgebra_heytingAlgebraBoolean.conj
+  local _S_cse1760 = Data_HeytingAlgebra_heytingAlgebraBoolean.conj
   if Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, v, 65535) then
     return Data_String_CodeUnits_singleton((function()
-      local v_S_1746 = (function()
-        if _S_cse1758(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_top1))) then
+      local v_S_1748 = (function()
+        if _S_cse1760(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Enum_top1))) then
           return Data_Maybe_Just(Data_Enum_fromCharCode(v))
         else
           return Data_Maybe_Nothing
         end
       end)()
-      if "Data.Maybe∷Maybe.Just" == v_S_1746[1] then
-        return v_S_1746[2]
-      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1746[1] then
+      if "Data.Maybe∷Maybe.Just" == v_S_1748[1] then
+        return v_S_1748[2]
+      elseif "Data.Maybe∷Maybe.Nothing" == v_S_1748[1] then
         if Data_Ord_lessThan_S_w(Data_Ord_ordInt, v, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
           return Data_Bounded_bottomChar
         else
@@ -367,32 +367,10 @@ local Data_String_CodePoints_singletonFallback = function(v)
     end)())
   else
     return (function()
-      local x_S_1747 = Data_EuclideanRing_foreign.intDiv(v - 65536)(1024) + 55296
-      return Data_String_CodeUnits_singleton((function()
-        local v_S_1748 = (function()
-          if _S_cse1758(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1747, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1747, Data_Enum_toCharCode(Data_Enum_top1))) then
-            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1747))
-          else
-            return Data_Maybe_Nothing
-          end
-        end)()
-        if "Data.Maybe∷Maybe.Just" == v_S_1748[1] then
-          return v_S_1748[2]
-        elseif "Data.Maybe∷Maybe.Nothing" == v_S_1748[1] then
-          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1747, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
-            return Data_Bounded_bottomChar
-          else
-            return Data_Bounded_topChar
-          end
-        else
-          return error("No patterns matched")
-        end
-      end)())
-    end)() .. (function()
-      local x_S_1749 = Data_EuclideanRing_foreign.intMod(v - 65536)(1024) + 56320
+      local x_S_1749 = Data_EuclideanRing_foreign.intDiv(v - 65536)(1024) + 55296
       return Data_String_CodeUnits_singleton((function()
         local v_S_1750 = (function()
-          if _S_cse1758(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1749, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1749, Data_Enum_toCharCode(Data_Enum_top1))) then
+          if _S_cse1760(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1749, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1749, Data_Enum_toCharCode(Data_Enum_top1))) then
             return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1749))
           else
             return Data_Maybe_Nothing
@@ -402,6 +380,28 @@ local Data_String_CodePoints_singletonFallback = function(v)
           return v_S_1750[2]
         elseif "Data.Maybe∷Maybe.Nothing" == v_S_1750[1] then
           if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1749, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
+            return Data_Bounded_bottomChar
+          else
+            return Data_Bounded_topChar
+          end
+        else
+          return error("No patterns matched")
+        end
+      end)())
+    end)() .. (function()
+      local x_S_1751 = Data_EuclideanRing_foreign.intMod(v - 65536)(1024) + 56320
+      return Data_String_CodeUnits_singleton((function()
+        local v_S_1752 = (function()
+          if _S_cse1760(Data_Ord_greaterThanOrEq_S_w(Data_Ord_ordInt, x_S_1751, Data_Enum_toCharCode(Data_Enum_bottom1)))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, x_S_1751, Data_Enum_toCharCode(Data_Enum_top1))) then
+            return Data_Maybe_Just(Data_Enum_fromCharCode(x_S_1751))
+          else
+            return Data_Maybe_Nothing
+          end
+        end)()
+        if "Data.Maybe∷Maybe.Just" == v_S_1752[1] then
+          return v_S_1752[2]
+        elseif "Data.Maybe∷Maybe.Nothing" == v_S_1752[1] then
+          if Data_Ord_lessThan_S_w(Data_Ord_ordInt, x_S_1751, Data_Enum_toCharCode(Data_Bounded_bottomChar)) then
             return Data_Bounded_bottomChar
           else
             return Data_Bounded_topChar
@@ -470,31 +470,31 @@ Data_String_CodePoints_drop_S_w = function(n, s)
   return Data_String_CodeUnits_foreign.drop(Data_String_CodeUnits_length(Data_String_CodePoints_take_S_w(n, s)))(s)
 end
 local Data_String_CodePoints_toCodePointArray = Data_String_CodePoints_foreign._toCodePointArray(function( s_S_7 )
-  return Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1516)
-    local _S_cse1759 = v2_S_1516[1]
-    if "Data.Maybe∷Maybe.Nothing" == _S_cse1759 then
+  return Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1518)
+    local _S_cse1761 = v2_S_1518[1]
+    if "Data.Maybe∷Maybe.Nothing" == _S_cse1761 then
       return true
-    elseif "Data.Maybe∷Maybe.Just" == _S_cse1759 then
+    elseif "Data.Maybe∷Maybe.Just" == _S_cse1761 then
       return false
     else
       return error("No patterns matched")
     end
   end)(Partial_Unsafe__unsafePartial(function()
-    return function(v_S_1562)
-      if "Data.Maybe∷Maybe.Just" == v_S_1562[1] then
-        return v_S_1562[2]
+    return function(v_S_1564)
+      if "Data.Maybe∷Maybe.Just" == v_S_1564[1] then
+        return v_S_1564[2]
       else
         return error("No patterns matched")
       end
     end
-  end))(function(v_S_1514) return v_S_1514[1] end)(function(v_S_1515)
-    return v_S_1515[2]
+  end))(function(v_S_1516) return v_S_1516[1] end)(function(v_S_1517)
+    return v_S_1517[2]
   end)(function(s_S_8)
-    local v1_S_1565 = Data_String_CodePoints_uncons(s_S_8)
-    if "Data.Maybe∷Maybe.Just" == v1_S_1565[1] then
+    local v1_S_1567 = Data_String_CodePoints_uncons(s_S_8)
+    if "Data.Maybe∷Maybe.Just" == v1_S_1567[1] then
       return Data_Maybe_Just((function(value0)
         return function(value1) return { value0, value1 } end
-      end)(v1_S_1565[2].head)(v1_S_1565[2].tail))
+      end)(v1_S_1567[2].head)(v1_S_1567[2].tail))
     else
       return Data_Maybe_Nothing
     end
@@ -554,11 +554,11 @@ local Data_String_CodePoints_boundedEnumCodePoint = {
 }
 Data_String_CodePoints_Lazy_enumCodePoint = PSLUA_runtime_lazy("enumCodePoint")(function(  )
   return {
-    succ = function(a_S_1550)
-      return Data_String_CodePoints_boundedEnumCodePoint.toEnum(Data_String_CodePoints_boundedEnumCodePoint.fromEnum(a_S_1550) + 1)
+    succ = function(a_S_1552)
+      return Data_String_CodePoints_boundedEnumCodePoint.toEnum(Data_String_CodePoints_boundedEnumCodePoint.fromEnum(a_S_1552) + 1)
     end,
-    pred = function(a_S_1558)
-      return Data_String_CodePoints_boundedEnumCodePoint.toEnum(Data_String_CodePoints_boundedEnumCodePoint.fromEnum(a_S_1558) - 1)
+    pred = function(a_S_1560)
+      return Data_String_CodePoints_boundedEnumCodePoint.toEnum(Data_String_CodePoints_boundedEnumCodePoint.fromEnum(a_S_1560) - 1)
     end,
     Ord0 = function() return Data_String_CodePoints_ordCodePoint end
   }
@@ -570,27 +570,27 @@ local Golden_StringCodePoints_Test_fromEnum = Data_String_CodePoints_boundedEnum
 local Golden_StringCodePoints_Test_showArray = {
   show = Data_Show_showArrayImpl(Data_Show_showIntImpl)
 }
-M.Golden_StringCodePoints_Test_cp = function(x_S_1650)
+M.Golden_StringCodePoints_Test_cp = function(x_S_1652)
   return Partial_Unsafe__unsafePartial(function()
-    return function(v_S_1524)
-      if "Data.Maybe∷Maybe.Just" == v_S_1524[1] then
-        return v_S_1524[2]
+    return function(v_S_1526)
+      if "Data.Maybe∷Maybe.Just" == v_S_1526[1] then
+        return v_S_1526[2]
       else
         return error("No patterns matched")
       end
     end
-  end)(Data_String_CodePoints_boundedEnumCodePoint.toEnum(x_S_1650))
+  end)(Data_String_CodePoints_boundedEnumCodePoint.toEnum(x_S_1652))
 end
-M.Golden_StringCodePoints_Test_codes = function(x_S_1647)
-  return Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(x_S_1647))
+M.Golden_StringCodePoints_Test_codes = function(x_S_1649)
+  return Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(x_S_1649))
 end
 return (function()
-  local _S_cse1760 = {
-    show = function(v_S_1703)
-      local _S_cse1761 = v_S_1703[1]
-      if "Data.Maybe∷Maybe.Just" == _S_cse1761 then
-        return "(Just " .. Data_Show_showIntImpl(v_S_1703[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == _S_cse1761 then
+  local _S_cse1762 = {
+    show = function(v_S_1705)
+      local _S_cse1763 = v_S_1705[1]
+      if "Data.Maybe∷Maybe.Just" == _S_cse1763 then
+        return "(Just " .. Data_Show_showIntImpl(v_S_1705[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == _S_cse1763 then
         return "Nothing"
       else
         return error("No patterns matched")
@@ -602,53 +602,53 @@ return (function()
   local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Data_String_CodeUnits_length("aéЯ𝐀z"))()
   local _ = Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_take_S_w(2, "aéЯ𝐀z"))))()
   local _ = Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_drop_S_w(2, "aéЯ𝐀z"))))()
-  local _ = Effect_Console_logShow_S_w(_S_cse1760, (function()
-    local v1_S_1701 = Data_String_CodePoints_codePointAt_S_w(0, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1701[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1701[2]))
+  local _ = Effect_Console_logShow_S_w(_S_cse1762, (function()
+    local v1_S_1703 = Data_String_CodePoints_codePointAt_S_w(0, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1703[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1703[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
-  local _ = Effect_Console_logShow_S_w(_S_cse1760, (function()
-    local v1_S_1709 = Data_String_CodePoints_codePointAt_S_w(3, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1709[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1709[2]))
+  local _ = Effect_Console_logShow_S_w(_S_cse1762, (function()
+    local v1_S_1711 = Data_String_CodePoints_codePointAt_S_w(3, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1711[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1711[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
-  local _ = Effect_Console_logShow_S_w(_S_cse1760, (function()
-    local v1_S_1717 = Data_String_CodePoints_codePointAt_S_w(5, "aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1717[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1717[2]))
+  local _ = Effect_Console_logShow_S_w(_S_cse1762, (function()
+    local v1_S_1719 = Data_String_CodePoints_codePointAt_S_w(5, "aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1719[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1719[2]))
     else
       return Data_Maybe_Nothing
     end
   end)())()
-  local _ = Effect_Console_logShow_S_w(_S_cse1760, (function()
-    local v1_S_1728 = Data_String_CodePoints_uncons("aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1728[1] then
-      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1728[2].head))
+  local _ = Effect_Console_logShow_S_w(_S_cse1762, (function()
+    local v1_S_1730 = Data_String_CodePoints_uncons("aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1730[1] then
+      return Data_Maybe_Just(Golden_StringCodePoints_Test_fromEnum(v1_S_1730[2].head))
     else
       return Data_Maybe_Nothing
     end
   end)())()
   local _ = Effect_Console_logShow_S_w({
-    show = function(v_S_1641)
-      local _S_cse1762 = v_S_1641[1]
-      if "Data.Maybe∷Maybe.Just" == _S_cse1762 then
-        return "(Just " .. Data_Show_showArrayImpl(Data_Show_showIntImpl)(v_S_1641[2]) .. ")"
-      elseif "Data.Maybe∷Maybe.Nothing" == _S_cse1762 then
+    show = function(v_S_1643)
+      local _S_cse1764 = v_S_1643[1]
+      if "Data.Maybe∷Maybe.Just" == _S_cse1764 then
+        return "(Just " .. Data_Show_showArrayImpl(Data_Show_showIntImpl)(v_S_1643[2]) .. ")"
+      elseif "Data.Maybe∷Maybe.Nothing" == _S_cse1764 then
         return "Nothing"
       else
         return error("No patterns matched")
       end
     end
   }, (function()
-    local v1_S_1743 = Data_String_CodePoints_uncons("aéЯ𝐀z")
-    if "Data.Maybe∷Maybe.Just" == v1_S_1743[1] then
-      return Data_Maybe_Just(Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(v1_S_1743[2].tail)))
+    local v1_S_1745 = Data_String_CodePoints_uncons("aéЯ𝐀z")
+    if "Data.Maybe∷Maybe.Just" == v1_S_1745[1] then
+      return Data_Maybe_Just(Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(v1_S_1745[2].tail)))
     else
       return Data_Maybe_Nothing
     end
@@ -665,9 +665,9 @@ return (function()
     end
   }, Data_String_CodePoints_foreign._fromCodePointArray(Data_String_CodePoints_singletonFallback)(Data_String_CodePoints_toCodePointArray("aéЯ𝐀z")) == "aéЯ𝐀z")()
   return Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_singleton(Partial_Unsafe__unsafePartial(function(  )
-    return function(v_S_1756)
-      if "Data.Maybe∷Maybe.Just" == v_S_1756[1] then
-        return v_S_1756[2]
+    return function(v_S_1758)
+      if "Data.Maybe∷Maybe.Just" == v_S_1758[1] then
+        return v_S_1758[2]
       else
         return error("No patterns matched")
       end

--- a/test/ps/spago.lock
+++ b/test/ps/spago.lock
@@ -32,7 +32,7 @@
     },
     "package_set": {
       "address": {
-        "url": "https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260713/packages.json"
+        "url": "https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260714/packages.json"
       },
       "compiler": ">=0.15.15 <0.16.0",
       "content": {
@@ -64,7 +64,7 @@
         "arraybuffer-types": "3.0.2",
         "arrays": {
           "git": "https://github.com/purescript-lua/purescript-lua-arrays.git",
-          "ref": "v7.4.2",
+          "ref": "v7.4.3",
           "dependencies": [
             "foldable-traversable",
             "functions",
@@ -867,7 +867,7 @@
     "arrays": {
       "type": "git",
       "url": "https://github.com/purescript-lua/purescript-lua-arrays.git",
-      "rev": "f92475f4560c7fed9d4c5fb5787db246db6b270d",
+      "rev": "4641b4b5ee19c3b472151da585f4676147a7cd74",
       "dependencies": [
         "foldable-traversable",
         "functions",

--- a/test/ps/spago.yaml
+++ b/test/ps/spago.yaml
@@ -39,4 +39,4 @@ workspace:
   backend:
     cmd: "true"
   packageSet:
-    url: https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260713/packages.json
+    url: https://github.com/purescript-lua/purescript-lua-package-sets/releases/download/psc-0.15.15-20260714/packages.json


### PR DESCRIPTION
## What

Repoints the `test/ps` golden set at `psc-0.15.15-20260714`, which picks up arrays `v7.4.3`. That release restores the `Data.Array.ST.clone` export the Lua fork was missing (purescript-lua/purescript-lua-arrays#4), so code written against upstream `purescript-arrays` compiles against the set again.

## Golden churn

Limited to the `StringCodePoints` goldens, and benign:

- `golden.ir`: the content-addressed `.spago/p/arrays/<hash>` source-path stamp moves to the v7.4.3 collect commit, and the fresh-binder counter shifts by exactly two (`clone`/`cloneImpl` are the two new bindings entering the freshen graph before DCE). The IR structure is otherwise identical.
- `golden.lua`: the same `+2` fresh-binder renumbering.

No `eval/golden.txt` output moved, so the semantic oracle is unchanged. `spago.lock` records the new set URL and the arrays `v7.4.3` ref/rev.

## Verification

`cabal test all` passes (899 examples, 0 failures) after accepting the two structural goldens, and a clean re-run (no `PSLUA_GOLDEN_ACCEPT`) stays green.

Refs #267.
