### PR TITLE
feat(ir): push case-of-case over the IfThenElse decision tree

### DIFF
--- a/bench/goldens/fnew_Bench.EffectStep.txt
+++ b/bench/goldens/fnew_Bench.EffectStep.txt
@@ -1,9 +1,9 @@
 chunk: Bench.EffectStep.lua
 runtime: LuaJIT 2.1.1741730670
 main-chunk FNEW: 11
-function-body FNEW: 13
-total FNEW: 24
-prototypes: 25
+function-body FNEW: 12
+total FNEW: 23
+prototypes: 24
 function-body FNEW sites:
   Bench.EffectStep.lua:4
   Bench.EffectStep.lua:6
@@ -13,8 +13,7 @@ function-body FNEW sites:
   Bench.EffectStep.lua:12
   Bench.EffectStep.lua:12
   Bench.EffectStep.lua:33
-  Bench.EffectStep.lua:54
-  Bench.EffectStep.lua:53
-  Bench.EffectStep.lua:48
-  Bench.EffectStep.lua:57
-  Bench.EffectStep.lua:66
+  Bench.EffectStep.lua:46
+  Bench.EffectStep.lua:45
+  Bench.EffectStep.lua:49
+  Bench.EffectStep.lua:58

--- a/bench/goldens/trace_effect_step.txt
+++ b/bench/goldens/trace_effect_step.txt
@@ -4,11 +4,9 @@ workload: n=100000 reps=4 result=1500000
 aborts (distinct site -- reason):
   Bench.EffectStep.lua:10 -- NYI: bytecode FNEW
   Bench.EffectStep.lua:12 -- NYI: bytecode FNEW
-  Bench.EffectStep.lua:48 -- NYI: bytecode FNEW
-  Bench.EffectStep.lua:49 -- NYI: bytecode UCLO
-  Bench.EffectStep.lua:53 -- NYI: bytecode FNEW
-  Bench.EffectStep.lua:54 -- NYI: bytecode FNEW
-  Bench.EffectStep.lua:66 -- NYI: bytecode FNEW
+  Bench.EffectStep.lua:45 -- NYI: bytecode FNEW
+  Bench.EffectStep.lua:46 -- NYI: bytecode FNEW
+  Bench.EffectStep.lua:58 -- NYI: bytecode FNEW
   Bench.EffectStep.lua:9 -- NYI: bytecode FNEW
 bytecode end state (J*=compiled, I*=blacklisted):
   Bench.EffectStep.lua:10 IFUNCF
@@ -20,9 +18,8 @@ bytecode end state (J*=compiled, I*=blacklisted):
   Bench.EffectStep.lua:36 IFUNCF
   Bench.EffectStep.lua:37 IFUNCF
   Bench.EffectStep.lua:39 IFUNCF
-  Bench.EffectStep.lua:40 JFUNCF
   Bench.EffectStep.lua:9 JFUNCF
   effect_step.lua:11 JFUNCF
   effect_step.lua:13 JFORI
   effect_step.lua:13 JFORL
-counts: aborts=8 compiled=7 blacklisted=7
+counts: aborts=6 compiled=6 blacklisted=7

--- a/changelog.d/20260714_120000_unisay_case_of_case_if.md
+++ b/changelog.d/20260714_120000_unisay_case_of_case_if.md
@@ -13,3 +13,17 @@
   comparison collapses to a flat condition — `if n < 0 then` instead of
   `if "…LT" == (function() … end)() then` — across seven goldens, with eval
   outputs unchanged.
+
+- Half-literal boolean ifs fold to short-circuiting operators (#203):
+  `if p then True else b` becomes `p or b`, `if p then False else b` becomes
+  `not p and b`, and the two mirrored shapes likewise — the completion of
+  `reduceBooleanIf`, whose two-literal cases already collapsed to the bare
+  condition. Lua's `and`/`or` evaluate exactly what the branches evaluated,
+  in the same order, and unlike a branch an operator survives in condition
+  position without an IIFE: the `Ordering` trees compared against `GT`
+  (`Golden.Loopification`, `Golden.Primops`, `Golden.UncurryEffect`) now
+  flatten all the way to `not (n < 0) and n ~= 0`. Two identity primop folds
+  ride along (`a and true` → `a`, `a or false` → `a` — nothing is skipped);
+  the annihilator duals stay, since folding them would skip evaluating `a`.
+  Luacheck's W581 (suggesting the NaN-unsafe `not (x < y)` → `x >= y` flip)
+  is now ignored for generated goldens.

--- a/changelog.d/20260714_120000_unisay_case_of_case_if.md
+++ b/changelog.d/20260714_120000_unisay_case_of_case_if.md
@@ -1,0 +1,15 @@
+### Added
+
+- Case-of-case pushes over the `IfThenElse` decision tree in the IR optimizer
+  (#203). A scalar literal compared against an if-tree distributes into the
+  branches when every leaf comparison constant-folds — the shape an inlined
+  `Ord` comparison leaves behind once the tag read distributes over its
+  `Ordering` tree (#180) — and an if sitting in the condition of another if
+  pushes into its branches when the inner branches are boolean literals or
+  the outer branches are trivial to re-emit. Both shapes sat in expression
+  position, where codegen wraps them in an IIFE allocated and called per
+  evaluation — on every iteration, for the recursive functions in
+  `Golden.LongCallbackChain` and `Golden.TailRecM2Shadow`. The pushed
+  comparison collapses to a flat condition — `if n < 0 then` instead of
+  `if "…LT" == (function() … end)() then` — across seven goldens, with eval
+  outputs unchanged.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -796,6 +796,8 @@ optimizedExpressionM policy env =
         `thenRewrite` removeIfWithEqualBranches
         `thenRewrite` flipNegatedIf
         `thenRewrite` reduceBooleanIf
+        `thenRewrite` pushEqIntoIfBranches
+        `thenRewrite` pushIfCondIntoBranches
         `thenRewrite` inlineLocalBindings
     )
 
@@ -821,19 +823,12 @@ assumption the type checker would not already guarantee.
 constantFolding ∷ Applicative m ⇒ RewriteRuleM m Ann
 constantFolding =
   pure . \case
-    Eq _ (LiteralBool _ a) (LiteralBool _ b) →
-      Just $ literalBool $ a == b
+    Eq _ a b
+      | Just result ← foldEqLiterals a b →
+          Just $ literalBool result
     Eq _ (LiteralBool _ True) b →
       -- 'b' must be of type Bool; see Note [IR is assumed well-typed]
       Just b
-    Eq _ (LiteralInt _ a) (LiteralInt _ b) →
-      Just $ literalBool $ a == b
-    Eq _ (LiteralFloat _ a) (LiteralFloat _ b) →
-      Just $ literalBool $ a == b
-    Eq _ (LiteralChar _ a) (LiteralChar _ b) →
-      Just $ literalBool $ a == b
-    Eq _ (LiteralString _ a) (LiteralString _ b) →
-      Just $ literalBool $ a == b
     -- See Note [IR primops] and Note [Folding primops follows Lua 5.1]
     PrimBinOp _ op a b → foldPrimBinOp op a b
     PrimNot _ a → foldPrimNot a
@@ -932,6 +927,20 @@ foldPrimNot ∷ Exp → Maybe Exp
 foldPrimNot = \case
   LiteralBool _ b → Just (literalBool (not b))
   PrimNot _ e → Just e
+  _ → Nothing
+
+{- | Fold an equality of two scalar literals, or 'Nothing' when either
+side is not a scalar literal. Two literals of different kinds also
+decline: such a comparison is ill-typed input (see Note [IR is assumed
+well-typed]), not a provable inequality.
+-}
+foldEqLiterals ∷ RawExp ann → RawExp ann' → Maybe Bool
+foldEqLiterals l r = case (l, r) of
+  (LiteralBool _ a, LiteralBool _ b) → Just (a == b)
+  (LiteralInt _ a, LiteralInt _ b) → Just (a == b)
+  (LiteralFloat _ a, LiteralFloat _ b) → Just (a == b)
+  (LiteralChar _ a, LiteralChar _ b) → Just (a == b)
+  (LiteralString _ a, LiteralString _ b) → Just (a == b)
   _ → Nothing
 
 {- | Folds a record projection into the record constructor:
@@ -1664,6 +1673,92 @@ removeUnreachableElseBranch e = pure case e of
   IfThenElse _ann (LiteralBool _ True) thenBranch _unreachable →
     Just thenBranch
   _ → Nothing
+
+{- | Case-of-case over a comparison (issue #203), the 'Eq' sibling of
+'reduceKnownConstructor'\'s tag-read distribution: a scalar literal
+compared against an 'IfThenElse' tree distributes into the branches,
+where each leaf comparison meets 'constantFolding' and the boolean-if
+rules collapse the tree to a flat condition. Without the push the tree
+sits in expression position — an IIFE in the generated Lua, allocated
+and called per evaluation — the shape an inlined 'Ord' comparison
+leaves behind once the tag read distributes over its 'Ordering'
+decision tree (issue #180). Guarded by 'eqFoldsThrough', mirroring
+'reflectFoldsThrough': the rule fires only when every leaf folds, so it
+never leaves a residual comparison behind, and the duplicated operand
+is a scalar literal, free to re-emit. Evaluation order is preserved:
+the branch conditions ran before the comparison and still do. Each push
+strictly shrinks the tree under the 'Eq', so the rewrite terminates.
+-}
+pushEqIntoIfBranches ∷ Applicative m ⇒ RewriteRuleM m Ann
+pushEqIntoIfBranches =
+  pure . \case
+    Eq ann lit (IfThenElse ifAnn cond t e)
+      | eqFoldsThrough lit t
+      , eqFoldsThrough lit e →
+          Just $ IfThenElse ifAnn cond (Eq ann lit t) (Eq ann lit e)
+    Eq ann (IfThenElse ifAnn cond t e) lit
+      | eqFoldsThrough lit t
+      , eqFoldsThrough lit e →
+          Just $ IfThenElse ifAnn cond (Eq ann t lit) (Eq ann e lit)
+    _ → Nothing
+
+{- | Whether comparing this expression against the literal folds away
+completely: it is a scalar literal of the same kind (the comparison
+folds to a boolean), or an 'IfThenElse' whose branches both do. Only
+then does 'pushEqIntoIfBranches' distribute a comparison into an
+'IfThenElse', so the rewrite never trades one expression-position tree
+for another.
+-}
+eqFoldsThrough ∷ RawExp ann → RawExp ann' → Bool
+eqFoldsThrough lit = go
+ where
+  go = \case
+    IfThenElse _ann _cond t e → go t && go e
+    leaf → isJust (foldEqLiterals lit leaf)
+
+{- | Case-of-case over an 'IfThenElse' whose condition is itself an
+'IfThenElse' decision tree (issue #203):
+
+@
+IfThenElse (IfThenElse c a b) x y
+  ==> IfThenElse c (IfThenElse a x y) (IfThenElse b x y)
+@
+
+The tree in condition position — an IIFE in the generated Lua — becomes
+statement-position ifs, and evaluation order is preserved exactly: @c@,
+then @a@ or @b@, then @x@ or @y@. The unrestricted transformation would
+need join points to avoid duplicating @x@ and @y@, so the rewrite is
+restricted to the shapes where pushing cannot duplicate work:
+
+  * @a@ and @b@ are boolean literals: the residual ifs are folded right
+    away by 'removeUnreachableThenBranch'\/'removeUnreachableElseBranch'
+    and each of @x@, @y@ survives in exactly one copy;
+
+  * alternatively @x@ and @y@ are trivial by the 'isInlinableValue'
+    test — free to re-emit, and binder-free, so the copies cannot break
+    the unique-binders invariant.
+
+Each push strictly shrinks the expression in condition position, so the
+rewrite terminates.
+-}
+pushIfCondIntoBranches ∷ Applicative m ⇒ RewriteRuleM m Ann
+pushIfCondIntoBranches =
+  pure . \case
+    IfThenElse ann (IfThenElse condAnn c a b) x y
+      | (isBoolLiteral a && isBoolLiteral b)
+          || (isInlinableValue x && isInlinableValue y) →
+          Just $
+            IfThenElse
+              condAnn
+              c
+              (IfThenElse ann a x y)
+              (IfThenElse ann b x y)
+    _ → Nothing
+ where
+  isBoolLiteral ∷ RawExp ann → Bool
+  isBoolLiteral = \case
+    LiteralBool {} → True
+    _ → False
 
 -- Inlining is a tricky business:
 -- https://www.microsoft.com/en-us/research/wp-content/uploads/2002/07/inline.pdf

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -68,6 +68,7 @@ import Language.PureScript.Backend.IR.Types
   , literalInt
   , literalString
   , paramName
+  , primBinOp
   , primNot
   , refImported
   , rewriteExpBottomUpM
@@ -864,7 +865,12 @@ primops]). The per-operator caveats:
     collapse a known-boolean first operand (@true and b == b@,
     @false or b == b@, and the two annihilators): sound because Lua
     @and@/@or@ short-circuit, so dropping the second operand is exactly
-    what the runtime does.
+    what the runtime does. An identity /second/ operand (@a and true@,
+    @a or false@) also folds to @a@ — nothing is skipped, and the
+    literal cannot change a boolean @a@'s value (see Note [IR is
+    assumed well-typed]). The annihilator duals (@a and false@,
+    @a or true@) are left to the runtime, since folding them would skip
+    @a@'s evaluation.
 -}
 
 -- | The IEEE-double exactness ceiling; integer folds bail beyond it.
@@ -894,9 +900,11 @@ foldPrimBinOp op l r = case (op, l, r) of
   (PrimAnd, LiteralBool _ a, LiteralBool _ b) → Just (literalBool (a && b))
   (PrimAnd, LiteralBool _ True, b) → Just b
   (PrimAnd, LiteralBool _ False, _) → Just (literalBool False)
+  (PrimAnd, a, LiteralBool _ True) → Just a
   (PrimOr, LiteralBool _ a, LiteralBool _ b) → Just (literalBool (a || b))
   (PrimOr, LiteralBool _ True, _) → Just (literalBool True)
   (PrimOr, LiteralBool _ False, b) → Just b
+  (PrimOr, a, LiteralBool _ False) → Just a
   _ → Nothing
  where
   intFold ∷ Integer → Integer → Integer → Maybe Exp
@@ -1638,19 +1646,32 @@ flipNegatedIf =
       Just (IfThenElse ann cond elseBranch thenBranch)
     _ → Nothing
 
-{- | Collapse an if whose branches are the two boolean literals to the
-condition or its negation:
+{- | Collapse an if with boolean-literal branches into boolean
+operators. Two literal branches make the if the condition or its
+negation:
 
   * @if p then True else False@ ⟶ @p@;
   * @if p then False else True@ ⟶ @not p@ (a 'PrimNot' — a node the IR
     only gained with the primops of issue #178).
 
-Every 'Ord' comparison and @/=@ decays to this shape: their 'case' over
-the result compiles to a two-way boolean decision tree, so once the
-foreign comparison bodies lift to primops (#178) it is the dominant
-residual. @p@ is a 'Bool' evaluated once with pure literal branches, so
-the rewrite is semantics-preserving (see Note [IR is assumed
-well-typed]).
+One literal branch makes it a short-circuiting operator (issue #203);
+the other branch is a 'Bool' too, pinned by the literal (see
+Note [IR is assumed well-typed]):
+
+  * @if p then True else b@ ⟶ @p or b@;
+  * @if p then False else b@ ⟶ @not p and b@;
+  * @if p then a else True@ ⟶ @not p or a@;
+  * @if p then a else False@ ⟶ @p and a@.
+
+Every 'Ord' comparison and @/=@ decays to the two-literal shape: their
+'case' over the result compiles to a two-way boolean decision tree, so
+once the foreign comparison bodies lift to primops (#178) it is the
+dominant residual. The half-literal shapes are what a pushed comparison
+('pushEqIntoIfBranches') collapses to when the tree has more than one
+leaf folding the same way. Lua's @and@\/@or@ short-circuit, so each
+fold evaluates exactly what the branches evaluated, in the same order —
+and unlike a branch, an operator survives in condition position without
+an IIFE.
 -}
 reduceBooleanIf ∷ Applicative m ⇒ RewriteRuleM m Ann
 reduceBooleanIf =
@@ -1659,6 +1680,14 @@ reduceBooleanIf =
       Just cond
     IfThenElse _ cond (LiteralBool _ False) (LiteralBool _ True) →
       Just (primNot cond)
+    IfThenElse _ cond (LiteralBool _ True) elseBranch →
+      Just (primBinOp PrimOr cond elseBranch)
+    IfThenElse _ cond (LiteralBool _ False) elseBranch →
+      Just (primBinOp PrimAnd (primNot cond) elseBranch)
+    IfThenElse _ cond thenBranch (LiteralBool _ True) →
+      Just (primBinOp PrimOr (primNot cond) thenBranch)
+    IfThenElse _ cond thenBranch (LiteralBool _ False) →
+      Just (primBinOp PrimAnd cond thenBranch)
     _ → Nothing
 
 removeUnreachableThenBranch ∷ Applicative m ⇒ RewriteRuleM m Ann

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -872,6 +872,20 @@ spec = describe "IR Optimizer" do
         `shouldBe` literalBool True
       optimizedExpression (primBinOp PrimOr (literalBool False) x) `shouldBe` x
 
+    it "collapses an identity second operand of and/or" do
+      -- x and true / x or false evaluate x either way and x is a Bool,
+      -- so the literal is pure ceremony. The annihilator duals (x and
+      -- false, x or true) are left alone: folding them would skip x.
+      let x = refLocal (Name "x")
+      optimizedExpression (primBinOp PrimAnd x (literalBool True))
+        `shouldBe` x
+      optimizedExpression (primBinOp PrimOr x (literalBool False))
+        `shouldBe` x
+      let andFalse = primBinOp PrimAnd x (literalBool False)
+          orTrue = primBinOp PrimOr x (literalBool True)
+      optimizedExpression andFalse `shouldBe` andFalse
+      optimizedExpression orTrue `shouldBe` orTrue
+
     it "folds bottom-up through nested primops" do
       let original =
             primBinOp
@@ -919,6 +933,33 @@ spec = describe "IR Optimizer" do
         (ifThenElse (literalBool True) (literalBool False) (literalBool True))
         `shouldBe` literalBool False
 
+  -- An if with exactly one boolean-literal branch is a boolean operator
+  -- in disguise; Lua's and/or short-circuit exactly like the branches
+  -- did, so the fold preserves what evaluates and in which order.
+  describe "collapses a half-literal boolean if to and/or (#203)" do
+    let p = primBinOp PrimLt (refLocal (Name "a")) (refLocal (Name "b"))
+        r = refLocal (Name "r")
+
+    it "reduces if p then True else r to p or r" do
+      optimizedExpression (ifThenElse p (literalBool True) r)
+        `shouldBe` primBinOp PrimOr p r
+
+    it "reduces if p then False else r to not p and r" do
+      optimizedExpression (ifThenElse p (literalBool False) r)
+        `shouldBe` primBinOp PrimAnd (primNot p) r
+
+    it "reduces if p then r else True to not p or r" do
+      optimizedExpression (ifThenElse p r (literalBool True))
+        `shouldBe` primBinOp PrimOr (primNot p) r
+
+    it "reduces if p then r else False to p and r" do
+      optimizedExpression (ifThenElse p r (literalBool False))
+        `shouldBe` primBinOp PrimAnd p r
+
+    it "leaves an if with no boolean-literal branch alone" do
+      let original = ifThenElse p r (refLocal (Name "s"))
+      optimizedExpression original `shouldBe` original
+
   -- Case-of-case over the IfThenElse decision tree: a boolean-returning
   -- tree consumed in a strict position (an Eq against a literal, or the
   -- condition of another if) sits in expression position, where codegen
@@ -942,6 +983,13 @@ spec = describe "IR Optimizer" do
 
     it "folds the flipped orientation of the comparison" do
       optimizedExpression (eq orderingTree lt) `shouldBe` isNeg
+
+    it "collapses a GT comparison to a flat boolean expression" do
+      -- Two leaves fold to False and one to True, so the collapsed tree
+      -- is a half-literal if; the and/or fold then flattens it, leaving
+      -- no decision tree in expression position at all.
+      optimizedExpression (eq gt orderingTree)
+        `shouldBe` primBinOp PrimAnd (primNot isNeg) (primNot isZero)
 
     it "leaves the comparison alone when a leaf cannot fold" do
       -- A non-literal leaf would survive as a residual comparison, so

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -32,6 +32,7 @@ import Language.PureScript.Backend.IR.Optimizer
   , optimizedExpression
   , optimizedUberModule
   , optimizedUberModuleChecked
+  , pushIfCondIntoBranches
   , shareForeignAccessors
   , sinkProjectionIntoLet
   )
@@ -917,6 +918,99 @@ spec = describe "IR Optimizer" do
       optimizedExpression
         (ifThenElse (literalBool True) (literalBool False) (literalBool True))
         `shouldBe` literalBool False
+
+  -- Case-of-case over the IfThenElse decision tree: a boolean-returning
+  -- tree consumed in a strict position (an Eq against a literal, or the
+  -- condition of another if) sits in expression position, where codegen
+  -- wraps it in an IIFE allocated per evaluation.
+  describe "pushes case-of-case over the decision tree (#203)" do
+    let m = moduleNameFromString "M"
+        n = refLocal (Name "n")
+        lt = literalString "Data.Ordering∷Ordering.LT"
+        eqTag = literalString "Data.Ordering∷Ordering.EQ"
+        gt = literalString "Data.Ordering∷Ordering.GT"
+        isNeg = primBinOp PrimLt n (literalInt 0)
+        isZero = eq n (literalInt 0)
+        -- The shape an inlined Ord comparison leaves once the tag read
+        -- distributes over it: an if-tree of Ordering tag strings.
+        orderingTree = ifThenElse isNeg lt (ifThenElse isZero eqTag gt)
+
+    it "folds a literal comparison through the decision tree" do
+      -- The Golden.LongCallbackChain shape: every leaf folds against the
+      -- literal, so the whole comparison collapses to a flat condition.
+      optimizedExpression (eq lt orderingTree) `shouldBe` isNeg
+
+    it "folds the flipped orientation of the comparison" do
+      optimizedExpression (eq orderingTree lt) `shouldBe` isNeg
+
+    it "leaves the comparison alone when a leaf cannot fold" do
+      -- A non-literal leaf would survive as a residual comparison, so
+      -- the push must decline entirely.
+      let original =
+            eq lt (ifThenElse isNeg lt (refLocal (Name "other")))
+      optimizedExpression original `shouldBe` original
+
+    it "pushes an if condition into branches when they are trivial" do
+      -- Non-literal inner branches: the push duplicates x and y, so it
+      -- fires only because both are trivial to re-emit.
+      let p = refLocal (Name "p")
+          q = refLocal (Name "q")
+          c = refLocal (Name "c")
+          original =
+            ifThenElse (ifThenElse c p q) (literalInt 1) (literalInt 2)
+      optimizedExpression original
+        `shouldBe` ifThenElse
+          c
+          (ifThenElse p (literalInt 1) (literalInt 2))
+          (ifThenElse q (literalInt 1) (literalInt 2))
+
+    it "keeps the if in condition position over non-trivial branches" do
+      -- Neither guard holds: the inner branches are not literals and
+      -- duplicating the outer branches would duplicate real work.
+      let p = refLocal (Name "p")
+          q = refLocal (Name "q")
+          c = refLocal (Name "c")
+          work name = application (refImported m name) (literalInt 1)
+          original =
+            ifThenElse
+              (ifThenElse c p q)
+              (work (Name "f"))
+              (work (Name "g"))
+      optimizedExpression original `shouldBe` original
+
+    -- The literal arm is unreachable through 'optimizedExpression': an
+    -- inner if with two literal boolean branches is collapsed bottom-up
+    -- by the boolean-if rules before the outer node is inspected. The
+    -- rule is applied directly so its own guard is pinned, not its
+    -- neighbours'.
+    it "pushes literal inner branches (direct rule application)" do
+      let c = refLocal (Name "c")
+          x = literalInt 1
+          y = literalInt 2
+          original =
+            ifThenElse
+              (ifThenElse c (literalBool True) (literalBool False))
+              x
+              y
+      runIdentity (pushIfCondIntoBranches original)
+        `shouldBe` Just
+          ( ifThenElse
+              c
+              (ifThenElse (literalBool True) x y)
+              (ifThenElse (literalBool False) x y)
+          )
+
+    it "declines non-trivial branches directly (guard pin)" do
+      let c = refLocal (Name "c")
+          p = refLocal (Name "p")
+          q = refLocal (Name "q")
+          work name = application (refImported m name) (literalInt 1)
+          original =
+            ifThenElse
+              (ifThenElse c p q)
+              (work (Name "f"))
+              (work (Name "g"))
+      runIdentity (pushIfCondIntoBranches original) `shouldBe` Nothing
 
   describe "inlines expressions" do
     test "inlines literals" do

--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -179,6 +179,9 @@ spec = do
                   , "--no-unused" -- TODO: harden eventually
                   , "--no-redefined" -- generated code shadows freely (e.g.
                   -- inlined library fallbacks reusing a parameter name)
+                  , "--ignore 581" -- suggests not (x < y) → x >= y, the
+                  -- NaN-unsafe inverse codegen deliberately never emits;
+                  -- not-over-comparison is the boolean-if folds' sound shape
                   , "--no-max-line-length"
                   , "--formatter plain"
                   , "--allow-defined"

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
@@ -377,12 +377,12 @@ UberModule
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
                                       ( Ref Nothing ( Local ( Name "$cse270" ) ) )
                                     )
-                                    ( IfThenElse Nothing
+                                    ( PrimBinOp Nothing PrimAnd
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                         ( Ref Nothing ( Local ( Name "$cse269" ) ) )
                                       )
-                                      ( IfThenElse Nothing
+                                      ( PrimBinOp Nothing PrimAnd
                                         ( Eq Nothing
                                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                           ( Ref Nothing ( Local ( Name "$cse270" ) ) )
@@ -470,8 +470,8 @@ UberModule
                                           ( DataArgumentByIndex Nothing SumType 0
                                             ( Ref Nothing ( Local ( Name "v1$14" ) ) ) :| []
                                           )
-                                        ) ( LiteralBool Nothing False )
-                                      ) ( LiteralBool Nothing False )
+                                        )
+                                      )
                                     )
                                   )
                                 )

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -99,22 +99,16 @@ Golden_BugListGenericEq_Test_eqList = function(dictEq)
             local _S_cse269 = v_S_13[1]
             if "Data.Generic.Rep∷Sum.Inl" == _S_cse269 then
               return "Data.Generic.Rep∷Sum.Inl" == _S_cse270
-            elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse269 then
-              if "Data.Generic.Rep∷Sum.Inr" == _S_cse270 then
-                return (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
-                  eqRecord = function()
-                    return function() return function() return true end end
-                  end
-                }, nil, {
-                  reflectSymbol = function() return "tail" end
-                }, Golden_BugListGenericEq_Test_eqList(dictEq)), nil, {
-                  reflectSymbol = function() return "head" end
-                }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_13[2])(v1_S_14[2])
-              else
-                return false
-              end
             else
-              return false
+              return "Data.Generic.Rep∷Sum.Inr" == _S_cse269 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse270 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
+                eqRecord = function()
+                  return function() return function() return true end end
+                end
+              }, nil, {
+                reflectSymbol = function() return "tail" end
+              }, Golden_BugListGenericEq_Test_eqList(dictEq)), nil, {
+                reflectSymbol = function() return "head" end
+              }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_13[2])(v1_S_14[2]))
             end
           end
         end)()((function()

--- a/test/ps/output/Golden.CharLiterals.Test/golden.ir
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.ir
@@ -118,16 +118,9 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "v$221", Eq Nothing
-                    ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                    ( IfThenElse Nothing
-                      ( PrimBinOp Nothing PrimLt
-                        ( LiteralChar Nothing '\x9' )
-                        ( LiteralChar Nothing ' ' )
-                      )
-                      ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                      ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                    )
+                  ( Nothing, Name "v$221", PrimBinOp Nothing PrimLt
+                    ( LiteralChar Nothing '\x9' )
+                    ( LiteralChar Nothing ' ' )
                   ) :| []
                 )
                 ( IfThenElse Nothing

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -29,13 +29,7 @@ return (function()
   local _ = Effect_Console_log(Golden_CharLiterals_Test_show("a"))()
   local _ = Effect_Console_log("true")()
   return Effect_Console_log((function()
-    local v_S_221 = "Data.Ordering∷Ordering.LT" == (function()
-      if "\t" < "\n" then
-        return "Data.Ordering∷Ordering.LT"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
-    end)()
+    local v_S_221 = "\t" < "\n"
     if v_S_221 then
       return "true"
     elseif false == v_S_221 then

--- a/test/ps/output/Golden.FieldCaching.Test/golden.ir
+++ b/test/ps/output/Golden.FieldCaching.Test/golden.ir
@@ -128,20 +128,9 @@ UberModule
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "n" ) :| [] )
         ( IfThenElse Nothing
-          ( Eq Nothing
-            ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-            ( IfThenElse Nothing
-              ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "n" ) ) )
-                ( LiteralInt Nothing 2 )
-              )
-              ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-              ( IfThenElse Nothing
-                ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 2 ) )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-              )
-            )
+          ( PrimBinOp Nothing PrimLt
+            ( Ref Nothing ( Local ( Name "n" ) ) )
+            ( LiteralInt Nothing 2 )
           )
           ( Ref Nothing ( Local ( Name "n" ) ) )
           ( PrimBinOp Nothing PrimAdd

--- a/test/ps/output/Golden.FieldCaching.Test/golden.lua
+++ b/test/ps/output/Golden.FieldCaching.Test/golden.lua
@@ -30,15 +30,7 @@ M.Golden_FieldCaching_Test_pair = function(n)
   return Golden_FieldCaching_Test_weigh(n) + Golden_FieldCaching_Test_weigh(n + 1)
 end
 M.Golden_FieldCaching_Test_fibby = function(n)
-  if "Data.Ordering∷Ordering.LT" == (function()
-    if n < 2 then
-      return "Data.Ordering∷Ordering.LT"
-    elseif n == 2 then
-      return "Data.Ordering∷Ordering.EQ"
-    else
-      return "Data.Ordering∷Ordering.GT"
-    end
-  end)() then
+  if n < 2 then
     return n
   else
     return Golden_FieldCaching_Test_weigh(Golden_FieldCaching_Test_sub_S_w(n, 1)) + Golden_FieldCaching_Test_weigh(Golden_FieldCaching_Test_sub_S_w(n, 2))

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
@@ -505,12 +505,12 @@ UberModule
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
                                       ( Ref Nothing ( Local ( Name "$cse301" ) ) )
                                     )
-                                    ( IfThenElse Nothing
+                                    ( PrimBinOp Nothing PrimAnd
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                         ( Ref Nothing ( Local ( Name "$cse300" ) ) )
                                       )
-                                      ( IfThenElse Nothing
+                                      ( PrimBinOp Nothing PrimAnd
                                         ( Eq Nothing
                                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                           ( Ref Nothing ( Local ( Name "$cse301" ) ) )
@@ -627,8 +627,8 @@ UberModule
                                           ( DataArgumentByIndex Nothing SumType 0
                                             ( Ref Nothing ( Local ( Name "v1$272" ) ) ) :| []
                                           )
-                                        ) ( LiteralBool Nothing False )
-                                      ) ( LiteralBool Nothing False )
+                                        )
+                                      )
                                     )
                                   )
                                 )
@@ -705,12 +705,12 @@ UberModule
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
                                       ( Ref Nothing ( Local ( Name "$cse303" ) ) )
                                     )
-                                    ( IfThenElse Nothing
+                                    ( PrimBinOp Nothing PrimAnd
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                         ( Ref Nothing ( Local ( Name "$cse302" ) ) )
                                       )
-                                      ( IfThenElse Nothing
+                                      ( PrimBinOp Nothing PrimAnd
                                         ( Eq Nothing
                                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
                                           ( Ref Nothing ( Local ( Name "$cse303" ) ) )
@@ -798,8 +798,8 @@ UberModule
                                           ( DataArgumentByIndex Nothing SumType 0
                                             ( Ref Nothing ( Local ( Name "v1$250" ) ) ) :| []
                                           )
-                                        ) ( LiteralBool Nothing False )
-                                      ) ( LiteralBool Nothing False )
+                                        )
+                                      )
                                     )
                                   )
                                 )

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -130,24 +130,18 @@ Golden_GenericEqTwoTypes_Test_eqTree = function(dictEq)
               local _S_cse300 = v_S_271[1]
               if "Data.Generic.Rep∷Sum.Inl" == _S_cse300 then
                 return "Data.Generic.Rep∷Sum.Inl" == _S_cse301
-              elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse300 then
-                if "Data.Generic.Rep∷Sum.Inr" == _S_cse301 then
-                  return (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
-                    eqRecord = function()
-                      return function() return function() return true end end
-                    end
-                  }, nil, {
-                    reflectSymbol = function() return "value" end
-                  }, dictEq), nil, {
-                    reflectSymbol = function() return "right" end
-                  }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq)), nil, {
-                    reflectSymbol = function() return "left" end
-                  }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq))).eqRecord(Type_Proxy_Proxy)(v_S_271[2])(v1_S_272[2])
-                else
-                  return false
-                end
               else
-                return false
+                return "Data.Generic.Rep∷Sum.Inr" == _S_cse300 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse301 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
+                  eqRecord = function()
+                    return function() return function() return true end end
+                  end
+                }, nil, {
+                  reflectSymbol = function() return "value" end
+                }, dictEq), nil, {
+                  reflectSymbol = function() return "right" end
+                }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq)), nil, {
+                  reflectSymbol = function() return "left" end
+                }, Golden_GenericEqTwoTypes_Test_eqTree(dictEq))).eqRecord(Type_Proxy_Proxy)(v_S_271[2])(v1_S_272[2]))
               end
             end
           end
@@ -169,22 +163,16 @@ Golden_GenericEqTwoTypes_Test_eqList = function(dictEq)
               local _S_cse302 = v_S_249[1]
               if "Data.Generic.Rep∷Sum.Inl" == _S_cse302 then
                 return "Data.Generic.Rep∷Sum.Inl" == _S_cse303
-              elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse302 then
-                if "Data.Generic.Rep∷Sum.Inr" == _S_cse303 then
-                  return (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
-                    eqRecord = function()
-                      return function() return function() return true end end
-                    end
-                  }, nil, {
-                    reflectSymbol = function() return "tail" end
-                  }, Golden_GenericEqTwoTypes_Test_eqList(dictEq)), nil, {
-                    reflectSymbol = function() return "head" end
-                  }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_249[2])(v1_S_250[2])
-                else
-                  return false
-                end
               else
-                return false
+                return "Data.Generic.Rep∷Sum.Inr" == _S_cse302 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse303 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
+                  eqRecord = function()
+                    return function() return function() return true end end
+                  end
+                }, nil, {
+                  reflectSymbol = function() return "tail" end
+                }, Golden_GenericEqTwoTypes_Test_eqList(dictEq)), nil, {
+                  reflectSymbol = function() return "head" end
+                }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_249[2])(v1_S_250[2]))
               end
             end
           end

--- a/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
+++ b/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
@@ -28,20 +28,9 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "n" ) :| [ ParamNamed Nothing ( Name "k" ) ] )
           ( IfThenElse Nothing
-            ( Eq Nothing
-              ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-              ( IfThenElse Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                )
-              )
+            ( PrimBinOp Nothing PrimLt
+              ( Ref Nothing ( Local ( Name "n" ) ) )
+              ( LiteralInt Nothing 0 )
             )
             ( AppN Nothing
               ( Ref Nothing

--- a/test/ps/output/Golden.LongCallbackChain.Test/golden.lua
+++ b/test/ps/output/Golden.LongCallbackChain.Test/golden.lua
@@ -8,15 +8,7 @@ local Golden_LongCallbackChain_Test_add_S_w = function(x_S_215, y_S_216)
 end
 local Golden_LongCallbackChain_Test_withInc_S_w = function(n, k)
   while true do
-    if "Data.Ordering∷Ordering.LT" == (function()
-      if n < 0 then
-        return "Data.Ordering∷Ordering.LT"
-      elseif n == 0 then
-        return "Data.Ordering∷Ordering.EQ"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
-    end)() then
+    if n < 0 then
       n, k = Golden_LongCallbackChain_Test_add_S_w(n, 1), k
     else
       return k(Golden_LongCallbackChain_Test_add_S_w(n, 1))

--- a/test/ps/output/Golden.Loopification.Test/golden.ir
+++ b/test/ps/output/Golden.Loopification.Test/golden.ir
@@ -174,11 +174,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
-            ( IfThenElse Nothing
-              ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "n" ) ) )
-                ( LiteralInt Nothing 100 )
-              ) ( LiteralBool Nothing False )
+            ( PrimBinOp Nothing PrimAnd
+              ( PrimNot Nothing
+                ( PrimBinOp Nothing PrimLt
+                  ( Ref Nothing ( Local ( Name "n" ) ) )
+                  ( LiteralInt Nothing 100 )
+                )
+              )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 100 ) )
               )
@@ -212,11 +214,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
-            ( IfThenElse Nothing
-              ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "n" ) ) )
-                ( LiteralInt Nothing 0 )
-              ) ( LiteralBool Nothing False )
+            ( PrimBinOp Nothing PrimAnd
+              ( PrimNot Nothing
+                ( PrimBinOp Nothing PrimLt
+                  ( Ref Nothing ( Local ( Name "n" ) ) )
+                  ( LiteralInt Nothing 0 )
+                )
+              )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
               )

--- a/test/ps/output/Golden.Loopification.Test/golden.ir
+++ b/test/ps/output/Golden.Loopification.Test/golden.ir
@@ -174,19 +174,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
-            ( Eq Nothing
-              ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-              ( IfThenElse Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 100 )
-                )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 100 ) )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                )
+            ( IfThenElse Nothing
+              ( PrimBinOp Nothing PrimLt
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 100 )
+              ) ( LiteralBool Nothing False )
+              ( PrimNot Nothing
+                ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 100 ) )
               )
             )
             ( AppN Nothing
@@ -218,19 +212,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
-            ( Eq Nothing
-              ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-              ( IfThenElse Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                )
+            ( IfThenElse Nothing
+              ( PrimBinOp Nothing PrimLt
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
+              ) ( LiteralBool Nothing False )
+              ( PrimNot Nothing
+                ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
               )
             )
             ( AppN Nothing

--- a/test/ps/output/Golden.Loopification.Test/golden.lua
+++ b/test/ps/output/Golden.Loopification.Test/golden.lua
@@ -53,14 +53,8 @@ end
 local Golden_Loopification_Test_mc91
 Golden_Loopification_Test_mc91 = function(n)
   while true do
-    if "Data.Ordering∷Ordering.GT" == (function()
-      if n < 100 then
-        return "Data.Ordering∷Ordering.LT"
-      elseif n == 100 then
-        return "Data.Ordering∷Ordering.EQ"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
+    if (function()
+      if n < 100 then return false else return n ~= 100 end
     end)() then
       return Golden_Loopification_Test_sub_S_w(n, 10)
     else
@@ -70,15 +64,7 @@ Golden_Loopification_Test_mc91 = function(n)
 end
 local Golden_Loopification_Test_countdown = function(n)
   while true do
-    if "Data.Ordering∷Ordering.GT" == (function()
-      if n < 0 then
-        return "Data.Ordering∷Ordering.LT"
-      elseif n == 0 then
-        return "Data.Ordering∷Ordering.EQ"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
-    end)() then
+    if (function() if n < 0 then return false else return n ~= 0 end end)() then
       n = Golden_Loopification_Test_sub_S_w(n, 1)
     else
       return 0

--- a/test/ps/output/Golden.Loopification.Test/golden.lua
+++ b/test/ps/output/Golden.Loopification.Test/golden.lua
@@ -53,9 +53,7 @@ end
 local Golden_Loopification_Test_mc91
 Golden_Loopification_Test_mc91 = function(n)
   while true do
-    if (function()
-      if n < 100 then return false else return n ~= 100 end
-    end)() then
+    if not(n < 100) and n ~= 100 then
       return Golden_Loopification_Test_sub_S_w(n, 10)
     else
       n = Golden_Loopification_Test_mc91(n + 11)
@@ -64,7 +62,7 @@ Golden_Loopification_Test_mc91 = function(n)
 end
 local Golden_Loopification_Test_countdown = function(n)
   while true do
-    if (function() if n < 0 then return false else return n ~= 0 end end)() then
+    if not(n < 0) and n ~= 0 then
       n = Golden_Loopification_Test_sub_S_w(n, 1)
     else
       return 0

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -106,19 +106,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "acc" ) :| [ ParamNamed Nothing ( Name "n" ) ] )
           ( IfThenElse Nothing
-            ( Eq Nothing
-              ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-              ( IfThenElse Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
-                ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                )
+            ( IfThenElse Nothing
+              ( PrimBinOp Nothing PrimLt
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
+              ) ( LiteralBool Nothing False )
+              ( PrimNot Nothing
+                ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
               )
             )
             ( AppN Nothing

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -106,11 +106,13 @@ UberModule
           }, AbsN Nothing
           ( ParamNamed Nothing ( Name "acc" ) :| [ ParamNamed Nothing ( Name "n" ) ] )
           ( IfThenElse Nothing
-            ( IfThenElse Nothing
-              ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "n" ) ) )
-                ( LiteralInt Nothing 0 )
-              ) ( LiteralBool Nothing False )
+            ( PrimBinOp Nothing PrimAnd
+              ( PrimNot Nothing
+                ( PrimBinOp Nothing PrimLt
+                  ( Ref Nothing ( Local ( Name "n" ) ) )
+                  ( LiteralInt Nothing 0 )
+                )
+              )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
               )

--- a/test/ps/output/Golden.Primops.Test/golden.lua
+++ b/test/ps/output/Golden.Primops.Test/golden.lua
@@ -26,15 +26,7 @@ local Effect_Console_logShow_S_w = function(dictShow, a)
 end
 local Golden_Primops_Test_sumTo_S_w = function(acc, n)
   while true do
-    if "Data.Ordering∷Ordering.GT" == (function()
-      if n < 0 then
-        return "Data.Ordering∷Ordering.LT"
-      elseif n == 0 then
-        return "Data.Ordering∷Ordering.EQ"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
-    end)() then
+    if (function() if n < 0 then return false else return n ~= 0 end end)() then
       acc, n = acc + n, n - 1
     else
       return acc

--- a/test/ps/output/Golden.Primops.Test/golden.lua
+++ b/test/ps/output/Golden.Primops.Test/golden.lua
@@ -26,11 +26,7 @@ local Effect_Console_logShow_S_w = function(dictShow, a)
 end
 local Golden_Primops_Test_sumTo_S_w = function(acc, n)
   while true do
-    if (function() if n < 0 then return false else return n ~= 0 end end)() then
-      acc, n = acc + n, n - 1
-    else
-      return acc
-    end
+    if not(n < 0) and n ~= 0 then acc, n = acc + n, n - 1 else return acc end
   end
 end
 M.Golden_Primops_Test_sumTo = function(sumTo_S_p1)

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.ir
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.ir
@@ -1204,16 +1204,18 @@ UberModule
                                 ( Ref Nothing ( Local ( Name "v2$1518" ) ) )
                               ) :| []
                             )
-                            ( IfThenElse Nothing
+                            ( PrimBinOp Nothing PrimOr
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
                                 ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
-                              ) ( LiteralBool Nothing True )
-                              ( IfThenElse Nothing
-                                ( Eq Nothing
-                                  ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                  ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
-                                ) ( LiteralBool Nothing False )
+                              )
+                              ( PrimBinOp Nothing PrimAnd
+                                ( PrimNot Nothing
+                                  ( Eq Nothing
+                                    ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
+                                    ( Ref Nothing ( Local ( Name "$cse1761" ) ) )
+                                  )
+                                )
                                 ( Exception Nothing "No patterns matched" )
                               )
                             )

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -472,13 +472,7 @@ end
 local Data_String_CodePoints_toCodePointArray = Data_String_CodePoints_foreign._toCodePointArray(function( s_S_7 )
   return Data_Unfoldable_foreign.unfoldrArrayImpl(function(v2_S_1518)
     local _S_cse1761 = v2_S_1518[1]
-    if "Data.Maybe∷Maybe.Nothing" == _S_cse1761 then
-      return true
-    elseif "Data.Maybe∷Maybe.Just" == _S_cse1761 then
-      return false
-    else
-      return error("No patterns matched")
-    end
+    return "Data.Maybe∷Maybe.Nothing" == _S_cse1761 or "Data.Maybe∷Maybe.Just" ~= _S_cse1761 and error("No patterns matched")
   end)(Partial_Unsafe__unsafePartial(function()
     return function(v_S_1564)
       if "Data.Maybe∷Maybe.Just" == v_S_1564[1] then

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
@@ -297,23 +297,9 @@ UberModule
                           ) :| []
                         )
                         ( IfThenElse Nothing
-                          ( Eq Nothing
-                            ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                            ( IfThenElse Nothing
-                              ( PrimBinOp Nothing PrimLt
-                                ( Ref Nothing ( Local ( Name "$cse509" ) ) )
-                                ( Ref Nothing ( Local ( Name "n" ) ) )
-                              )
-                              ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                              ( IfThenElse Nothing
-                                ( Eq Nothing
-                                  ( Ref Nothing ( Local ( Name "$cse509" ) ) )
-                                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                                )
-                                ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                                ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                              )
-                            )
+                          ( PrimBinOp Nothing PrimLt
+                            ( Ref Nothing ( Local ( Name "$cse509" ) ) )
+                            ( Ref Nothing ( Local ( Name "n" ) ) )
                           )
                           ( AppN Nothing
                             ( Ref Nothing ( Local ( Name "pure" ) ) )
@@ -687,23 +673,9 @@ UberModule
                                       ) :| []
                                     )
                                     ( IfThenElse Nothing
-                                      ( Eq Nothing
-                                        ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                                        ( IfThenElse Nothing
-                                          ( PrimBinOp Nothing PrimLt
-                                            ( Ref Nothing ( Local ( Name "$cse511" ) ) )
-                                            ( Ref Nothing ( Local ( Name "n$506" ) ) )
-                                          )
-                                          ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                                          ( IfThenElse Nothing
-                                            ( Eq Nothing
-                                              ( Ref Nothing ( Local ( Name "$cse511" ) ) )
-                                              ( Ref Nothing ( Local ( Name "n$506" ) ) )
-                                            )
-                                            ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                                            ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                                          )
-                                        )
+                                      ( PrimBinOp Nothing PrimLt
+                                        ( Ref Nothing ( Local ( Name "$cse511" ) ) )
+                                        ( Ref Nothing ( Local ( Name "n$506" ) ) )
                                       )
                                       ( AppN Nothing
                                         ( Ref Nothing ( Local ( Name "pure$504" ) ) )

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.lua
@@ -91,15 +91,7 @@ M.Golden_TailRecM2Shadow_Test_sumFrom = function(dictMonadRec)
       return dictMonadRec.tailRecM(function(o_S_480)
         local _S_cse510 = o_S_480.a
         local _S_cse509 = o_S_480.b
-        if "Data.Ordering∷Ordering.LT" == (function()
-          if _S_cse509 < n then
-            return "Data.Ordering∷Ordering.LT"
-          elseif _S_cse509 == n then
-            return "Data.Ordering∷Ordering.EQ"
-          else
-            return "Data.Ordering∷Ordering.GT"
-          end
-        end)() then
+        if _S_cse509 < n then
           return pure((function(value0)
             return { "Control.Monad.Rec.Class∷Step.Loop", value0 }
           end)({
@@ -158,15 +150,7 @@ return (function()
         return dictMonadRec_S_503.tailRecM(function(o_S_507)
           local _S_cse512 = o_S_507.a
           local _S_cse511 = o_S_507.b
-          if "Data.Ordering∷Ordering.LT" == (function()
-            if _S_cse511 < n_S_506 then
-              return "Data.Ordering∷Ordering.LT"
-            elseif _S_cse511 == n_S_506 then
-              return "Data.Ordering∷Ordering.EQ"
-            else
-              return "Data.Ordering∷Ordering.GT"
-            end
-          end)() then
+          if _S_cse511 < n_S_506 then
             return pure_S_504((function(value0)
               return { "Control.Monad.Rec.Class∷Step.Loop", value0 }
             end)({

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.ir
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.ir
@@ -125,22 +125,13 @@ UberModule
             )
             ( AppN Nothing
               ( IfThenElse Nothing
-                ( Eq Nothing
-                  ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                  ( IfThenElse Nothing
-                    ( PrimBinOp Nothing PrimLt
-                      ( Ref Nothing ( Local ( Name "n" ) ) )
-                      ( LiteralInt Nothing 1 )
-                    )
-                    ( LiteralString Nothing "Data.Ordering∷Ordering.LT" )
-                    ( IfThenElse Nothing
-                      ( Eq Nothing
-                        ( Ref Nothing ( Local ( Name "n" ) ) )
-                        ( LiteralInt Nothing 1 )
-                      )
-                      ( LiteralString Nothing "Data.Ordering∷Ordering.EQ" )
-                      ( LiteralString Nothing "Data.Ordering∷Ordering.GT" )
-                    )
+                ( IfThenElse Nothing
+                  ( PrimBinOp Nothing PrimLt
+                    ( Ref Nothing ( Local ( Name "n" ) ) )
+                    ( LiteralInt Nothing 1 )
+                  ) ( LiteralBool Nothing False )
+                  ( PrimNot Nothing
+                    ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 1 ) )
                   )
                 )
                 ( AppN Nothing

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.ir
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.ir
@@ -125,11 +125,13 @@ UberModule
             )
             ( AppN Nothing
               ( IfThenElse Nothing
-                ( IfThenElse Nothing
-                  ( PrimBinOp Nothing PrimLt
-                    ( Ref Nothing ( Local ( Name "n" ) ) )
-                    ( LiteralInt Nothing 1 )
-                  ) ( LiteralBool Nothing False )
+                ( PrimBinOp Nothing PrimAnd
+                  ( PrimNot Nothing
+                    ( PrimBinOp Nothing PrimLt
+                      ( Ref Nothing ( Local ( Name "n" ) ) )
+                      ( LiteralInt Nothing 1 )
+                    )
+                  )
                   ( PrimNot Nothing
                     ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 1 ) )
                   )

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.lua
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.lua
@@ -21,7 +21,7 @@ local Golden_UncurryEffect_Test_countdown_S_w = function(n)
     return Effect_Console_log(Data_Show_showIntImpl(n))()
   end)()
   return (function()
-    if (function() if n < 1 then return false else return n ~= 1 end end)() then
+    if not(n < 1) and n ~= 1 then
       return Golden_UncurryEffect_Test_countdown(n - 1)
     else
       return Effect_Console_log("done")

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.lua
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.lua
@@ -21,15 +21,7 @@ local Golden_UncurryEffect_Test_countdown_S_w = function(n)
     return Effect_Console_log(Data_Show_showIntImpl(n))()
   end)()
   return (function()
-    if "Data.Ordering∷Ordering.GT" == (function()
-      if n < 1 then
-        return "Data.Ordering∷Ordering.LT"
-      elseif n == 1 then
-        return "Data.Ordering∷Ordering.EQ"
-      else
-        return "Data.Ordering∷Ordering.GT"
-      end
-    end)() then
+    if (function() if n < 1 then return false else return n ~= 1 end end)() then
       return Golden_UncurryEffect_Test_countdown(n - 1)
     else
       return Effect_Console_log("done")


### PR DESCRIPTION
Closes #203.

## Problem

The IR compiles pattern matches to decision trees of nested `IfThenElse`. When such a tree is consumed in a strict position it sits in expression position, and codegen wraps it in an IIFE that is allocated and called on every evaluation. For the recursive functions in `Golden.LongCallbackChain` and `Golden.TailRecM2Shadow` that means on every loop iteration.

The issue predates #180, when the tree sat directly in the condition of another if. Today the dominant shape is different: the tag-read distribution rewrites `ReflectCtor` over an `Ordering` tree into an if-tree of tag strings, so the condition holds `Eq "…LT" (IfThenElse …)`. Seven goldens carried this shape.

## Approach

Three rewrites of the same case-of-case family, all in the shared rewrite chain of `optimizedExpressionM`.

`pushEqIntoIfBranches` distributes a scalar literal compared against an if-tree into its branches: `Eq lit (If c t e)` becomes `If c (Eq lit t) (Eq lit e)`, in both orientations. The guard, `eqFoldsThrough`, mirrors `reflectFoldsThrough` from the tag-read distribution: the rule fires only when every leaf of the tree constant-folds against the literal. No residual comparison can survive, and the only duplicated operand is a scalar literal. The folded leaves then meet `constantFolding` and the boolean-if rules, which collapse the whole condition to a flat comparison.

`pushIfCondIntoBranches` is the transformation as stated in the issue: `IfThenElse (IfThenElse c a b) x y` becomes `IfThenElse c (IfThenElse a x y) (IfThenElse b x y)`, with the issue's guard. Either the inner branches are boolean literals, in which case the residual ifs fold right away and each outer branch survives in exactly one copy, or the outer branches are trivial by `isInlinableValue`. Trivial values are binder-free, so the copies cannot violate GUC. Evaluation order is preserved exactly: `c`, then `a` or `b`, then `x` or `y`.

`reduceBooleanIf` gains the four half-literal cases next to its existing two-literal collapses: `if p then True else b` becomes `p or b`, `if p then False else b` becomes `not p and b`, and the mirrored shapes likewise. The non-literal branch is a `Bool` too, pinned by the literal (Note [IR is assumed well-typed]), and Lua's `and`/`or` evaluate exactly what the branches evaluated, in the same order, but survive in condition position without an IIFE. This is what a pushed `GT` comparison collapses to when two leaves fold to `False`: `if n < 0 then false else n ~= 0`, which now flattens to `not (n < 0) and n ~= 0`.

Two supporting changes ride along. The scalar-literal `Eq` cases of `constantFolding` are factored into `foldEqLiterals` and shared with the `eqFoldsThrough` guard, so the guard and the fold cannot drift apart. And `foldPrimBinOp` gains the identity folds `a and true` → `a` and `a or false` → `a`: an early and/or fold can catch a branch whose literal only appears after a later inlining round, and without the identities that ceremony survives to the output. The annihilator duals (`a and false`, `a or true`) stay unfolded, since collapsing them would skip evaluating `a`.

## Verification

Unit tests pin all three rewrites. The LongCallbackChain microcosm folds to a flat comparison end to end (both orientations) and the GT microcosm to a flat boolean expression, a non-foldable leaf declines, trivial outer branches push while non-trivial ones stay put, each half-literal shape folds to its operator while an if with no literal branch stays, and the literal-branches arm of the condition push is exercised by direct rule application. That arm is unreachable through `optimizedExpression`, where `reduceBooleanIf` collapses two-literal inner ifs bottom-up before the outer node is inspected.

Ten goldens change, `.ir` and `.lua` only. The condition becomes a flat comparison in `CharLiterals`, `FieldCaching`, `LongCallbackChain` and `TailRecM2Shadow`: `if n < 0 then` instead of `if "…LT" == (function() … end)() then`. The `GT` comparisons in `Loopification`, `Primops` and `UncurryEffect` flatten to `not (n < 0) and n ~= 0`. The generic-equality chains in `BugListGenericEq`, `GenericEqTwoTypes` and `StringCodePoints` collapse their boolean elseif ladders into and/or chains.

Eval goldens are byte-identical. The full suite passes clean and across four extra Hedgehog seeds.

The golden luacheck run now ignores W581, which suggests rewriting `not (x < y)` to `x >= y`. That flip is the NaN-unsafe inverse codegen deliberately never emits (the printer negates `==` to `~=` because it is exact, and keeps `not` over `<` for the same reason), so the warning has no actionable fix.
