### PR TITLE
Dissolve small pure workers into saturated call sites (#211)

### DIFF
--- a/changelog.d/20260716_150000_unisay_small_pure_worker_inline.md
+++ b/changelog.d/20260716_150000_unisay_small_pure_worker_inline.md
@@ -1,0 +1,12 @@
+### Changed
+
+- Small pure workers now dissolve into their saturated call sites (#211),
+  generalizing the bare-primop unfolding of #281: a worker body that is a
+  tree of primops, equality tests and negations over parameter references,
+  scalar literals and cheap projection chains — possibly under a nested
+  lambda — is pasted at every saturated n-ary call site, bounded by the
+  small-inline budget. A shared helper such as `add3 x y z = x + y + z` or
+  `first x _ = x` no longer costs a Lua call per use: sites fold to the
+  inline expression and constant arguments fold further at compile time
+  (`add3 1 2 3` emits `6`). Workers whose bodies apply a function, branch,
+  or exceed the budget keep sharing, as do all value-position uses.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -1620,7 +1620,7 @@ inlineSaturatedCall policy env expr = case expr of
     , Nothing ← directedArity fname
     , Just rhs@(AbsN _ params body) ← Map.lookup fname env
     , length args == length params
-    , expSize rhs <= smallInlineBudget
+    , expSize rhs < smallInlineBudget
     , isCheapWorkerBody body
     , countFreeRef fname rhs == 0 →
         (\rhs' → Just (AppN ann rhs' args)) <$> freshenBinders rhs
@@ -1657,13 +1657,13 @@ saturated call site: a tree of arithmetic, comparison, equality and
 negation nodes over leaves 'complexityOf' classifies at most 'Deref' —
 references (in practice the worker's parameters), scalar-sized
 literals, and cheap-read chains over them, all free to re-evaluate —
-possibly under nested abstractions (an inner lambda pasted at the site
-allocates exactly the closure the worker's own body allocated per
-call). Such a body pastes to an inline operator expression: no work is
-duplicated and no allocation introduced, so 'inlineSaturatedCall'
-unfolds it at every saturated n-ary call site regardless of use count
-(issues #281, #211), with code growth bounded by 'smallInlineBudget'
-at the call site.
+possibly under nested abstractions. Such a body pastes to an inline
+operator expression that duplicates no work and allocates nothing
+beyond what the worker call already performed (an inner lambda pasted
+at the site is exactly the closure the worker's own body allocated per
+call), so 'inlineSaturatedCall' unfolds it at every saturated n-ary
+call site regardless of use count (issues #281, #211), with code
+growth bounded by 'smallInlineBudget' at the call site.
 
 'IfThenElse' is deliberately not admitted: a decision tree pasted into
 expression position lowers to a per-call IIFE — the allocation the

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -769,9 +769,10 @@ collapse.
 inlineSizeBudget ∷ Natural
 inlineSizeBudget = 64
 
-{- | The largest expression the Deref and KnownSize inlining tiers paste
-(Note [Complexity and Capture gate inlining]), sized in IR nodes like
-'inlineSizeBudget' but far below it: these tiers admit duplication at
+{- | The largest expression the Deref and KnownSize inlining tiers and
+the cheap-worker unfolding ('isCheapWorkerBody') paste (Note
+[Complexity and Capture gate inlining]), sized in IR nodes like
+'inlineSizeBudget' but far below it: these admissions duplicate at
 every use site, so growth scales with the use count.
 -}
 smallInlineBudget ∷ Natural
@@ -1601,15 +1602,16 @@ directive pins the binding as a shared reference at partial sites.
 
 An n-ary call — the direct worker call the uncurry split mints — is not
 a unary spine, so 'unwindApp' leaves it whole and the paths above never
-see it. Most workers are meant to stay shared bindings, but a worker
-whose body is a bare primop over trivial operands (the residue of a
-floated dictionary application like @add = Data.Semiring.add
-semiringInt@, resolved through the lifted foreign) makes the call itself
-the whole cost: pasting is the cheapest possible unfolding and folds
-each site to the inline operator (issue #281). The n-ary 'AbsN' root is
-pasted under the original 'AppN' node — never rebuilt as a unary spine,
-which would leave an under-applied redex ('pasteableRoot') — so the
-exact-arity 'betaReduce' consumes it in the same pass.
+see it. Most workers are meant to stay shared bindings, but a small
+worker whose body is cheap to duplicate ('isCheapWorkerBody' under
+'smallInlineBudget' — the residue of a floated dictionary application
+like @add = Data.Semiring.add semiringInt@, resolved through the lifted
+foreign, or a tiny helper purs shares because its operator occurs more
+than once) makes the call itself the whole cost: pasting folds each
+site to the inline expression (issues #281, #211). The n-ary 'AbsN'
+root is pasted under the original 'AppN' node — never rebuilt as a
+unary spine, which would leave an under-applied redex ('pasteableRoot')
+— so the exact-arity 'betaReduce' consumes it in the same pass.
 -}
 inlineSaturatedCall ∷ InlinePolicy → InlineEnv → RewriteRuleM SupplyM Ann
 inlineSaturatedCall policy env expr = case expr of
@@ -1618,7 +1620,8 @@ inlineSaturatedCall policy env expr = case expr of
     , Nothing ← directedArity fname
     , Just rhs@(AbsN _ params body) ← Map.lookup fname env
     , length args == length params
-    , isBarePrimOpBody body
+    , expSize rhs <= smallInlineBudget
+    , isCheapWorkerBody body
     , countFreeRef fname rhs == 0 →
         (\rhs' → Just (AppN ann rhs' args)) <$> freshenBinders rhs
   (unwindApp → (Ref _ fname, args))
@@ -1649,23 +1652,35 @@ inlineSaturatedCall policy env expr = case expr of
   directedArity ∷ Qualified Name → Maybe Natural
   directedArity fname = refQName fname >>= (`Map.lookup` policyArity policy)
 
-{- | Whether a worker body is a bare primop — a single arithmetic,
-comparison, equality or negated-equality node whose operands
-'complexityOf' classifies 'Trivial': references (in practice the
-worker's parameters) and scalar-sized literals, all free to re-emit.
-Such a body is the cheapest possible paste: no work can be duplicated
-and no allocation introduced, so 'inlineSaturatedCall' unfolds it at
-every saturated n-ary call site regardless of use count (issue #281).
+{- | Whether a worker body is cheap enough to duplicate at every
+saturated call site: a tree of arithmetic, comparison, equality and
+negation nodes over leaves 'complexityOf' classifies at most 'Deref' —
+references (in practice the worker's parameters), scalar-sized
+literals, and cheap-read chains over them, all free to re-evaluate —
+possibly under nested abstractions (an inner lambda pasted at the site
+allocates exactly the closure the worker's own body allocated per
+call). Such a body pastes to an inline operator expression: no work is
+duplicated and no allocation introduced, so 'inlineSaturatedCall'
+unfolds it at every saturated n-ary call site regardless of use count
+(issues #281, #211), with code growth bounded by 'smallInlineBudget'
+at the call site.
+
+'IfThenElse' is deliberately not admitted: a decision tree pasted into
+expression position lowers to a per-call IIFE — the allocation the
+case-of-case rules of issue #203 exist to remove — worse than the
+shared worker call it would replace. An application may hide arbitrary
+work and the allocating shapes (constructors, non-empty literals,
+'Let') price above 'Deref', so all of them decline through the
+'complexityOf' fallback, conservative for unlisted node kinds by
+construction.
 -}
-isBarePrimOpBody ∷ RawExp ann → Bool
-isBarePrimOpBody = \case
-  PrimBinOp _ _ a b → isTrivialOperand a && isTrivialOperand b
-  Eq _ a b → isTrivialOperand a && isTrivialOperand b
-  PrimNot _ e → isBarePrimOpBody e
-  _ → False
- where
-  isTrivialOperand ∷ RawExp ann → Bool
-  isTrivialOperand = (== Trivial) . complexityOf
+isCheapWorkerBody ∷ RawExp ann → Bool
+isCheapWorkerBody = \case
+  PrimBinOp _ _ a b → isCheapWorkerBody a && isCheapWorkerBody b
+  Eq _ a b → isCheapWorkerBody a && isCheapWorkerBody b
+  PrimNot _ e → isCheapWorkerBody e
+  AbsN _ _params body → isCheapWorkerBody body
+  leaf → complexityOf leaf <= Deref
 
 -- | Re-apply the arguments 'unwindApp' peeled, as a unary spine.
 rebuildSpine ∷ [Exp] → Exp → Exp

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -63,6 +63,7 @@ import Language.PureScript.Backend.IR.Types
   , ifThenElse
   , isLiteral
   , lets
+  , listGrouping
   , literalBool
   , literalFloat
   , literalInt
@@ -1614,6 +1615,151 @@ spec = describe "IR Optimizer" do
         `shouldBe` [ (Name "main1", primBinOp PrimAdd n1 n2)
                    , (Name "main2", primBinOp PrimAdd n2 n1)
                    ]
+
+  describe "dissolves small pure workers into saturated call sites (#211)" do
+    let mainModule = moduleNameFromString "Main"
+        extern = moduleNameFromString "Extern"
+        n1 = refImported extern (Name "n1")
+        n2 = refImported extern (Name "n2")
+        n3 = refImported extern (Name "n3")
+        x = Name "x"
+        y = Name "y"
+        checked = either (fail . show) pure . optimizedUberModuleChecked
+        uberWith name def sites =
+          Linker.UberModule
+            { uberModuleForeigns = []
+            , uberModuleBindings = [Standalone (QName mainModule name, def)]
+            , uberModuleExports =
+                [(Name ("main" <> show i), site) | (i, site) ← zip [1 ∷ Int ..] sites]
+            }
+        topLevelNames uber =
+          fst <$> (listGrouping =<< Linker.uberModuleBindings uber)
+
+    it "folds a nested primop tree into every saturated call site" do
+      -- add3 = λx. λy. λz. (x + y) + z: the nested left operand is not
+      -- Trivial, so the bare-primop rule (#281) declined it and every
+      -- call paid for the shared worker.
+      let z = Name "z"
+          add3Ref = refImported mainModule (Name "add3")
+          add3Def =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                abstraction (paramNamed z) $
+                  primBinOp
+                    PrimAdd
+                    (primBinOp PrimAdd (refLocal x) (refLocal y))
+                    (refLocal z)
+          saturated a b = application (application (application add3Ref a) b)
+      optimized ←
+        checked $
+          uberWith (Name "add3") add3Def [saturated n1 n2 n3, saturated n3 n2 n1]
+      Linker.uberModuleBindings optimized `shouldBe` []
+      Linker.uberModuleExports optimized
+        `shouldBe` [ (Name "main1", primBinOp PrimAdd (primBinOp PrimAdd n1 n2) n3)
+                   , (Name "main2", primBinOp PrimAdd (primBinOp PrimAdd n3 n2) n1)
+                   ]
+
+    it "folds a parameter-selecting worker (no operator at all)" do
+      -- first = λx. λy. x: the body is a bare reference — not a primop,
+      -- so the #281 rule never saw it.
+      let firstRef = refImported mainModule (Name "first")
+          firstDef =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                refLocal x
+          saturated a = application (application firstRef a)
+      optimized ←
+        checked $
+          uberWith (Name "first") firstDef [saturated n1 n2, saturated n2 n1]
+      Linker.uberModuleBindings optimized `shouldBe` []
+      Linker.uberModuleExports optimized
+        `shouldBe` [(Name "main1", n1), (Name "main2", n2)]
+
+    it "admits projection-chain operands (Deref leaves)" do
+      -- addFields = λx. λy. x.foo + y.bar: record and module tables are
+      -- write-once, so re-reading a field at the paste site duplicates
+      -- no work.
+      let addFieldsRef = refImported mainModule (Name "addFields")
+          addFieldsDef =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                primBinOp
+                  PrimAdd
+                  (objectProp (refLocal x) (PropName "foo"))
+                  (objectProp (refLocal y) (PropName "bar"))
+          saturated a = application (application addFieldsRef a)
+      optimized ←
+        checked $
+          uberWith
+            (Name "addFields")
+            addFieldsDef
+            [saturated n1 n2, saturated n2 n1]
+      Linker.uberModuleBindings optimized `shouldBe` []
+      Linker.uberModuleExports optimized
+        `shouldBe` [
+                     ( Name "main1"
+                     , primBinOp
+                         PrimAdd
+                         (objectProp n1 (PropName "foo"))
+                         (objectProp n2 (PropName "bar"))
+                     )
+                   ,
+                     ( Name "main2"
+                     , primBinOp
+                         PrimAdd
+                         (objectProp n2 (PropName "foo"))
+                         (objectProp n1 (PropName "bar"))
+                     )
+                   ]
+
+    it "keeps a worker whose body applies a function" do
+      -- callAdd = λx. λy. g (x + y): an application may hide arbitrary
+      -- work, so the call sites keep sharing the worker.
+      let g = refImported extern (Name "g")
+          callAddRef = refImported mainModule (Name "callAdd")
+          callAddDef =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                application
+                  g
+                  (primBinOp PrimAdd (refLocal x) (refLocal y))
+          saturated a = application (application callAddRef a)
+      optimized ←
+        checked $
+          uberWith (Name "callAdd") callAddDef [saturated n1 n2, saturated n2 n1]
+      topLevelNames optimized `shouldBe` [QName mainModule (Name "callAdd$w")]
+
+    it "keeps a worker whose body branches" do
+      -- pickOr = λx. λy. if x then y else 0: an IfThenElse pasted into
+      -- expression position lowers to a per-call IIFE (issue #203) —
+      -- worse than the shared worker call it would replace.
+      let pickOrRef = refImported mainModule (Name "pickOr")
+          pickOrDef =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                ifThenElse (refLocal x) (refLocal y) (literalInt 0)
+          saturated a = application (application pickOrRef a)
+      optimized ←
+        checked $
+          uberWith (Name "pickOr") pickOrDef [saturated n1 n2, saturated n2 n1]
+      topLevelNames optimized `shouldBe` [QName mainModule (Name "pickOr$w")]
+
+    it "keeps a worker whose primop tree exceeds the small budget" do
+      -- Same shape as add3, but grown past 'smallInlineBudget': pasting
+      -- it at every site trades one call for unbounded code growth.
+      let wideRef = refImported mainModule (Name "wide")
+          wideDef =
+            abstraction (paramNamed x) $
+              abstraction (paramNamed y) $
+                foldl'
+                  (primBinOp PrimAdd)
+                  (refLocal x)
+                  (concat (replicate 8 [refLocal y, refLocal x]))
+          saturated a = application (application wideRef a)
+      optimized ←
+        checked $
+          uberWith (Name "wide") wideDef [saturated n1 n2, saturated n2 n1]
+      topLevelNames optimized `shouldBe` [QName mainModule (Name "wide$w")]
 
   describe "honours @inline arity=N directives (issue #232)" do
     let mainModule = moduleNameFromString "Main"

--- a/test/ps/output/Golden.Unbinding.Test/golden.ir
+++ b/test/ps/output/Golden.Unbinding.Test/golden.ir
@@ -1,37 +1,12 @@
 UberModule
-  { uberModuleBindings =
-    [ Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.Unbinding.Test", qnameName = Name "f$w"
-        }, AbsN Nothing
-        ( ParamUnused Nothing :| [ ParamUnused Nothing ] )
-        ( LiteralInt Nothing 3 )
-      )
-    ], uberModuleForeigns = [], uberModuleExports =
+  { uberModuleBindings = [], uberModuleForeigns = [], uberModuleExports =
     [
       ( Name "a", LiteralInt Nothing 1 ),
       ( Name "b", LiteralInt Nothing 2 ),
       ( Name "f", AbsN Nothing
-        ( ParamNamed Nothing ( Name "f$p1$0" ) :| [] )
-        ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "f$p2$1" ) :| [] )
-          ( AppN Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Golden.Unbinding.Test" ) ( Name "f$w" ) ) )
-            ( Ref Nothing
-              ( Local ( Name "f$p1$0" ) ) :|
-              [ Ref Nothing ( Local ( Name "f$p2$1" ) ) ]
-            )
-          )
-        )
+        ( ParamUnused Nothing :| [] )
+        ( AbsN Nothing ( ParamUnused Nothing :| [] ) ( LiteralInt Nothing 3 ) )
       ),
-      ( Name "c", AppN Nothing
-        ( Ref Nothing ( Imported ( ModuleName "Golden.Unbinding.Test" ) ( Name "f$w" ) ) )
-        ( LiteralInt Nothing 1 :|
-          [ AppN Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Golden.Unbinding.Test" ) ( Name "f$w" ) ) )
-            ( LiteralInt Nothing 2 :| [ LiteralInt Nothing 1 ] )
-          ]
-        )
-      )
+      ( Name "c", LiteralInt Nothing 3 )
     ]
   }

--- a/test/ps/output/Golden.Unbinding.Test/golden.lua
+++ b/test/ps/output/Golden.Unbinding.Test/golden.lua
@@ -1,11 +1,6 @@
-local Golden_Unbinding_Test_f_S_w = function() return 3 end
 return {
   a = 1,
   b = 2,
-  f = function(f_S_p1_S_0)
-    return function(f_S_p2_S_1)
-      return Golden_Unbinding_Test_f_S_w(f_S_p1_S_0, f_S_p2_S_1)
-    end
-  end,
-  c = Golden_Unbinding_Test_f_S_w(1, Golden_Unbinding_Test_f_S_w(2, 1))
+  f = function() return function() return 3 end end,
+  c = 3
 }

--- a/test/ps/output/Golden.UncurriedLift.Test/golden.ir
+++ b/test/ps/output/Golden.UncurriedLift.Test/golden.ir
@@ -106,11 +106,9 @@ UberModule
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "addOnePlusTwoTo"
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "c$682" ) :| [] )
-        ( AppN Nothing
-          ( Ref Nothing ( Imported ( ModuleName "Golden.UncurriedLift.Test" ) ( Name "add3" ) ) )
-          ( LiteralInt Nothing 1 :|
-            [ LiteralInt Nothing 2, Ref Nothing ( Local ( Name "c$682" ) ) ]
-          )
+        ( PrimBinOp Nothing PrimAdd
+          ( LiteralInt Nothing 3 )
+          ( Ref Nothing ( Local ( Name "c$682" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =
@@ -155,14 +153,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.UncurriedLift.Test" ) ( Name "add3" ) )
-                      )
-                      ( LiteralInt Nothing 1 :|
-                        [ LiteralInt Nothing 2, LiteralInt Nothing 3 ]
-                      ) :| []
-                    ) :| []
+                    ( LiteralInt Nothing 6 :| [] ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -192,14 +183,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.UncurriedLift.Test" ) ( Name "add3" ) )
-                      )
-                      ( LiteralInt Nothing 1 :|
-                        [ LiteralInt Nothing 2, LiteralInt Nothing 100 ]
-                      ) :| []
-                    ) :| []
+                    ( LiteralInt Nothing 103 :| [] ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -209,14 +193,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.UncurriedLift.Test" ) ( Name "add3" ) )
-                      )
-                      ( LiteralInt Nothing 1 :|
-                        [ LiteralInt Nothing 2, LiteralInt Nothing 200 ]
-                      ) :| []
-                    ) :| []
+                    ( LiteralInt Nothing 203 :| [] ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.UncurriedLift.Test/golden.lua
+++ b/test/ps/output/Golden.UncurriedLift.Test/golden.lua
@@ -24,19 +24,19 @@ local Golden_UncurriedLift_Test_logTwice = function(a_S_673, b_S_674)
     return Effect_Console_log(b_S_674)()
   end)()
 end
-local Golden_UncurriedLift_Test_add3 = function(a_S_694, b_S_695, c_S_696)
+M.Golden_UncurriedLift_Test_add3 = function(a_S_694, b_S_695, c_S_696)
   return a_S_694 + b_S_695 + c_S_696
 end
 M.Golden_UncurriedLift_Test_addOnePlusTwoTo = function(c_S_682)
-  return Golden_UncurriedLift_Test_add3(1, 2, c_S_682)
+  return 3 + c_S_682
 end
 return (function()
   local _ = Golden_UncurriedLift_Test_logTwice("hello", "world")
-  local _ = Effect_Console_log(Data_Show_showIntImpl(Golden_UncurriedLift_Test_add3(1, 2, 3)))()
+  local _ = Effect_Console_log(Data_Show_showIntImpl(6))()
   local _ = Effect_Console_log(Data_Show_showIntImpl(20))()
   local _ = Effect_Console_log(Data_Show_showIntImpl(48))()
-  local _ = Effect_Console_log(Data_Show_showIntImpl(Golden_UncurriedLift_Test_add3(1, 2, 100)))()
-  local _ = Effect_Console_log(Data_Show_showIntImpl(Golden_UncurriedLift_Test_add3(1, 2, 200)))()
+  local _ = Effect_Console_log(Data_Show_showIntImpl(103))()
+  local _ = Effect_Console_log(Data_Show_showIntImpl(203))()
   return Effect_Console_log(Data_Show_showIntImpl(Control_Monad_ST_Internal_foreign.run(function(  )
     return 42
   end)))()

--- a/test/ps/output/Golden.Uncurry.Test/golden.ir
+++ b/test/ps/output/Golden.Uncurry.Test/golden.ir
@@ -168,42 +168,6 @@ UberModule
         ]
       ), Standalone
       ( QName
-        { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "alwaysFirst$w"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x" ) :| [ ParamUnused Nothing ] )
-        ( Ref Nothing ( Local ( Name "x" ) ) )
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "adderOf$w"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x" ) :| [ ParamNamed Nothing ( Name "y" ) ] )
-        ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "y$229" ) :| [] )
-          ( PrimBinOp Nothing PrimAdd
-            ( PrimBinOp Nothing PrimAdd
-              ( Ref Nothing ( Local ( Name "x" ) ) )
-              ( Ref Nothing ( Local ( Name "y" ) ) )
-            )
-            ( Ref Nothing ( Local ( Name "y$229" ) ) )
-          )
-        )
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "add3$w"
-        }, AbsN Nothing
-        ( ParamNamed Nothing
-          ( Name "x" ) :|
-          [ ParamNamed Nothing ( Name "y" ), ParamNamed Nothing ( Name "z" ) ]
-        )
-        ( PrimBinOp Nothing PrimAdd
-          ( PrimBinOp Nothing PrimAdd
-            ( Ref Nothing ( Local ( Name "x" ) ) )
-            ( Ref Nothing ( Local ( Name "y" ) ) )
-          )
-          ( Ref Nothing ( Local ( Name "z" ) ) )
-        )
-      ), Standalone
-      ( QName
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "add3"
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "add3$p1" ) :| [] )
@@ -211,15 +175,12 @@ UberModule
           ( ParamNamed Nothing ( Name "add3$p2" ) :| [] )
           ( AbsN Nothing
             ( ParamNamed Nothing ( Name "add3$p3" ) :| [] )
-            ( AppN Nothing
-              ( Ref Nothing ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) ) )
-              ( Ref Nothing
-                ( Local ( Name "add3$p1" ) ) :|
-                [ Ref Nothing
-                  ( Local ( Name "add3$p2" ) ), Ref Nothing
-                  ( Local ( Name "add3$p3" ) )
-                ]
+            ( PrimBinOp Nothing PrimAdd
+              ( PrimBinOp Nothing PrimAdd
+                ( Ref Nothing ( Local ( Name "add3$p1" ) ) )
+                ( Ref Nothing ( Local ( Name "add3$p2" ) ) )
               )
+              ( Ref Nothing ( Local ( Name "add3$p3" ) ) )
             )
           )
         )
@@ -228,11 +189,9 @@ UberModule
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "inc"
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "add3$p3$223" ) :| [] )
-        ( AppN Nothing
-          ( Ref Nothing ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) ) )
-          ( LiteralInt Nothing 1 :|
-            [ LiteralInt Nothing 0, Ref Nothing ( Local ( Name "add3$p3$223" ) ) ]
-          )
+        ( PrimBinOp Nothing PrimAdd
+          ( LiteralInt Nothing 1 )
+          ( Ref Nothing ( Local ( Name "add3$p3$223" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =
@@ -254,11 +213,14 @@ UberModule
         ( ParamNamed Nothing ( Name "adderOf$p1$215" ) :| [] )
         ( AbsN Nothing
           ( ParamNamed Nothing ( Name "adderOf$p2$216" ) :| [] )
-          ( AppN Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "adderOf$w" ) ) )
-            ( Ref Nothing
-              ( Local ( Name "adderOf$p1$215" ) ) :|
-              [ Ref Nothing ( Local ( Name "adderOf$p2$216" ) ) ]
+          ( AbsN Nothing
+            ( ParamNamed Nothing ( Name "y$298" ) :| [] )
+            ( PrimBinOp Nothing PrimAdd
+              ( PrimBinOp Nothing PrimAdd
+                ( Ref Nothing ( Local ( Name "adderOf$p1$215" ) ) )
+                ( Ref Nothing ( Local ( Name "adderOf$p2$216" ) ) )
+              )
+              ( Ref Nothing ( Local ( Name "y$298" ) ) )
             )
           )
         )
@@ -266,16 +228,8 @@ UberModule
       ( Name "alwaysFirst", AbsN Nothing
         ( ParamNamed Nothing ( Name "alwaysFirst$p1$217" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "alwaysFirst$p2$218" ) :| [] )
-          ( AppN Nothing
-            ( Ref Nothing
-              ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "alwaysFirst$w" ) )
-            )
-            ( Ref Nothing
-              ( Local ( Name "alwaysFirst$p1$217" ) ) :|
-              [ Ref Nothing ( Local ( Name "alwaysFirst$p2$218" ) ) ]
-            )
-          )
+          ( ParamUnused Nothing :| [] )
+          ( Ref Nothing ( Local ( Name "alwaysFirst$p1$217" ) ) )
         )
       ),
       ( Name "main", AbsN Nothing
@@ -287,12 +241,7 @@ UberModule
                 ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                 ( Ref Nothing
                   ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                  [ AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) )
-                    )
-                    ( LiteralInt Nothing 1 :| [ LiteralInt Nothing 2, LiteralInt Nothing 3 ] )
-                  ]
+                  [ LiteralInt Nothing 6 ]
                 )
               )
               ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -303,12 +252,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) )
-                      )
-                      ( LiteralInt Nothing 4 :| [ LiteralInt Nothing 5, LiteralInt Nothing 6 ] )
-                    ]
+                    [ LiteralInt Nothing 15 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -318,12 +262,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) )
-                      )
-                      ( LiteralInt Nothing 10 :| [ LiteralInt Nothing 1, LiteralInt Nothing 2 ] )
-                    ]
+                    [ LiteralInt Nothing 13 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -333,12 +272,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) )
-                      )
-                      ( LiteralInt Nothing 1 :| [ LiteralInt Nothing 0, LiteralInt Nothing 41 ] )
-                    ]
+                    [ LiteralInt Nothing 42 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -369,14 +303,10 @@ UberModule
                           ( PropName "arrayMap" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "add3$p3$258" ) :| [] )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "add3$w" ) )
-                            )
-                            ( LiteralInt Nothing 1 :|
-                              [ LiteralInt Nothing 2, Ref Nothing ( Local ( Name "add3$p3$258" ) ) ]
-                            )
+                          ( ParamNamed Nothing ( Name "add3$p3$259" ) :| [] )
+                          ( PrimBinOp Nothing PrimAdd
+                            ( LiteralInt Nothing 3 )
+                            ( Ref Nothing ( Local ( Name "add3$p3$259" ) ) )
                           ) :| []
                         )
                       )
@@ -426,24 +356,24 @@ UberModule
                     [ Let Nothing
                       ( RecursiveGroup
                         (
-                          ( Nothing, Name "go$w$262", AbsN Nothing
+                          ( Nothing, Name "go$w$263", AbsN Nothing
                             ( ParamNamed Nothing
-                              ( Name "acc$263" ) :|
-                              [ ParamNamed Nothing ( Name "n$264" ) ]
+                              ( Name "acc$264" ) :|
+                              [ ParamNamed Nothing ( Name "n$265" ) ]
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
-                                ( Ref Nothing ( Local ( Name "n$264" ) ) )
+                                ( Ref Nothing ( Local ( Name "n$265" ) ) )
                                 ( LiteralInt Nothing 0 )
                               )
-                              ( Ref Nothing ( Local ( Name "acc$263" ) ) )
+                              ( Ref Nothing ( Local ( Name "acc$264" ) ) )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "go$w$262" ) ) )
+                                ( Ref Nothing ( Local ( Name "go$w$263" ) ) )
                                 ( PrimBinOp Nothing PrimAdd
-                                  ( Ref Nothing ( Local ( Name "acc$263" ) ) )
-                                  ( Ref Nothing ( Local ( Name "n$264" ) ) ) :|
+                                  ( Ref Nothing ( Local ( Name "acc$264" ) ) )
+                                  ( Ref Nothing ( Local ( Name "n$265" ) ) ) :|
                                   [ PrimBinOp Nothing PrimSub
-                                    ( Ref Nothing ( Local ( Name "n$264" ) ) )
+                                    ( Ref Nothing ( Local ( Name "n$265" ) ) )
                                     ( LiteralInt Nothing 1 )
                                   ]
                                 )
@@ -453,7 +383,7 @@ UberModule
                         ) :| []
                       )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "go$w$262" ) ) )
+                        ( Ref Nothing ( Local ( Name "go$w$263" ) ) )
                         ( LiteralInt Nothing 0 :| [ LiteralInt Nothing 10 ] )
                       )
                     ]
@@ -469,24 +399,24 @@ UberModule
                     [ Let Nothing
                       ( RecursiveGroup
                         (
-                          ( Nothing, Name "go$w$273", AbsN Nothing
+                          ( Nothing, Name "go$w$274", AbsN Nothing
                             ( ParamNamed Nothing
-                              ( Name "acc$274" ) :|
-                              [ ParamNamed Nothing ( Name "n$275" ) ]
+                              ( Name "acc$275" ) :|
+                              [ ParamNamed Nothing ( Name "n$276" ) ]
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
-                                ( Ref Nothing ( Local ( Name "n$275" ) ) )
+                                ( Ref Nothing ( Local ( Name "n$276" ) ) )
                                 ( LiteralInt Nothing 0 )
                               )
-                              ( Ref Nothing ( Local ( Name "acc$274" ) ) )
+                              ( Ref Nothing ( Local ( Name "acc$275" ) ) )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "go$w$273" ) ) )
+                                ( Ref Nothing ( Local ( Name "go$w$274" ) ) )
                                 ( PrimBinOp Nothing PrimAdd
-                                  ( Ref Nothing ( Local ( Name "acc$274" ) ) )
-                                  ( Ref Nothing ( Local ( Name "n$275" ) ) ) :|
+                                  ( Ref Nothing ( Local ( Name "acc$275" ) ) )
+                                  ( Ref Nothing ( Local ( Name "n$276" ) ) ) :|
                                   [ PrimBinOp Nothing PrimSub
-                                    ( Ref Nothing ( Local ( Name "n$275" ) ) )
+                                    ( Ref Nothing ( Local ( Name "n$276" ) ) )
                                     ( LiteralInt Nothing 1 )
                                   ]
                                 )
@@ -496,7 +426,7 @@ UberModule
                         ) :| []
                       )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "go$w$273" ) ) )
+                        ( Ref Nothing ( Local ( Name "go$w$274" ) ) )
                         ( LiteralInt Nothing 0 :| [ LiteralInt Nothing 100 ] )
                       )
                     ]
@@ -509,15 +439,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( AppN Nothing
-                        ( Ref Nothing
-                          ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "adderOf$w" ) )
-                        )
-                        ( LiteralInt Nothing 1 :| [ LiteralInt Nothing 2 ] )
-                      )
-                      ( LiteralInt Nothing 3 :| [] )
-                    ]
+                    [ LiteralInt Nothing 6 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -527,15 +449,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( AppN Nothing
-                        ( Ref Nothing
-                          ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "adderOf$w" ) )
-                        )
-                        ( LiteralInt Nothing 2 :| [ LiteralInt Nothing 3 ] )
-                      )
-                      ( LiteralInt Nothing 4 :| [] )
-                    ]
+                    [ LiteralInt Nothing 9 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -545,12 +459,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                    [ AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "alwaysFirst$w" ) )
-                      )
-                      ( LiteralInt Nothing 7 :| [ LiteralInt Nothing 8 ] )
-                    ]
+                    [ LiteralInt Nothing 7 ]
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -562,12 +471,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "logShow$w" ) ) )
               ( Ref Nothing
                 ( Imported ( ModuleName "Data.Show" ) ( Name "showInt" ) ) :|
-                [ AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "alwaysFirst$w" ) )
-                  )
-                  ( LiteralInt Nothing 9 :| [ LiteralInt Nothing 10 ] )
-                ]
+                [ LiteralInt Nothing 9 ]
               )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.Uncurry.Test/golden.lua
+++ b/test/ps/output/Golden.Uncurry.Test/golden.lua
@@ -60,61 +60,54 @@ M.Golden_Uncurry_Test_evenSteps = function(evenSteps_S_p1)
     return Golden_Uncurry_Test_evenSteps_S_w(evenSteps_S_p1, evenSteps_S_p2)
   end
 end
-local Golden_Uncurry_Test_alwaysFirst_S_w = function(x) return x end
-local Golden_Uncurry_Test_adderOf_S_w = function(x, y)
-  return function(y_S_229) return x + y + y_S_229 end
-end
-local Golden_Uncurry_Test_add3_S_w = function(x, y, z) return x + y + z end
 M.Golden_Uncurry_Test_add3 = function(add3_S_p1)
   return function(add3_S_p2)
-    return function(add3_S_p3)
-      return Golden_Uncurry_Test_add3_S_w(add3_S_p1, add3_S_p2, add3_S_p3)
-    end
+    return function(add3_S_p3) return add3_S_p1 + add3_S_p2 + add3_S_p3 end
   end
 end
 M.Golden_Uncurry_Test_inc = function(add3_S_p3_S_223)
-  return Golden_Uncurry_Test_add3_S_w(1, 0, add3_S_p3_S_223)
+  return 1 + add3_S_p3_S_223
 end
 return (function()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_add3_S_w(1, 2, 3))()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_add3_S_w(4, 5, 6))()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_add3_S_w(10, 1, 2))()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_add3_S_w(1, 0, 41))()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 6)()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 15)()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 13)()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 42)()
   local _ = Effect_Console_logShow_S_w({
     show = Data_Show_foreign.showArrayImpl(Data_Show_showIntImpl)
-  }, Data_Functor_foreign.arrayMap(function(add3_S_p3_S_258)
-    return Golden_Uncurry_Test_add3_S_w(1, 2, add3_S_p3_S_258)
+  }, Data_Functor_foreign.arrayMap(function(add3_S_p3_S_259)
+    return 3 + add3_S_p3_S_259
   end)({ [1] = 1, [2] = 2, [3] = 3 }))()
   local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_evenSteps_S_w(0, 10))()
   local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_oddSteps_S_w(0, 7))()
   local _ = Effect_Console_logShow_S_w(Data_Show_showInt, (function()
-    local go_S_w_S_262
-    go_S_w_S_262 = function(acc_S_263, n_S_264)
+    local go_S_w_S_263
+    go_S_w_S_263 = function(acc_S_264, n_S_265)
       while true do
-        if n_S_264 == 0 then
-          return acc_S_263
+        if n_S_265 == 0 then
+          return acc_S_264
         else
-          acc_S_263, n_S_264 = acc_S_263 + n_S_264, n_S_264 - 1
+          acc_S_264, n_S_265 = acc_S_264 + n_S_265, n_S_265 - 1
         end
       end
     end
-    return go_S_w_S_262(0, 10)
+    return go_S_w_S_263(0, 10)
   end)())()
   local _ = Effect_Console_logShow_S_w(Data_Show_showInt, (function()
-    local go_S_w_S_273
-    go_S_w_S_273 = function(acc_S_274, n_S_275)
+    local go_S_w_S_274
+    go_S_w_S_274 = function(acc_S_275, n_S_276)
       while true do
-        if n_S_275 == 0 then
-          return acc_S_274
+        if n_S_276 == 0 then
+          return acc_S_275
         else
-          acc_S_274, n_S_275 = acc_S_274 + n_S_275, n_S_275 - 1
+          acc_S_275, n_S_276 = acc_S_275 + n_S_276, n_S_276 - 1
         end
       end
     end
-    return go_S_w_S_273(0, 100)
+    return go_S_w_S_274(0, 100)
   end)())()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_adderOf_S_w(1, 2)(3))()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_adderOf_S_w(2, 3)(4))()
-  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_alwaysFirst_S_w(7, 8))()
-  return Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_alwaysFirst_S_w(9, 10))()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 6)()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 9)()
+  local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 7)()
+  return Effect_Console_logShow_S_w(Data_Show_showInt, 9)()
 end)()


### PR DESCRIPTION
Closes #211.

## Problem

Issue #211 predates two changes that reshaped its landscape: the Capture/Complexity inlining lattices (#231) and the bare-primop worker unfolding (#281). #281 already dissolves `sub$w(v, 1)` into `v - 1`, but its predicate demands a *single* primop node over `Trivial` operands, so anything one step richer kept paying a Lua call per saturated site:

```lua
local Golden_Uncurry_Test_alwaysFirst_S_w = function(x) return x end
local Golden_Uncurry_Test_adderOf_S_w = function(x, y)
  return function(y_S_229) return x + y + y_S_229 end
end
local Golden_Uncurry_Test_add3_S_w = function(x, y, z) return x + y + z end
```

`(x + y) + z` is a *nested* primop (the left operand is not `Trivial`), `return x` is not a primop at all, and a projection-chain operand like `r.foo` prices `Deref`, one notch above `Trivial`. All three declined.

## Change

`isBarePrimOpBody` becomes `isCheapWorkerBody`: a tree of primops, equality tests and negations over leaves `complexityOf` classifies at most `Deref` (parameter references, scalar literals, cheap projection chains), possibly under nested lambdas. The paste is additionally bounded by `smallInlineBudget` — the constant whose documented meaning is exactly "duplication at every use site":

```haskell
isCheapWorkerBody ∷ RawExp ann → Bool
isCheapWorkerBody = \case
  PrimBinOp _ _ a b → isCheapWorkerBody a && isCheapWorkerBody b
  Eq _ a b → isCheapWorkerBody a && isCheapWorkerBody b
  PrimNot _ e → isCheapWorkerBody e
  AbsN _ _params body → isCheapWorkerBody body
  leaf → complexityOf leaf <= Deref
```

Everything else rides on existing machinery: the n-ary `AbsN` root is pasted under the original `AppN`, the exact-arity `betaReduce` consumes it in the same pass, and `constantFolding` finishes the job where arguments are literal. The former call sites in `Golden.Uncurry.Test`:

```lua
-- before
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_add3_S_w(1, 2, 3))()
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_adderOf_S_w(1, 2)(3))()
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, Golden_Uncurry_Test_alwaysFirst_S_w(7, 8))()
-- after
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 6)()
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 6)()
local _ = Effect_Console_logShow_S_w(Data_Show_showInt, 7)()
```

and the partially-applied residual closure folds its constants too:

```lua
-- before
Data_Functor_foreign.arrayMap(function(add3_S_p3_S_258)
  return Golden_Uncurry_Test_add3_S_w(1, 2, add3_S_p3_S_258)
end)
-- after
Data_Functor_foreign.arrayMap(function(add3_S_p3_S_259)
  return 3 + add3_S_p3_S_259
end)
```

All three workers above are gone from the output entirely: once every saturated site is inlined, DCE drops the worker, and the late uncurry run leaves the surviving manifest chain alone because a binding with no saturated site is never split.

## What deliberately stays shared

`IfThenElse` bodies are not admitted, deviating from the issue's original allowed list: an `IfThenElse` in expression position lowers through `chunkToExpression` to a per-call IIFE — the exact allocation the case-of-case rules of #203 exist to remove — so pasting a decision tree would trade a named call for a closure allocation plus a call. Application bodies (`sumTo$w`, `evenSteps$w`, `logShow$w`, the monad workers), allocating bodies (`Ctor`, non-empty literals, `Let`) and oversized trees also keep sharing, each declining through the `complexityOf` fallback or the budget. Value-position uses are untouched by construction: the rule fires only at saturated `AppN` heads, so the sharing-vs-Capture concern that #231 codified for the local tiers never arises (no lambda literal lands in a branch or closure position — it is consumed by `betaReduce` on the spot).

The issue's original sketch — extending the shared `isInlinableExpr` guard so the *binding* dissolves before uncurry — would have bypassed the `CaptureNone` gate of `isDuplicatableClosedAbs` and pasted lambda literals into value positions (the #204 trace-abort pathology). Keeping the admission per-call-site delivers the same end state for call uses while leaving every value use a shared reference, so this lands as a completion of #211 in the post-#231/#281 architecture rather than a literal transcription.

## Testing

Unit tests mirror the #281 spec block: three positives (nested primop tree, parameter-selecting body, `Deref`-leaf operands — red before the change) and three negatives pinning the exclusions (application body, branching body, over-budget tree — green before and after). Golden churn is limited to `Golden.Uncurry.Test`, `Golden.UncurriedLift.Test` and `Golden.Unbinding.Test`; every eval oracle passes unchanged, and the full suite is stable across four hspec seeds (`1`, `42`, `20260716`, `999983`).
