### PR TITLE
feat(optimizer): fold ordering on ASCII char literals (#222)

### DIFF
--- a/changelog.d/20260723_100000_unisay_fold_ascii_char_ordering.md
+++ b/changelog.d/20260723_100000_unisay_fold_ascii_char_ordering.md
@@ -1,0 +1,11 @@
+### Changed
+
+- The IR constant folder now evaluates ordering comparisons (`<`, `<=`,
+  `>`, `>=`) on two ASCII `Char` literals (#222). Equality on `Char`
+  literals already folded; ordering was held back because Lua orders
+  strings by bytes, which can disagree with codepoint order — but for
+  two codepoints below U+0080 the single-byte representation orders
+  identically, so the fold is gated on the ASCII range. Non-ASCII chars
+  and `String` literals remain unfolded. In the `CharLiterals` golden,
+  `show ('\t' < '\n')` collapses from a runtime branch on a constant
+  condition to the literal `"true"`.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -2,6 +2,7 @@ module Language.PureScript.Backend.IR.Optimizer where
 
 import Control.Lens (over, toListOf, transformOf, universeOf)
 import Control.Monad.Writer.CPS (WriterT, runWriterT, tell)
+import Data.Char (isAscii)
 import Data.Foldable (foldrM)
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
@@ -1036,9 +1037,11 @@ primops]). The per-operator caveats:
   * @..@ folds string with string only. Lua coerces a number operand on
     concat with a version- and build-dependent format, so a number is
     never reproduced at compile time.
-  * Comparisons fold on two numbers (int or finite float); strings and
-    chars are left alone, because Lua orders strings by bytes while the
-    IR literal carries semantic 'Text'.
+  * Comparisons fold on two numbers (int or finite float), and on two
+    ASCII chars, whose single-byte Lua representation orders exactly
+    like the codepoint. Strings and non-ASCII chars are left alone,
+    because Lua orders strings by bytes while the IR literal carries
+    semantic 'Text'.
   * @and@/@or@ fold when both operands are boolean, and additionally
     collapse a known-boolean first operand (@true and b == b@,
     @false or b == b@, and the two annihilators): sound because Lua
@@ -1071,10 +1074,10 @@ foldPrimBinOp op l r = case (op, l, r) of
   (PrimDiv, LiteralFloat _ a, LiteralFloat _ b) → floatFold (a / b)
   (PrimConcat, LiteralString _ a, LiteralString _ b) →
     Just (literalString (a <> b))
-  (PrimLt, _, _) → literalBool . (== LT) <$> numericCompare l r
-  (PrimLe, _, _) → literalBool . (/= GT) <$> numericCompare l r
-  (PrimGt, _, _) → literalBool . (== GT) <$> numericCompare l r
-  (PrimGe, _, _) → literalBool . (/= LT) <$> numericCompare l r
+  (PrimLt, _, _) → literalBool . (== LT) <$> compareLiterals l r
+  (PrimLe, _, _) → literalBool . (/= GT) <$> compareLiterals l r
+  (PrimGt, _, _) → literalBool . (== GT) <$> compareLiterals l r
+  (PrimGe, _, _) → literalBool . (/= LT) <$> compareLiterals l r
   (PrimAnd, LiteralBool _ a, LiteralBool _ b) → Just (literalBool (a && b))
   (PrimAnd, LiteralBool _ True, b) → Just b
   (PrimAnd, LiteralBool _ False, _) → Just (literalBool False)
@@ -1095,11 +1098,13 @@ foldPrimBinOp op l r = case (op, l, r) of
     | isFinite result = Just (literalFloat result)
     | otherwise = Nothing
 
-  numericCompare ∷ Exp → Exp → Maybe Ordering
-  numericCompare a b = case (a, b) of
+  compareLiterals ∷ Exp → Exp → Maybe Ordering
+  compareLiterals a b = case (a, b) of
     (LiteralInt _ x, LiteralInt _ y) → Just (compare x y)
     (LiteralFloat _ x, LiteralFloat _ y)
       | isFinite x, isFinite y → Just (compare x y)
+    (LiteralChar _ x, LiteralChar _ y)
+      | isAscii x, isAscii y → Just (compare x y)
     _ → Nothing
 
   isFinite ∷ Double → Bool

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -65,6 +65,7 @@ import Language.PureScript.Backend.IR.Types
   , lets
   , listGrouping
   , literalBool
+  , literalChar
   , literalFloat
   , literalInt
   , literalObject
@@ -926,6 +927,22 @@ spec = describe "IR Optimizer" do
     it "does not fold string comparisons (bytes vs Text)" do
       let original = primBinOp PrimLt (literalString "a") (literalString "b")
       optimizedExpression original `shouldBe` original
+
+    it "folds ordering on two ASCII char literals (#222)" do
+      optimizedExpression (primBinOp PrimLt (literalChar '\t') (literalChar '\n'))
+        `shouldBe` literalBool True
+      optimizedExpression (primBinOp PrimLe (literalChar 'a') (literalChar 'a'))
+        `shouldBe` literalBool True
+      optimizedExpression (primBinOp PrimGt (literalChar 'a') (literalChar 'b'))
+        `shouldBe` literalBool False
+      optimizedExpression (primBinOp PrimGe (literalChar 'z') (literalChar 'a'))
+        `shouldBe` literalBool True
+
+    it "does not fold ordering on non-ASCII char literals (bytes vs Text)" do
+      let nonAscii = primBinOp PrimLt (literalChar 'é') (literalChar 'ê')
+          mixed = primBinOp PrimLt (literalChar 'a') (literalChar 'é')
+      optimizedExpression nonAscii `shouldBe` nonAscii
+      optimizedExpression mixed `shouldBe` mixed
 
     it "folds boolean and/or and not" do
       optimizedExpression (primBinOp PrimAnd (literalBool True) (literalBool False))

--- a/test/ps/output/Golden.CharLiterals.Test/golden.ir
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.ir
@@ -116,25 +116,7 @@ UberModule
           ( AppN Nothing
             ( AppN Nothing
               ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
-              ( Let Nothing
-                ( Standalone
-                  ( Nothing, Name "v$221", PrimBinOp Nothing PrimLt
-                    ( LiteralChar Nothing '\x9' )
-                    ( LiteralChar Nothing ' ' )
-                  ) :| []
-                )
-                ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "v$221" ) ) )
-                  ( LiteralString Nothing "true" )
-                  ( IfThenElse Nothing
-                    ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "v$221" ) ) )
-                    )
-                    ( LiteralString Nothing "false" )
-                    ( Exception Nothing "No patterns matched" )
-                  )
-                ) :| []
-              )
+              ( LiteralString Nothing "true" :| [] )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
           )

--- a/test/ps/output/Golden.CharLiterals.Test/golden.lua
+++ b/test/ps/output/Golden.CharLiterals.Test/golden.lua
@@ -28,14 +28,5 @@ return (function()
   local _ = Effect_Console_log(Golden_CharLiterals_Test_show("\\"))()
   local _ = Effect_Console_log(Golden_CharLiterals_Test_show("a"))()
   local _ = Effect_Console_log("true")()
-  return Effect_Console_log((function()
-    local v_S_221 = "\t" < "\n"
-    if v_S_221 then
-      return "true"
-    elseif false == v_S_221 then
-      return "false"
-    else
-      return error("No patterns matched")
-    end
-  end)())()
+  return Effect_Console_log("true")()
 end)()


### PR DESCRIPTION
Closes #222.

## What

`compareLiterals` (né `numericCompare`, renamed since it now handles more than numbers) gains one arm: ordering comparisons (`<`, `<=`, `>`, `>=`) on two `Char` literals fold at compile time when both codepoints are below U+0080.

```haskell
(LiteralChar _ x, LiteralChar _ y)
  | isAscii x, isAscii y → Just (compare x y)
```

## Why the ASCII gate

Note [Folding primops follows Lua 5.1] holds ordering back because Lua orders strings by bytes while the IR literal carries a semantic codepoint, so a host-side `compare` could disagree with the runtime on non-ASCII operands. For two ASCII chars the single-byte representation orders identically to the codepoint, so the fold matches the runtime exactly. Non-ASCII chars and `String` literals stay out of scope; the Note's comparison bullet is updated to record the refinement.

## Effect on the CharLiterals golden

The final `show ('\t' < '\n')` used to compile to a runtime branch on a constant condition:

```lua
return Effect_Console_log((function()
  local v_S_221 = "\t" < "\n"
  if v_S_221 then
    return "true"
  elseif false == v_S_221 then
    return "false"
  else
    return error("No patterns matched")
  end
end)())()
```

With the fold in place the existing downstream rewrites cascade (`if true then LT else GT` → `LT`, `"…LT" == "…LT"` → `true`, `if true then "true"` → `"true"`) and the whole block collapses:

```lua
return Effect_Console_log("true")()
```

The hand-verified eval oracle (`eval/golden.txt`) is unchanged — the module still prints `true` — so the collapse is semantics-preserving.

## Tests

Written test-first (red before the fix): a unit test pins the ASCII fold for all four operators, and a companion test pins the soundness guard — a non-ASCII pair (`'é' < 'ê'`) and a mixed pair (`'a' < 'é'`) are left unfolded. Full `cabal test all` is green, and the randomized `IR Optimizer` spec group was stress-run 12 times on fresh seeds with no failures or hangs.