### PR TITLE
test: fix two GHC warnings in optimizer/CPR specs

### DIFF
--- a/test/Language/PureScript/Backend/IR/Cpr/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Cpr/Spec.hs
@@ -2,7 +2,6 @@ module Language.PureScript.Backend.IR.Cpr.Spec where
 
 import Data.List qualified as List
 import Data.Set qualified as Set
-import Data.Text qualified as Text
 import Hedgehog (Gen, annotateShow, forAll, (===))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -1812,6 +1812,7 @@ spec = describe "IR Optimizer" do
                       (dataArgumentByIndex ProductType 1 (refLocal (Name "v")))
                   )
         productDict = literalObject [(bindProp, productBind)]
+        chainSite ∷ Exp → Int → Exp
         chainSite mm i =
           application
             (application (objectProp dictRef bindProp) mm)


### PR DESCRIPTION
Follow-up spotted while working on #288: tricorder's GHCi session surfaces two warnings that cabal's flag set doesn't (so CI stayed green), but they're worth fixing anyway per the project's no-tolerated-warnings policy.

## What

- `test/Language/PureScript/Backend/IR/Cpr/Spec.hs`: removes the qualified `Data.Text` import, unused since some earlier edit.
- `test/Language/PureScript/Backend/IR/Optimizer/Spec.hs`: adds a type signature to `chainSite` (the local helper in the #221 growth-bound tests), silencing `-Wmissing-local-signatures` on its inferred `Exp -> Int -> Exp`.

Both are mechanical; no behavior or golden output changes.

Copilot review request skipped — quota's spent till end of month.