### PR TITLE
feat(optimizer): collapse Boolean pattern matches to a two-way if (#223)

### DIFF
--- a/changelog.d/20260723_150000_unisay_collapse_boolean_match.md
+++ b/changelog.d/20260723_150000_unisay_collapse_boolean_match.md
@@ -1,0 +1,20 @@
+### Added
+
+- Boolean pattern matches — including every inlined `show` of a `Boolean` —
+  collapse to a two-way `if` (#223). A match on a `Boolean` compiled to a
+  three-way `if` with a synthesized default (`if a then … elseif false == a
+  then … else error("No patterns matched") end`), although `true`/`false`
+  already cover the type: the re-test was opaque to the optimizer and the dead
+  default was printed verbatim. Two additions reduce it. The boolean-equality
+  fold in `constantFolding` is completed — `false == b` and `b == false` fold
+  to `not b`, `b == true` to `b` (only the left-literal `true == b` folded
+  before) — and the new `propagateKnownCondIntoBranches` rule propagates a
+  variable condition's known value into its branches: inside `if c then t else
+  e` the variable `c` is `true` throughout `t` and `false` throughout `e`, so
+  its occurrences there are replaced with the matching literal and the existing
+  folds collapse the re-test, dropping the unreachable default. The `elseif
+  false ==` idiom disappears from every golden that carried it, and the
+  collapsed `show` bodies now clear the call-site inline budget — in the
+  `NumberIsNaN` golden that cascade dead-codes the whole `Ring` dictionary. A
+  genuinely partial match keeps its default: only a re-test of the same
+  variable folds. Eval goldens are unchanged.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -974,6 +974,7 @@ optimizedExpressionWithPastes pastes policy env =
         `thenRewrite` removeUnreachableThenBranch
         `thenRewrite` removeUnreachableElseBranch
         `thenRewrite` removeIfWithEqualBranches
+        `thenRewrite` propagateKnownCondIntoBranches
         `thenRewrite` flipNegatedIf
         `thenRewrite` reduceBooleanIf
         `thenRewrite` pushEqIntoIfBranches
@@ -1006,9 +1007,18 @@ constantFolding =
     Eq _ a b
       | Just result ← foldEqLiterals a b →
           Just $ literalBool result
+    -- The other operand must be of type Bool in each of the four cases
+    -- below; see Note [IR is assumed well-typed]. A false literal folds
+    -- to the negation (issue #223) — the shape a Boolean pattern match
+    -- re-tests its scrutinee with (@false == a@).
     Eq _ (LiteralBool _ True) b →
-      -- 'b' must be of type Bool; see Note [IR is assumed well-typed]
       Just b
+    Eq _ b (LiteralBool _ True) →
+      Just b
+    Eq _ (LiteralBool _ False) b →
+      Just (primNot b)
+    Eq _ b (LiteralBool _ False) →
+      Just (primNot b)
     -- See Note [IR primops] and Note [Folding primops follows Lua 5.1]
     PrimBinOp _ op a b → foldPrimBinOp op a b
     PrimNot _ a → foldPrimNot a
@@ -1965,6 +1975,41 @@ removeIfWithEqualBranches e =
       | thenBranch `alphaEq` elseBranch →
           Just thenBranch
     _ → Nothing
+
+{- | Propagate a branch condition's known value into the branches (issue
+#223), the Boolean sibling of 'propagateKnownCtorThroughLet': inside
+@if c then t else e@ the variable @c@ is 'True' throughout @t@ and
+'False' throughout @e@, so its occurrences in the branches are replaced
+with the matching literal. The existing folds then finish the job: a
+Boolean pattern match compiles to a re-test of the scrutinee behind the
+first branch — @if a then "true" else (if false == a then "false" else
+error)@ — and with @a@ known 'False' in the else branch the re-test
+folds to a literal condition and 'removeUnreachableThenBranch' drops
+the synthesized default, collapsing the match to a two-way if.
+
+Only a variable condition propagates: an IR binding is immutable, so
+re-reading it in a branch is free and yields the value the test just
+observed, and replacing the read with a literal duplicates no work. The
+substitution licence is Note [IR is assumed well-typed]: @c@ is a
+'Bool', so truth of the test is equality with @true@. The substitution
+itself follows the GUC discipline of 'substituteCopyM' — no scope is
+threaded, which is exact under unique binders.
+
+Placed after 'removeIfWithEqualBranches': branches that are equal while
+still naming @c@ collapse to a single copy, which substituting the two
+literals first would unequalize. Fixpoint-safe: the rule fires only
+when a branch has a free occurrence of @c@ and leaves none behind, so
+it cannot re-fire on its own result, and a 'Ref' becomes a literal
+node-for-node, so the tree never grows.
+-}
+propagateKnownCondIntoBranches ∷ RewriteRuleM SupplyM Ann
+propagateKnownCondIntoBranches = \case
+  IfThenElse ann cond@(Ref _ name) thenBranch elseBranch
+    | countFreeRef name thenBranch + countFreeRef name elseBranch > 0 → do
+        thenBranch' ← substituteCopyM name (literalBool True) thenBranch
+        elseBranch' ← substituteCopyM name (literalBool False) elseBranch
+        pure . Just $ IfThenElse ann cond thenBranch' elseBranch'
+  _ → pure Nothing
 
 {- | Drop a negated condition by swapping the branches:
 @if not p then a else b@ ⟶ @if p then b else a@. Runs before

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -59,6 +59,7 @@ import Language.PureScript.Backend.IR.Types
   , ctorId
   , dataArgumentByIndex
   , eq
+  , exception
   , getAnn
   , ifThenElse
   , isLiteral
@@ -1048,6 +1049,75 @@ spec = describe "IR Optimizer" do
     it "leaves an if with no boolean-literal branch alone" do
       let original = ifThenElse p r (refLocal (Name "s"))
       optimizedExpression original `shouldBe` original
+
+  -- A pattern match on a Boolean compiles to a three-way if with a
+  -- synthesized default: the scrutinee is re-tested behind the first
+  -- branch (`false == a`) and the default is unreachable, since
+  -- true/false already cover a Boolean. The boolean-equality folds and
+  -- the known-condition propagation collapse it to a two-way if.
+  describe "collapses a Boolean pattern match to a two-way if (#223)" do
+    let m = moduleNameFromString "M"
+        a = refLocal (Name "a")
+        b = primBinOp PrimLt (refLocal (Name "x")) (refLocal (Name "y"))
+        deadDefault = exception "No patterns matched"
+
+    it "reduces False == b to not b" do
+      optimizedExpression (eq (literalBool False) b) `shouldBe` primNot b
+
+    it "reduces b == False to not b" do
+      optimizedExpression (eq b (literalBool False)) `shouldBe` primNot b
+
+    it "reduces b == True to b" do
+      optimizedExpression (eq b (literalBool True)) `shouldBe` b
+
+    it "still folds two boolean literals to a literal" do
+      optimizedExpression (eq (literalBool False) (literalBool False))
+        `shouldBe` literalBool True
+
+    it "reduces the three-way Boolean match to a two-way if" do
+      -- The shape every inlined `show` of a Boolean produces.
+      let original =
+            ifThenElse a (literalString "true") $
+              ifThenElse
+                (eq (literalBool False) a)
+                (literalString "false")
+                deadDefault
+      optimizedExpression original
+        `shouldBe` ifThenElse a (literalString "true") (literalString "false")
+
+    it "propagates the condition's truth into the then branch" do
+      -- if a then a else e: a is True throughout the then branch, and
+      -- the half-literal boolean-if fold finishes the collapse.
+      let e = refLocal (Name "e")
+      optimizedExpression (ifThenElse a a e)
+        `shouldBe` primBinOp PrimOr a e
+
+    it "keeps the default of a genuinely partial match" do
+      -- No second arm at all: the default is live and must survive.
+      let original = ifThenElse a (literalString "true") deadDefault
+      optimizedExpression original `shouldBe` original
+
+    it "keeps the default when the guard tests a different variable" do
+      -- The re-test folds only for the same variable; a different one
+      -- may genuinely be true, so the default stays reachable (the
+      -- equality fold and the negated-if flip still normalise it).
+      let c = refLocal (Name "c")
+          original =
+            ifThenElse a (literalString "true") $
+              ifThenElse
+                (eq (literalBool False) c)
+                (literalString "false")
+                deadDefault
+          expected =
+            ifThenElse a (literalString "true") $
+              ifThenElse c deadDefault (literalString "false")
+      optimizedExpression original `shouldBe` expected
+
+    it "prefers collapsing equal branches over propagating the condition" do
+      -- if a then f a else f a ≡ f a: substituting True/False into the
+      -- branches first would unequalize them and lose the collapse.
+      let fa = application (refImported m (Name "f")) a
+      optimizedExpression (ifThenElse a fa fa) `shouldBe` fa
 
   -- Case-of-case over the IfThenElse decision tree: a boolean-returning
   -- tree consumed in a strict position (an Eq against a literal, or the

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
@@ -14,6 +14,12 @@ UberModule
         [ ( Nothing, Name "log" ) ]
       ), Standalone
       ( QName
+        { qnameModuleName = ModuleName "Effect.Console", qnameName = Name "log"
+        }, ObjectProp Nothing
+        ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
+        ( PropName "log" )
+      ), Standalone
+      ( QName
         { qnameModuleName = ModuleName "Type.Proxy", qnameName = Name "Proxy"
         }, Ctor Nothing ProductType
         ( ModuleName "Type.Proxy" )
@@ -179,26 +185,6 @@ UberModule
         )
       ), Standalone
       ( QName
-        { qnameModuleName = ModuleName "Golden.BugListGenericEq.Test", qnameName = Name "logShow"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
-        ( AppN Nothing
-          ( ObjectProp Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
-            ( PropName "log" )
-          )
-          ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "a$2" ) ) )
-            ( LiteralString Nothing "true" )
-            ( IfThenElse Nothing
-              ( Eq Nothing ( LiteralBool Nothing False ) ( Ref Nothing ( Local ( Name "a$2" ) ) ) )
-              ( LiteralString Nothing "false" )
-              ( Exception Nothing "No patterns matched" )
-            ) :| []
-          )
-        )
-      ), Standalone
-      ( QName
         { qnameModuleName = ModuleName "Golden.BugListGenericEq.Test", qnameName = Name "Nil"
         }, Ctor Nothing SumType
         ( ModuleName "Golden.BugListGenericEq.Test" )
@@ -224,14 +210,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse274", ReflectCtor Nothing
+                ( Nothing, Name "$cse268", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                  ( Ref Nothing ( Local ( Name "$cse274" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse268" ) ) )
                 )
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Nil" ) )
@@ -239,7 +225,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                    ( Ref Nothing ( Local ( Name "$cse274" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse268" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Golden.BugListGenericEq.Test" )
@@ -256,14 +242,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x0" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse275", ReflectCtor Nothing
+                ( Nothing, Name "$cse269", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x0" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Nil" )
-                  ( Ref Nothing ( Local ( Name "$cse275" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse269" ) ) )
                 )
                 ( Ctor Nothing SumType
                   ( ModuleName "Data.Generic.Rep" )
@@ -278,7 +264,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Cons" )
-                    ( Ref Nothing ( Local ( Name "$cse275" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse269" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Data.Generic.Rep" )
@@ -308,13 +294,13 @@ UberModule
                   ( ParamNamed Nothing ( Name "y" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse278", ReflectCtor Nothing
+                      ( Nothing, Name "$cse272", ReflectCtor Nothing
                         ( Ref Nothing ( Local ( Name "y" ) ) )
                       ) :| []
                     )
                     ( Let Nothing
                       ( Standalone
-                        ( Nothing, Name "$cse277", Ctor Nothing SumType
+                        ( Nothing, Name "$cse271", Ctor Nothing SumType
                           ( ModuleName "Data.Generic.Rep" )
                           ( TyName "Sum" )
                           ( CtorName "Inl" )
@@ -327,7 +313,7 @@ UberModule
                       )
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "$cse276", ReflectCtor Nothing
+                          ( Nothing, Name "$cse270", ReflectCtor Nothing
                             ( Ref Nothing ( Local ( Name "x" ) ) )
                           ) :| []
                         )
@@ -337,13 +323,13 @@ UberModule
                               ( Nothing, Name "v$13", IfThenElse Nothing
                                 ( Eq Nothing
                                   ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Nil" )
-                                  ( Ref Nothing ( Local ( Name "$cse276" ) ) )
+                                  ( Ref Nothing ( Local ( Name "$cse270" ) ) )
                                 )
-                                ( Ref Nothing ( Local ( Name "$cse277" ) ) )
+                                ( Ref Nothing ( Local ( Name "$cse271" ) ) )
                                 ( IfThenElse Nothing
                                   ( Eq Nothing
                                     ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Cons" )
-                                    ( Ref Nothing ( Local ( Name "$cse276" ) ) )
+                                    ( Ref Nothing ( Local ( Name "$cse270" ) ) )
                                   )
                                   ( Ctor Nothing SumType
                                     ( ModuleName "Data.Generic.Rep" )
@@ -361,34 +347,34 @@ UberModule
                               ( ParamNamed Nothing ( Name "v1$14" ) :| [] )
                               ( Let Nothing
                                 ( Standalone
-                                  ( Nothing, Name "$cse280", ReflectCtor Nothing
+                                  ( Nothing, Name "$cse274", ReflectCtor Nothing
                                     ( Ref Nothing ( Local ( Name "v1$14" ) ) )
                                   ) :| []
                                 )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "$cse279", ReflectCtor Nothing
+                                    ( Nothing, Name "$cse273", ReflectCtor Nothing
                                       ( Ref Nothing ( Local ( Name "v$13" ) ) )
                                     ) :| []
                                   )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                      ( Ref Nothing ( Local ( Name "$cse279" ) ) )
+                                      ( Ref Nothing ( Local ( Name "$cse273" ) ) )
                                     )
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                      ( Ref Nothing ( Local ( Name "$cse280" ) ) )
+                                      ( Ref Nothing ( Local ( Name "$cse274" ) ) )
                                     )
                                     ( PrimBinOp Nothing PrimAnd
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                                        ( Ref Nothing ( Local ( Name "$cse279" ) ) )
+                                        ( Ref Nothing ( Local ( Name "$cse273" ) ) )
                                       )
                                       ( PrimBinOp Nothing PrimAnd
                                         ( Eq Nothing
                                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                                          ( Ref Nothing ( Local ( Name "$cse280" ) ) )
+                                          ( Ref Nothing ( Local ( Name "$cse274" ) ) )
                                         )
                                         ( AppN Nothing
                                           ( AppN Nothing
@@ -484,13 +470,13 @@ UberModule
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Nil" )
-                              ( Ref Nothing ( Local ( Name "$cse278" ) ) )
+                              ( Ref Nothing ( Local ( Name "$cse272" ) ) )
                             )
-                            ( Ref Nothing ( Local ( Name "$cse277" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse271" ) ) )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Cons" )
-                                ( Ref Nothing ( Local ( Name "$cse278" ) ) )
+                                ( Ref Nothing ( Local ( Name "$cse272" ) ) )
                               )
                               ( Ctor Nothing SumType
                                 ( ModuleName "Data.Generic.Rep" )
@@ -582,13 +568,19 @@ UberModule
           ( Standalone
             ( Nothing, Name "_", AppN Nothing
               ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "logShow" ) )
-                )
-                ( AppN Nothing
+                ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                ( IfThenElse Nothing
                   ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                      )
+                      ( Ref Nothing
+                        ( Imported
+                          ( ModuleName "Golden.BugListGenericEq.Test" )
+                          ( Name "Nil" )
+                        ) :| []
+                      )
                     )
                     ( Ref Nothing
                       ( Imported
@@ -597,9 +589,8 @@ UberModule
                       ) :| []
                     )
                   )
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Nil" ) ) :| []
-                  ) :| []
+                  ( LiteralString Nothing "true" )
+                  ( LiteralString Nothing "false" ) :| []
                 )
               )
               ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -607,13 +598,39 @@ UberModule
             [ Standalone
               ( Nothing, Name "_", AppN Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
                     ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                        )
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported
+                              ( ModuleName "Golden.BugListGenericEq.Test" )
+                              ( Name "cons$w" )
+                            )
+                          )
+                          ( LiteralInt Nothing 1 :|
+                            [ AppN Nothing
+                              ( Ref Nothing
+                                ( Imported
+                                  ( ModuleName "Golden.BugListGenericEq.Test" )
+                                  ( Name "cons$w" )
+                                )
+                              )
+                              ( LiteralInt Nothing 2 :|
+                                [ Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Golden.BugListGenericEq.Test" )
+                                    ( Name "Nil" )
+                                  )
+                                ]
+                              )
+                            ]
+                          ) :| []
+                        )
                       )
                       ( AppN Nothing
                         ( Ref Nothing
@@ -642,29 +659,8 @@ UberModule
                         ) :| []
                       )
                     )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "cons$w" ) )
-                      )
-                      ( LiteralInt Nothing 1 :|
-                        [ AppN Nothing
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.BugListGenericEq.Test" )
-                              ( Name "cons$w" )
-                            )
-                          )
-                          ( LiteralInt Nothing 2 :|
-                            [ Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.BugListGenericEq.Test" )
-                                ( Name "Nil" )
-                              )
-                            ]
-                          )
-                        ]
-                      ) :| []
-                    ) :| []
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -673,35 +669,37 @@ UberModule
           )
           ( AppN Nothing
             ( AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "logShow" ) )
-              )
-              ( AppN Nothing
+              ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+              ( IfThenElse Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "eq" ) )
+                    )
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "cons$w" ) )
+                      )
+                      ( LiteralInt Nothing 1 :|
+                        [ Ref Nothing
+                          ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Nil" ) )
+                        ]
+                      ) :| []
+                    )
                   )
                   ( AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "cons$w" ) )
                     )
-                    ( LiteralInt Nothing 1 :|
+                    ( LiteralInt Nothing 2 :|
                       [ Ref Nothing
                         ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Nil" ) )
                       ]
                     ) :| []
                   )
                 )
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "cons$w" ) )
-                  )
-                  ( LiteralInt Nothing 2 :|
-                    [ Ref Nothing
-                      ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Nil" ) )
-                    ]
-                  ) :| []
-                ) :| []
+                ( LiteralString Nothing "true" )
+                ( LiteralString Nothing "false" ) :| []
               )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -5,6 +5,7 @@ local Record_Unsafe_foreign = {
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
+local Effect_Console_log = Effect_Console_foreign.log
 local Type_Proxy_Proxy = {}
 local Data_HeytingAlgebra_heytingAlgebraBoolean
 Data_HeytingAlgebra_heytingAlgebraBoolean = {
@@ -39,17 +40,6 @@ local Data_Eq_eqRowCons_S_w = function( dictEqRecord
     end
   }
 end
-local Golden_BugListGenericEq_Test_logShow = function(a_S_2)
-  return Effect_Console_foreign.log((function()
-    if a_S_2 then
-      return "true"
-    elseif false == a_S_2 then
-      return "false"
-    else
-      return error("No patterns matched")
-    end
-  end)())
-end
 local Golden_BugListGenericEq_Test_Nil = {
   "Golden.BugListGenericEq.Test∷List.Nil"
 }
@@ -58,20 +48,20 @@ M.Golden_BugListGenericEq_Test_Cons = function(value0)
 end
 M.Golden_BugListGenericEq_Test_genericList = {
   to = function(x)
-    local _S_cse274 = x[1]
-    if "Data.Generic.Rep∷Sum.Inl" == _S_cse274 then
+    local _S_cse268 = x[1]
+    if "Data.Generic.Rep∷Sum.Inl" == _S_cse268 then
       return Golden_BugListGenericEq_Test_Nil
-    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse274 then
+    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse268 then
       return { "Golden.BugListGenericEq.Test∷List.Cons", x[2] }
     else
       return error("No patterns matched")
     end
   end,
   from = function(x0)
-    local _S_cse275 = x0[1]
-    if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse275 then
+    local _S_cse269 = x0[1]
+    if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse269 then
       return { "Data.Generic.Rep∷Sum.Inl", {} }
-    elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse275 then
+    elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse269 then
       return { "Data.Generic.Rep∷Sum.Inr", x0[2] }
     else
       return error("No patterns matched")
@@ -83,26 +73,26 @@ Golden_BugListGenericEq_Test_eqList = function(dictEq)
   return {
     eq = function(x)
       return function(y)
-        local _S_cse278 = y[1]
-        local _S_cse277 = { "Data.Generic.Rep∷Sum.Inl", {} }
-        local _S_cse276 = x[1]
+        local _S_cse272 = y[1]
+        local _S_cse271 = { "Data.Generic.Rep∷Sum.Inl", {} }
+        local _S_cse270 = x[1]
         return (function()
           local v_S_13 = (function()
-            if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse276 then
-              return _S_cse277
-            elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse276 then
+            if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse270 then
+              return _S_cse271
+            elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse270 then
               return { "Data.Generic.Rep∷Sum.Inr", x[2] }
             else
               return error("No patterns matched")
             end
           end)()
           return function(v1_S_14)
-            local _S_cse280 = v1_S_14[1]
-            local _S_cse279 = v_S_13[1]
-            if "Data.Generic.Rep∷Sum.Inl" == _S_cse279 then
-              return "Data.Generic.Rep∷Sum.Inl" == _S_cse280
+            local _S_cse274 = v1_S_14[1]
+            local _S_cse273 = v_S_13[1]
+            if "Data.Generic.Rep∷Sum.Inl" == _S_cse273 then
+              return "Data.Generic.Rep∷Sum.Inl" == _S_cse274
             else
-              return "Data.Generic.Rep∷Sum.Inr" == _S_cse279 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse280 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
+              return "Data.Generic.Rep∷Sum.Inr" == _S_cse273 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse274 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
                 eqRecord = function()
                   return function() return function() return true end end
                 end
@@ -114,9 +104,9 @@ Golden_BugListGenericEq_Test_eqList = function(dictEq)
             end
           end
         end)()((function()
-          if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse278 then
-            return _S_cse277
-          elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse278 then
+          if "Golden.BugListGenericEq.Test∷List.Nil" == _S_cse272 then
+            return _S_cse271
+          elseif "Golden.BugListGenericEq.Test∷List.Cons" == _S_cse272 then
             return { "Data.Generic.Rep∷Sum.Inr", y[2] }
           else
             return error("No patterns matched")
@@ -138,7 +128,25 @@ local Golden_BugListGenericEq_Test_cons_S_w = function(head, tail)
   }
 end
 return (function()
-  local _ = Golden_BugListGenericEq_Test_logShow(Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_Nil)(Golden_BugListGenericEq_Test_Nil))()
-  local _ = Golden_BugListGenericEq_Test_logShow(Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil))))()
-  return Golden_BugListGenericEq_Test_logShow(Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_Nil))(Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))()
+  local _ = Effect_Console_log((function()
+    if Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_Nil)(Golden_BugListGenericEq_Test_Nil) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)))(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil))) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  return Effect_Console_log((function()
+    if Golden_BugListGenericEq_Test_eq(Golden_BugListGenericEq_Test_cons_S_w(1, Golden_BugListGenericEq_Test_Nil))(Golden_BugListGenericEq_Test_cons_S_w(2, Golden_BugListGenericEq_Test_Nil)) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
 end)()

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
@@ -14,6 +14,12 @@ UberModule
         [ ( Nothing, Name "log" ) ]
       ), Standalone
       ( QName
+        { qnameModuleName = ModuleName "Effect.Console", qnameName = Name "log"
+        }, ObjectProp Nothing
+        ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
+        ( PropName "log" )
+      ), Standalone
+      ( QName
         { qnameModuleName = ModuleName "Type.Proxy", qnameName = Name "Proxy"
         }, Ctor Nothing ProductType
         ( ModuleName "Type.Proxy" )
@@ -263,7 +269,7 @@ UberModule
         )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse449", ObjectProp Nothing
+            ( Nothing, Name "$cse441", ObjectProp Nothing
               ( Ref Nothing ( Local ( Name "dictGeneric" ) ) )
               ( PropName "from" )
             ) :| []
@@ -275,12 +281,12 @@ UberModule
                 ( PropName "genericEq'" )
               )
               ( AppN Nothing
-                ( Ref Nothing ( Local ( Name "$cse449" ) ) )
+                ( Ref Nothing ( Local ( Name "$cse441" ) ) )
                 ( Ref Nothing ( Local ( Name "x" ) ) :| [] ) :| []
               )
             )
             ( AppN Nothing
-              ( Ref Nothing ( Local ( Name "$cse449" ) ) )
+              ( Ref Nothing ( Local ( Name "$cse441" ) ) )
               ( Ref Nothing ( Local ( Name "y" ) ) :| [] ) :| []
             )
           )
@@ -298,34 +304,34 @@ UberModule
                 ( ParamNamed Nothing ( Name "v1$8" ) :| [] )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "$cse451", ReflectCtor Nothing
+                    ( Nothing, Name "$cse443", ReflectCtor Nothing
                       ( Ref Nothing ( Local ( Name "v1$8" ) ) )
                     ) :| []
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse450", ReflectCtor Nothing
+                      ( Nothing, Name "$cse442", ReflectCtor Nothing
                         ( Ref Nothing ( Local ( Name "v$7" ) ) )
                       ) :| []
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                        ( Ref Nothing ( Local ( Name "$cse450" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse442" ) ) )
                       )
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                        ( Ref Nothing ( Local ( Name "$cse451" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse443" ) ) )
                       )
                       ( PrimBinOp Nothing PrimAnd
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                          ( Ref Nothing ( Local ( Name "$cse450" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse442" ) ) )
                         )
                         ( PrimBinOp Nothing PrimAnd
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                            ( Ref Nothing ( Local ( Name "$cse451" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse443" ) ) )
                           )
                           ( AppN Nothing
                             ( AppN Nothing
@@ -395,26 +401,6 @@ UberModule
         )
       ), Standalone
       ( QName
-        { qnameModuleName = ModuleName "Golden.GenericEqTwoTypes.Test", qnameName = Name "logShow"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
-        ( AppN Nothing
-          ( ObjectProp Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
-            ( PropName "log" )
-          )
-          ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "a$2" ) ) )
-            ( LiteralString Nothing "true" )
-            ( IfThenElse Nothing
-              ( Eq Nothing ( LiteralBool Nothing False ) ( Ref Nothing ( Local ( Name "a$2" ) ) ) )
-              ( LiteralString Nothing "false" )
-              ( Exception Nothing "No patterns matched" )
-            ) :| []
-          )
-        )
-      ), Standalone
-      ( QName
         { qnameModuleName = ModuleName "Golden.GenericEqTwoTypes.Test", qnameName = Name "Leaf"
         }, Ctor Nothing SumType
         ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -478,14 +464,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse452", ReflectCtor Nothing
+                ( Nothing, Name "$cse444", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                  ( Ref Nothing ( Local ( Name "$cse452" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse444" ) ) )
                 )
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Leaf" ) )
@@ -493,7 +479,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                    ( Ref Nothing ( Local ( Name "$cse452" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse444" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -510,14 +496,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x0" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse453", ReflectCtor Nothing
+                ( Nothing, Name "$cse445", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x0" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.GenericEqTwoTypes.Test∷Tree.Leaf" )
-                  ( Ref Nothing ( Local ( Name "$cse453" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse445" ) ) )
                 )
                 ( Ctor Nothing SumType
                   ( ModuleName "Data.Generic.Rep" )
@@ -530,7 +516,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.GenericEqTwoTypes.Test∷Tree.Node" )
-                    ( Ref Nothing ( Local ( Name "$cse453" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse445" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Data.Generic.Rep" )
@@ -555,14 +541,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse454", ReflectCtor Nothing
+                ( Nothing, Name "$cse446", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                  ( Ref Nothing ( Local ( Name "$cse454" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse446" ) ) )
                 )
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Nil" ) )
@@ -570,7 +556,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                    ( Ref Nothing ( Local ( Name "$cse454" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse446" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -587,14 +573,14 @@ UberModule
             ( ParamNamed Nothing ( Name "x0" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse455", ReflectCtor Nothing
+                ( Nothing, Name "$cse447", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "x0" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.GenericEqTwoTypes.Test∷List.Nil" )
-                  ( Ref Nothing ( Local ( Name "$cse455" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse447" ) ) )
                 )
                 ( Ctor Nothing SumType
                   ( ModuleName "Data.Generic.Rep" )
@@ -607,7 +593,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.GenericEqTwoTypes.Test∷List.Cons" )
-                    ( Ref Nothing ( Local ( Name "$cse455" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse447" ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Data.Generic.Rep" )
@@ -950,13 +936,39 @@ UberModule
           ( Standalone
             ( Nothing, Name "_", AppN Nothing
               ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "logShow" ) )
-                )
-                ( AppN Nothing
+                ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                ( IfThenElse Nothing
                   ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
+                      )
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported
+                            ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                            ( Name "cons$w" )
+                          )
+                        )
+                        ( LiteralInt Nothing 1 :|
+                          [ AppN Nothing
+                            ( Ref Nothing
+                              ( Imported
+                                ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                ( Name "cons$w" )
+                              )
+                            )
+                            ( LiteralInt Nothing 2 :|
+                              [ Ref Nothing
+                                ( Imported
+                                  ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                  ( Name "Nil" )
+                                )
+                              ]
+                            )
+                          ]
+                        ) :| []
+                      )
                     )
                     ( AppN Nothing
                       ( Ref Nothing
@@ -985,12 +997,40 @@ UberModule
                       ) :| []
                     )
                   )
-                  ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "cons$w" ) )
-                    )
-                    ( LiteralInt Nothing 1 :|
-                      [ AppN Nothing
+                  ( LiteralString Nothing "true" )
+                  ( LiteralString Nothing "false" ) :| []
+                )
+              )
+              ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
+            ) :|
+            [ Standalone
+              ( Nothing, Name "_", AppN Nothing
+                ( AppN Nothing
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
+                        )
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported
+                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                              ( Name "cons$w" )
+                            )
+                          )
+                          ( LiteralInt Nothing 1 :|
+                            [ Ref Nothing
+                              ( Imported
+                                ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                ( Name "Nil" )
+                              )
+                            ]
+                          ) :| []
+                        )
+                      )
+                      ( AppN Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -1004,68 +1044,58 @@ UberModule
                               ( Name "Nil" )
                             )
                           ]
-                        )
-                      ]
-                    ) :| []
-                  ) :| []
-                )
-              )
-              ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
-            ) :|
-            [ Standalone
-              ( Nothing, Name "_", AppN Nothing
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq1" ) )
-                      )
-                      ( AppN Nothing
-                        ( Ref Nothing
-                          ( Imported
-                            ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                            ( Name "cons$w" )
-                          )
-                        )
-                        ( LiteralInt Nothing 1 :|
-                          [ Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                              ( Name "Nil" )
-                            )
-                          ]
                         ) :| []
                       )
                     )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported
-                          ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                          ( Name "cons$w" )
-                        )
-                      )
-                      ( LiteralInt Nothing 2 :|
-                        [ Ref Nothing
-                          ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Nil" ) )
-                        ]
-                      ) :| []
-                    ) :| []
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
               ( Nothing, Name "_", AppN Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
                     ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
+                        )
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported
+                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                              ( Name "node$w" )
+                            )
+                          )
+                          ( Ref Nothing
+                            ( Imported
+                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                              ( Name "Leaf" )
+                            ) :|
+                            [ LiteralInt Nothing 1, AppN Nothing
+                              ( Ref Nothing
+                                ( Imported
+                                  ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                  ( Name "node$w" )
+                                )
+                              )
+                              ( Ref Nothing
+                                ( Imported
+                                  ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                  ( Name "Leaf" )
+                                ) :|
+                                [ LiteralInt Nothing 2, Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                                    ( Name "Leaf" )
+                                  )
+                                ]
+                              )
+                            ]
+                          ) :| []
+                        )
                       )
                       ( AppN Nothing
                         ( Ref Nothing
@@ -1102,6 +1132,23 @@ UberModule
                         ) :| []
                       )
                     )
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
+                  )
+                )
+                ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
+              )
+            ]
+          )
+          ( AppN Nothing
+            ( AppN Nothing
+              ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+              ( IfThenElse Nothing
+                ( AppN Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
+                    )
                     ( AppN Nothing
                       ( Ref Nothing
                         ( Imported
@@ -1114,43 +1161,14 @@ UberModule
                           ( ModuleName "Golden.GenericEqTwoTypes.Test" )
                           ( Name "Leaf" )
                         ) :|
-                        [ LiteralInt Nothing 1, AppN Nothing
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                              ( Name "node$w" )
-                            )
-                          )
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                              ( Name "Leaf" )
-                            ) :|
-                            [ LiteralInt Nothing 2, Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.GenericEqTwoTypes.Test" )
-                                ( Name "Leaf" )
-                              )
-                            ]
+                        [ LiteralInt Nothing 1, Ref Nothing
+                          ( Imported
+                            ( ModuleName "Golden.GenericEqTwoTypes.Test" )
+                            ( Name "Leaf" )
                           )
                         ]
                       ) :| []
-                    ) :| []
-                  )
-                )
-                ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
-              )
-            ]
-          )
-          ( AppN Nothing
-            ( AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "logShow" ) )
-              )
-              ( AppN Nothing
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "eq" ) )
+                    )
                   )
                   ( AppN Nothing
                     ( Ref Nothing
@@ -1161,23 +1179,14 @@ UberModule
                         ( ModuleName "Golden.GenericEqTwoTypes.Test" )
                         ( Name "Leaf" )
                       ) :|
-                      [ LiteralInt Nothing 1, Ref Nothing
+                      [ LiteralInt Nothing 2, Ref Nothing
                         ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Leaf" ) )
                       ]
                     ) :| []
                   )
                 )
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "node$w" ) )
-                  )
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Leaf" ) ) :|
-                    [ LiteralInt Nothing 2, Ref Nothing
-                      ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Leaf" ) )
-                    ]
-                  ) :| []
-                ) :| []
+                ( LiteralString Nothing "true" )
+                ( LiteralString Nothing "false" ) :| []
               )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.lua
@@ -5,6 +5,7 @@ local Record_Unsafe_foreign = {
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
+local Effect_Console_log = Effect_Console_foreign.log
 local Type_Proxy_Proxy = {}
 local Data_HeytingAlgebra_heytingAlgebraBoolean
 Data_HeytingAlgebra_heytingAlgebraBoolean = {
@@ -60,19 +61,19 @@ local Data_Eq_Generic_genericEqConstructor = function(dictGenericEq)
   }
 end
 local Data_Eq_Generic_genericEq_S_w = function(dictGeneric, dictGenericEq, x, y)
-  local _S_cse449 = dictGeneric.from
-  return dictGenericEq.genericEqPrime(_S_cse449(x))(_S_cse449(y))
+  local _S_cse441 = dictGeneric.from
+  return dictGenericEq.genericEqPrime(_S_cse441(x))(_S_cse441(y))
 end
 local Golden_GenericEqTwoTypes_Test_genericEqSum = function(dictGenericEq1_S_5)
   return {
     genericEqPrime = function(v_S_7)
       return function(v1_S_8)
-        local _S_cse451 = v1_S_8[1]
-        local _S_cse450 = v_S_7[1]
-        if "Data.Generic.Rep∷Sum.Inl" == _S_cse450 then
-          return "Data.Generic.Rep∷Sum.Inl" == _S_cse451
+        local _S_cse443 = v1_S_8[1]
+        local _S_cse442 = v_S_7[1]
+        if "Data.Generic.Rep∷Sum.Inl" == _S_cse442 then
+          return "Data.Generic.Rep∷Sum.Inl" == _S_cse443
         else
-          return "Data.Generic.Rep∷Sum.Inr" == _S_cse450 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse451 and dictGenericEq1_S_5.genericEqPrime(v_S_7[2])(v1_S_8[2]))
+          return "Data.Generic.Rep∷Sum.Inr" == _S_cse442 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse443 and dictGenericEq1_S_5.genericEqPrime(v_S_7[2])(v1_S_8[2]))
         end
       end
     end
@@ -88,17 +89,6 @@ local Golden_GenericEqTwoTypes_Test_eqRowCons_S_w = function( eqRowCons_S_p3_S_2
       return function() return function() return true end end
     end
   }, nil, eqRowCons_S_p3_S_233, eqRowCons_S_p4_S_234)
-end
-local Golden_GenericEqTwoTypes_Test_logShow = function(a_S_2)
-  return Effect_Console_foreign.log((function()
-    if a_S_2 then
-      return "true"
-    elseif false == a_S_2 then
-      return "false"
-    else
-      return error("No patterns matched")
-    end
-  end)())
 end
 local Golden_GenericEqTwoTypes_Test_Leaf = {
   "Golden.GenericEqTwoTypes.Test∷Tree.Leaf"
@@ -120,20 +110,20 @@ local Golden_GenericEqTwoTypes_Test_node_S_w = function(left, value, right)
 end
 local Golden_GenericEqTwoTypes_Test_genericTree = {
   to = function(x)
-    local _S_cse452 = x[1]
-    if "Data.Generic.Rep∷Sum.Inl" == _S_cse452 then
+    local _S_cse444 = x[1]
+    if "Data.Generic.Rep∷Sum.Inl" == _S_cse444 then
       return Golden_GenericEqTwoTypes_Test_Leaf
-    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse452 then
+    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse444 then
       return { "Golden.GenericEqTwoTypes.Test∷Tree.Node", x[2] }
     else
       return error("No patterns matched")
     end
   end,
   from = function(x0)
-    local _S_cse453 = x0[1]
-    if "Golden.GenericEqTwoTypes.Test∷Tree.Leaf" == _S_cse453 then
+    local _S_cse445 = x0[1]
+    if "Golden.GenericEqTwoTypes.Test∷Tree.Leaf" == _S_cse445 then
       return { "Data.Generic.Rep∷Sum.Inl", Data_Generic_Rep_NoArguments }
-    elseif "Golden.GenericEqTwoTypes.Test∷Tree.Node" == _S_cse453 then
+    elseif "Golden.GenericEqTwoTypes.Test∷Tree.Node" == _S_cse445 then
       return { "Data.Generic.Rep∷Sum.Inr", x0[2] }
     else
       return error("No patterns matched")
@@ -142,20 +132,20 @@ local Golden_GenericEqTwoTypes_Test_genericTree = {
 }
 local Golden_GenericEqTwoTypes_Test_genericList = {
   to = function(x)
-    local _S_cse454 = x[1]
-    if "Data.Generic.Rep∷Sum.Inl" == _S_cse454 then
+    local _S_cse446 = x[1]
+    if "Data.Generic.Rep∷Sum.Inl" == _S_cse446 then
       return Golden_GenericEqTwoTypes_Test_Nil
-    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse454 then
+    elseif "Data.Generic.Rep∷Sum.Inr" == _S_cse446 then
       return { "Golden.GenericEqTwoTypes.Test∷List.Cons", x[2] }
     else
       return error("No patterns matched")
     end
   end,
   from = function(x0)
-    local _S_cse455 = x0[1]
-    if "Golden.GenericEqTwoTypes.Test∷List.Nil" == _S_cse455 then
+    local _S_cse447 = x0[1]
+    if "Golden.GenericEqTwoTypes.Test∷List.Nil" == _S_cse447 then
       return { "Data.Generic.Rep∷Sum.Inl", Data_Generic_Rep_NoArguments }
-    elseif "Golden.GenericEqTwoTypes.Test∷List.Cons" == _S_cse455 then
+    elseif "Golden.GenericEqTwoTypes.Test∷List.Cons" == _S_cse447 then
       return { "Data.Generic.Rep∷Sum.Inr", x0[2] }
     else
       return error("No patterns matched")
@@ -201,8 +191,32 @@ local Golden_GenericEqTwoTypes_Test_cons_S_w = function(head, tail)
   }
 end
 return (function()
-  local _ = Golden_GenericEqTwoTypes_Test_logShow(Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil))))()
-  local _ = Golden_GenericEqTwoTypes_Test_logShow(Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_Nil))(Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))()
-  local _ = Golden_GenericEqTwoTypes_Test_logShow(Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf))))()
-  return Golden_GenericEqTwoTypes_Test_logShow(Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_Leaf))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))()
+  local _ = Effect_Console_log((function()
+    if Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)))(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil))) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Golden_GenericEqTwoTypes_Test_eq1(Golden_GenericEqTwoTypes_Test_cons_S_w(1, Golden_GenericEqTwoTypes_Test_Nil))(Golden_GenericEqTwoTypes_Test_cons_S_w(2, Golden_GenericEqTwoTypes_Test_Nil)) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf))) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  return Effect_Console_log((function()
+    if Golden_GenericEqTwoTypes_Test_eq(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 1, Golden_GenericEqTwoTypes_Test_Leaf))(Golden_GenericEqTwoTypes_Test_node_S_w(Golden_GenericEqTwoTypes_Test_Leaf, 2, Golden_GenericEqTwoTypes_Test_Leaf)) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
 end)()

--- a/test/ps/output/Golden.NumberIsNaN.Test/golden.ir
+++ b/test/ps/output/Golden.NumberIsNaN.Test/golden.ir
@@ -2,16 +2,15 @@ UberModule
   { uberModuleBindings =
     [ Standalone
       ( QName
-        { qnameModuleName = ModuleName "Data.Semiring", qnameName = Name "foreign"
-        }, ForeignImport Nothing
-        ( ModuleName "Data.Semiring" ) ".spago/p/prelude/5718c84fdde6247749cb053e816df696c30fe691/src/Data/Semiring.purs"
-        [ ( Nothing, Name "numAdd" ), ( Nothing, Name "numMul" ) ]
-      ), Standalone
-      ( QName
         { qnameModuleName = ModuleName "Data.Ring", qnameName = Name "foreign"
         }, ForeignImport Nothing
         ( ModuleName "Data.Ring" ) ".spago/p/prelude/5718c84fdde6247749cb053e816df696c30fe691/src/Data/Ring.purs"
         [ ( Nothing, Name "numSub" ) ]
+      ), Standalone
+      ( QName
+        { qnameModuleName = ModuleName "Data.Ring", qnameName = Name "numSub" }, ObjectProp Nothing
+        ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "foreign" ) ) )
+        ( PropName "numSub" )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Number", qnameName = Name "foreign"
@@ -43,56 +42,10 @@ UberModule
         [ ( Nothing, Name "log" ) ]
       ), Standalone
       ( QName
-        { qnameModuleName = ModuleName "Data.Ring", qnameName = Name "sub" }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "dict" ) :| [] )
-        ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "dict" ) ) ) ( PropName "sub" ) )
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Data.Ring", qnameName = Name "ringNumber"
-        }, LiteralObject Nothing
-        [
-          ( PropName "sub", ObjectProp Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "foreign" ) ) )
-            ( PropName "numSub" )
-          ),
-          ( PropName "Semiring0", AbsN Nothing
-            ( ParamUnused Nothing :| [] )
-            ( LiteralObject Nothing
-              [
-                ( PropName "add", ObjectProp Nothing
-                  ( Ref Nothing ( Imported ( ModuleName "Data.Semiring" ) ( Name "foreign" ) ) )
-                  ( PropName "numAdd" )
-                ),
-                ( PropName "zero", LiteralFloat Nothing 0.0 ),
-                ( PropName "mul", ObjectProp Nothing
-                  ( Ref Nothing ( Imported ( ModuleName "Data.Semiring" ) ( Name "foreign" ) ) )
-                  ( PropName "numMul" )
-                ),
-                ( PropName "one", LiteralFloat Nothing 1.0 )
-              ]
-            )
-          )
-        ]
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.NumberIsNaN.Test", qnameName = Name "logShow"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
-        ( AppN Nothing
-          ( ObjectProp Nothing
-            ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
-            ( PropName "log" )
-          )
-          ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "a$2" ) ) )
-            ( LiteralString Nothing "true" )
-            ( IfThenElse Nothing
-              ( Eq Nothing ( LiteralBool Nothing False ) ( Ref Nothing ( Local ( Name "a$2" ) ) ) )
-              ( LiteralString Nothing "false" )
-              ( Exception Nothing "No patterns matched" )
-            ) :| []
-          )
-        )
+        { qnameModuleName = ModuleName "Effect.Console", qnameName = Name "log"
+        }, ObjectProp Nothing
+        ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
+        ( PropName "log" )
       )
     ], uberModuleForeigns = [], uberModuleExports =
     [
@@ -102,14 +55,14 @@ UberModule
           ( Standalone
             ( Nothing, Name "_", AppN Nothing
               ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.NumberIsNaN.Test" ) ( Name "logShow" ) )
-                )
-                ( AppN Nothing
-                  ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Data.Number" ) ( Name "nan" ) ) :| []
-                  ) :| []
+                ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                ( IfThenElse Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
+                    ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "nan" ) ) :| [] )
+                  )
+                  ( LiteralString Nothing "true" )
+                  ( LiteralString Nothing "false" ) :| []
                 )
               )
               ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -117,77 +70,60 @@ UberModule
             [ Standalone
               ( Nothing, Name "_", AppN Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.NumberIsNaN.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
-                    ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
                     ( AppN Nothing
+                      ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                       ( AppN Nothing
                         ( AppN Nothing
-                          ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "sub" ) ) )
-                          ( Ref Nothing
-                            ( Imported ( ModuleName "Data.Ring" ) ( Name "ringNumber" ) ) :| []
-                          )
+                          ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "numSub" ) ) )
+                          ( LiteralFloat Nothing 0.0 :| [] )
                         )
-                        ( ObjectProp Nothing
-                          ( AppN Nothing
-                            ( ObjectProp Nothing
-                              ( Ref Nothing
-                                ( Imported ( ModuleName "Data.Ring" ) ( Name "ringNumber" ) )
-                              )
-                              ( PropName "Semiring0" )
-                            )
-                            ( Ref Nothing
-                              ( Imported ( ModuleName "Prim" ) ( Name "undefined" ) ) :| []
-                            )
-                          )
-                          ( PropName "zero" ) :| []
-                        )
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Data.Number" ) ( Name "nan" ) ) :| []
+                        ) :| []
                       )
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Data.Number" ) ( Name "nan" ) ) :| []
-                      ) :| []
-                    ) :| []
+                    )
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
               ( Nothing, Name "_", AppN Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.NumberIsNaN.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
-                    ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
                     ( AppN Nothing
+                      ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
                       ( AppN Nothing
                         ( AppN Nothing
-                          ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "sub" ) ) )
+                          ( Ref Nothing ( Imported ( ModuleName "Data.Ring" ) ( Name "numSub" ) ) )
                           ( Ref Nothing
-                            ( Imported ( ModuleName "Data.Ring" ) ( Name "ringNumber" ) ) :| []
+                            ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
                           )
                         )
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
-                        )
+                        ) :| []
                       )
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
-                      ) :| []
-                    ) :| []
+                    )
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
               ( Nothing, Name "_", AppN Nothing
                 ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.NumberIsNaN.Test" ) ( Name "logShow" ) )
-                  )
-                  ( AppN Nothing
-                    ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
-                    ( LiteralFloat Nothing 42.0 :| [] ) :| []
+                  ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+                  ( IfThenElse Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
+                      ( LiteralFloat Nothing 42.0 :| [] )
+                    )
+                    ( LiteralString Nothing "true" )
+                    ( LiteralString Nothing "false" ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -196,14 +132,16 @@ UberModule
           )
           ( AppN Nothing
             ( AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.NumberIsNaN.Test" ) ( Name "logShow" ) )
-              )
-              ( AppN Nothing
-                ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
-                ) :| []
+              ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
+              ( IfThenElse Nothing
+                ( AppN Nothing
+                  ( Ref Nothing ( Imported ( ModuleName "Data.Number" ) ( Name "isNaN" ) ) )
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.Number" ) ( Name "infinity" ) ) :| []
+                  )
+                )
+                ( LiteralString Nothing "true" )
+                ( LiteralString Nothing "false" ) :| []
               )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.NumberIsNaN.Test/golden.lua
+++ b/test/ps/output/Golden.NumberIsNaN.Test/golden.lua
@@ -1,10 +1,7 @@
-local Data_Semiring_foreign = {
-  numAdd = function(x) return function(y) return x + y end end,
-  numMul = function(x) return function(y) return x * y end end
-}
 local Data_Ring_foreign = {
   numSub = function(x) return function(y) return x - y end end
 }
+local Data_Ring_numSub = Data_Ring_foreign.numSub
 local Data_Number_foreign = {
   nan = 0 / 0,
   isNaN = function(x) return x ~= x end,
@@ -16,33 +13,37 @@ local Data_Number_nan = Data_Number_foreign.nan
 local Effect_Console_foreign = {
   log = function(s) return function() print(s) end end
 }
-local Data_Ring_sub = function(dict) return dict.sub end
-local Data_Ring_ringNumber = {
-  sub = Data_Ring_foreign.numSub,
-  Semiring0 = function()
-    return {
-      add = Data_Semiring_foreign.numAdd,
-      zero = 0.0,
-      mul = Data_Semiring_foreign.numMul,
-      one = 1.0
-    }
-  end
-}
-local Golden_NumberIsNaN_Test_logShow = function(a_S_2)
-  return Effect_Console_foreign.log((function()
-    if a_S_2 then
-      return "true"
-    elseif false == a_S_2 then
-      return "false"
-    else
-      return error("No patterns matched")
-    end
-  end)())
-end
+local Effect_Console_log = Effect_Console_foreign.log
 return (function()
-  local _ = Golden_NumberIsNaN_Test_logShow(Data_Number_isNaN(Data_Number_nan))()
-  local _ = Golden_NumberIsNaN_Test_logShow(Data_Number_isNaN(Data_Ring_sub(Data_Ring_ringNumber)((Data_Ring_ringNumber.Semiring0()).zero)(Data_Number_nan)))()
-  local _ = Golden_NumberIsNaN_Test_logShow(Data_Number_isNaN(Data_Ring_sub(Data_Ring_ringNumber)(Data_Number_infinity)(Data_Number_infinity)))()
-  local _ = Golden_NumberIsNaN_Test_logShow(Data_Number_isNaN(42.0))()
-  return Golden_NumberIsNaN_Test_logShow(Data_Number_isNaN(Data_Number_infinity))()
+  local _ = Effect_Console_log((function()
+    if Data_Number_isNaN(Data_Number_nan) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Data_Number_isNaN(Data_Ring_numSub(0.0)(Data_Number_nan)) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Data_Number_isNaN(Data_Ring_numSub(Data_Number_infinity)(Data_Number_infinity)) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
+  local _ = Effect_Console_log((function()
+    if Data_Number_isNaN(42.0) then return "true" else return "false" end
+  end)())()
+  return Effect_Console_log((function()
+    if Data_Number_isNaN(Data_Number_infinity) then
+      return "true"
+    else
+      return "false"
+    end
+  end)())()
 end)()

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -167,13 +167,7 @@ UberModule
                   ( IfThenElse Nothing
                     ( Ref Nothing ( Local ( Name "v$241" ) ) )
                     ( LiteralString Nothing "true" )
-                    ( IfThenElse Nothing
-                      ( Eq Nothing ( LiteralBool Nothing False )
-                        ( Ref Nothing ( Local ( Name "v$241" ) ) )
-                      )
-                      ( LiteralString Nothing "false" )
-                      ( Exception Nothing "No patterns matched" )
-                    )
+                    ( LiteralString Nothing "false" )
                   )
                 )
               ]

--- a/test/ps/output/Golden.Primops.Test/golden.lua
+++ b/test/ps/output/Golden.Primops.Test/golden.lua
@@ -37,13 +37,7 @@ end
 return (function()
   local _S_cse252 = {
     show = function(v_S_241)
-      if v_S_241 then
-        return "true"
-      elseif false == v_S_241 then
-        return "false"
-      else
-        return error("No patterns matched")
-      end
+      if v_S_241 then return "true" else return "false" end
     end
   }
   local _ = Effect_Console_logShow_S_w({

--- a/test/ps/output/Golden.RecursiveBindings.Test/golden.ir
+++ b/test/ps/output/Golden.RecursiveBindings.Test/golden.ir
@@ -12,15 +12,9 @@ UberModule
                   ( Ref Nothing ( Local ( Name "no$1" ) ) )
                   ( LiteralBool Nothing False :| [] )
                 )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( LiteralBool Nothing False )
-                    ( Ref Nothing ( Local ( Name "v$2" ) ) )
-                  )
-                  ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "no$1" ) ) )
-                    ( LiteralBool Nothing True :| [] )
-                  )
-                  ( Exception Nothing "No patterns matched" )
+                ( AppN Nothing
+                  ( Ref Nothing ( Local ( Name "no$1" ) ) )
+                  ( LiteralBool Nothing True :| [] )
                 )
               )
             ) :|
@@ -33,15 +27,9 @@ UberModule
                     ( Ref Nothing ( Local ( Name "yes$0" ) ) )
                     ( LiteralBool Nothing False :| [] )
                   )
-                  ( IfThenElse Nothing
-                    ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "v0$3" ) ) )
-                    )
-                    ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "yes$0" ) ) )
-                      ( LiteralBool Nothing True :| [] )
-                    )
-                    ( Exception Nothing "No patterns matched" )
+                  ( AppN Nothing
+                    ( Ref Nothing ( Local ( Name "yes$0" ) ) )
+                    ( LiteralBool Nothing True :| [] )
                   )
                 )
               )
@@ -64,15 +52,9 @@ UberModule
                   ( Ref Nothing ( Local ( Name "no$15" ) ) )
                   ( LiteralBool Nothing False :| [] )
                 )
-                ( IfThenElse Nothing
-                  ( Eq Nothing ( LiteralBool Nothing False )
-                    ( Ref Nothing ( Local ( Name "v$16" ) ) )
-                  )
-                  ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "no$15" ) ) )
-                    ( LiteralBool Nothing True :| [] )
-                  )
-                  ( Exception Nothing "No patterns matched" )
+                ( AppN Nothing
+                  ( Ref Nothing ( Local ( Name "no$15" ) ) )
+                  ( LiteralBool Nothing True :| [] )
                 )
               )
             ) :|
@@ -85,15 +67,9 @@ UberModule
                     ( Ref Nothing ( Local ( Name "yes$14" ) ) )
                     ( LiteralBool Nothing False :| [] )
                   )
-                  ( IfThenElse Nothing
-                    ( Eq Nothing ( LiteralBool Nothing False )
-                      ( Ref Nothing ( Local ( Name "v0$17" ) ) )
-                    )
-                    ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "yes$14" ) ) )
-                      ( LiteralBool Nothing True :| [] )
-                    )
-                    ( Exception Nothing "No patterns matched" )
+                  ( AppN Nothing
+                    ( Ref Nothing ( Local ( Name "yes$14" ) ) )
+                    ( LiteralBool Nothing True :| [] )
                   )
                 )
               )

--- a/test/ps/output/Golden.RecursiveBindings.Test/golden.lua
+++ b/test/ps/output/Golden.RecursiveBindings.Test/golden.lua
@@ -3,22 +3,10 @@ return {
     local yes_S_0
     local no_S_1
     yes_S_0 = function(v_S_2)
-      if v_S_2 then
-        return no_S_1(false)
-      elseif false == v_S_2 then
-        return no_S_1(true)
-      else
-        return error("No patterns matched")
-      end
+      if v_S_2 then return no_S_1(false) else return no_S_1(true) end
     end
     no_S_1 = function(v0_S_3)
-      if v0_S_3 then
-        return yes_S_0(false)
-      elseif false == v0_S_3 then
-        return yes_S_0(true)
-      else
-        return error("No patterns matched")
-      end
+      if v0_S_3 then return yes_S_0(false) else return yes_S_0(true) end
     end
     return no_S_1(false)
   end)(),
@@ -26,22 +14,10 @@ return {
     local yes_S_14
     local no_S_15
     yes_S_14 = function(v_S_16)
-      if v_S_16 then
-        return no_S_15(false)
-      elseif false == v_S_16 then
-        return no_S_15(true)
-      else
-        return error("No patterns matched")
-      end
+      if v_S_16 then return no_S_15(false) else return no_S_15(true) end
     end
     no_S_15 = function(v0_S_17)
-      if v0_S_17 then
-        return yes_S_14(false)
-      elseif false == v0_S_17 then
-        return yes_S_14(true)
-      else
-        return error("No patterns matched")
-      end
+      if v0_S_17 then return yes_S_14(false) else return yes_S_14(true) end
     end
     return no_S_15(false)
   end)(),

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.ir
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.ir
@@ -2021,13 +2021,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Ref Nothing ( Local ( Name "v$1236" ) ) )
                           ( LiteralString Nothing "true" )
-                          ( IfThenElse Nothing
-                            ( Eq Nothing ( LiteralBool Nothing False )
-                              ( Ref Nothing ( Local ( Name "v$1236" ) ) )
-                            )
-                            ( LiteralString Nothing "false" )
-                            ( Exception Nothing "No patterns matched" )
-                          )
+                          ( LiteralString Nothing "false" )
                         )
                       )
                     ] :|

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -638,13 +638,7 @@ return (function()
   end)())()
   local _ = Effect_Console_logShow_S_w({
     show = function(v_S_1236)
-      if v_S_1236 then
-        return "true"
-      elseif false == v_S_1236 then
-        return "false"
-      else
-        return error("No patterns matched")
-      end
+      if v_S_1236 then return "true" else return "false" end
     end
   }, Data_String_CodePoints_foreign._fromCodePointArray(Data_String_CodePoints_singletonFallback)(Data_String_CodePoints_toCodePointArray("aéЯ𝐀z")) == "aéЯ𝐀z")()
   return Effect_Console_logShow_S_w(Golden_StringCodePoints_Test_showArray, Data_Functor_arrayMap(Golden_StringCodePoints_Test_fromEnum)(Data_String_CodePoints_toCodePointArray(Data_String_CodePoints_singleton(Partial_Unsafe__unsafePartial(function(  )


### PR DESCRIPTION
Closes #223.

## What

A pattern match on a `Boolean` compiled to a three-way `if` with a synthesized, unreachable default — the shape every inlined `show` or `logShow` of a boolean produces:

```lua
if a then
  return "true"
elseif false == a then
  return "false"
else
  return error("No patterns matched")
end
```

`a` is a `Boolean`, so `true`/`false` already cover it, but no existing rule had a handle on the shape: `constantFolding` knew only the left-literal `true == b` case, and the unreachable-branch rules need a literal condition. It now reduces to:

```lua
if a then return "true" else return "false" end
```

## How

Both pieces proposed in the issue, reusing the existing folds for the actual collapse:

1. **The boolean-equality fold in `constantFolding` is completed.** `false == b` and `b == false` fold to `not b`, and `b == true` folds to `b`, mirroring the existing left-literal `true == b` case (sound per Note [IR is assumed well-typed]).

2. **New rule `propagateKnownCondIntoBranches`** — the Boolean sibling of `propagateKnownCtorThroughLet`, the more general of the issue's two alternatives. Inside `if c then t else e` a variable condition `c` is `true` throughout `t` and `false` throughout `e`, so its free occurrences in the branches are replaced with the matching literal; the existing folds then finish the job:

   ```
   if c then "true" else (if (false == c) then "false" else Exc)
     -- propagation: in the else branch, c is known false
   if c then "true" else (if (false == false) then "false" else Exc)
     -- constantFolding (existing): false == false → true
   if c then "true" else (if true then "false" else Exc)
     -- removeUnreachableElseBranch (existing)
   if c then "true" else "false"
   ```

   The rule fires only on a variable condition (re-reading an immutable binding is free and yields the value the test just observed), leaves no free occurrence behind so it cannot re-fire on its own result, and never grows the tree (a `Ref` becomes a literal node-for-node). It is placed after `removeIfWithEqualBranches` in the rewrite chain: branches that are equal while still naming `c` collapse to a single copy, which substituting the two literals first would unequalize — a unit test pins this ordering.

## Tests

Written test-first (red before the fix): unit tests pin the three new equality folds, the end-to-end three-way→two-way collapse, then-branch propagation (`if a then a else e` → `a or e`), and the guards — a genuinely partial match keeps its default, and a guard testing a *different* variable keeps the `error` arm. The randomized IR specs pass across 5 extra seeds.

## Goldens

The `elseif false ==` idiom disappears from every golden that carried it (9 sites across 6 goldens at current `main`; the issue counted 16 against an older corpus). Sample from `Golden.RecursiveBindings.Test`:

```diff
     yes_S_0 = function(v_S_2)
-      if v_S_2 then
-        return no_S_1(false)
-      elseif false == v_S_2 then
-        return no_S_1(true)
-      else
-        return error("No patterns matched")
-      end
+      if v_S_2 then return no_S_1(false) else return no_S_1(true) end
     end
```

The collapse also cascades: the shrunk boolean `show` bodies now clear the call-site inline budget, so `logShow` pastes at its call sites in the GenericEq/NumberIsNaN goldens, and in `Golden.NumberIsNaN.Test` that dead-codes the whole `Ring` dictionary:

```diff
-local Data_Semiring_foreign = {
-  numAdd = function(x) return function(y) return x + y end end,
-  numMul = function(x) return function(y) return x * y end end
-}
 ...
-local Data_Ring_sub = function(dict) return dict.sub end
-local Data_Ring_ringNumber = {
-  sub = Data_Ring_foreign.numSub,
-  Semiring0 = function()
-    return {
-      add = Data_Semiring_foreign.numAdd,
-      zero = 0.0,
-      mul = Data_Semiring_foreign.numMul,
-      one = 1.0
-    }
-  end
-}
```

`Golden.GenericEqTwoTypes.Test` keeps its 4 remaining `error("No patterns matched")` defaults — those are constructor-tag matches on closed sums, explicitly out of scope per the issue. **Eval goldens are unchanged**, which is the semantic safety net: runtime output is identical, only the shape moved.
