### PR TITLE
feat(optimizer): splice a tail-position application of a function literal

### DIFF
--- a/changelog.d/20260724_150000_unisay_splice_tail_literal_application.md
+++ b/changelog.d/20260724_150000_unisay_splice_tail_literal_application.md
@@ -1,0 +1,40 @@
+### Added
+
+- A tail-position application of a function literal splices into the
+  enclosing function body (#295). #230 and the trailing-call fold removed
+  the scope-call closures but stopped one step short: when the pushed
+  application landed on a returned function literal, the beta-redex
+  stayed — one closure allocation and one extra call per invocation.
+  `Golden.LongApplyChain.Test`'s `applySecond` carried the shape on every
+  node of its 40-deep apply chain:
+
+  ```lua
+  return (function(v1_S_626)
+    if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
+      ...
+    end
+  end)(b_S_134)
+  ```
+
+  The generalized rule — `collapseTailLiteralApplication`, formerly
+  `collapseTailScopeCall` — binds the parameters as one simultaneous
+  `local` and splices the body:
+
+  ```lua
+  local v1_S_626 = b_S_134
+  if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
+    ...
+  end
+  ```
+
+  The one-statement `local` is the exact translation of Lua's call
+  binding (the whole initializer list evaluates before any name binds,
+  the last expression expands its multiple values, missing values fill
+  with `nil`), and the arguments stay at the same program point in the
+  same scope. `foldCallThroughScopeCall` also hands each literal it
+  rebuilds to the collapse, so the redexes it creates at depths the
+  bottom-up driver has already passed reduce even in expression position
+  — a table row or an operand, as in `Golden.Issue37.Test` and
+  `Golden.StringCodePoints.Test`. In `Golden.LongWriterBind.Test` the
+  chain composes with the projection folds far enough to drop the last
+  read of a dictionary combinator altogether. Eval goldens are unchanged.

--- a/lib/Language/PureScript/Backend/Lua/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Optimizer.hs
@@ -71,7 +71,7 @@ rewriteRulesInOrder ∷ LuaLimits → [RewriteRule]
 rewriteRulesInOrder limits =
   [ reduceTableDefinitionAccessor
   , foldFieldProjectionThroughScopeCall limits
-  , foldCallThroughScopeCall
+  , foldCallThroughScopeCall limits
   , collapseTailLiteralApplication limits
   , foldNotEqual
   ]
@@ -200,9 +200,16 @@ no-argument, immediately-invoked function is folded into its @return@s.
 The shape is how the code generator runs a selected thunk — "pick an
 effect, then run it" lowers to a scope call immediately applied — and
 folding the application inward exposes a plain scope call that
-'collapseTailLiteralApplication' can then splice away. The freshly built call is
-folded once more by this same rule, in case the returned expression is
-itself an applied scope call.
+'collapseTailLiteralApplication' can then splice away. The freshly built
+call is folded once more by this same rule, in case the returned
+expression is itself an applied scope call. The rebuilt literal is then
+handed to 'collapseTailLiteralApplication' directly: the pushed
+application may have landed on a returned function literal — a
+beta-redex at a depth the bottom-up driver has already passed — and
+while a literal in a function tail re-collapses when the driver reaches
+that enclosing function, one in expression position (a table row, an
+operand) has no later chance. The 'LuaLimits' are only forwarded to that
+collapse.
 
 Applying before versus after the call returns is observably the same: the
 leading statements run first either way, the returned expression is
@@ -239,8 +246,8 @@ selection is exactly a branching tail. The rule declines when:
   once, since a single branch runs, but syntactically repeated — and
   atoms keep that duplication trivial.
 -}
-foldCallThroughScopeCall ∷ RewriteRule
-foldCallThroughScopeCall = \case
+foldCallThroughScopeCall ∷ LuaLimits → RewriteRule
+foldCallThroughScopeCall limits = \case
   original@( FunctionCall
                (Ann (FunctionCall (Ann (Function [] body)) []))
                args
@@ -248,7 +255,9 @@ foldCallThroughScopeCall = \case
       | not (chunkScopeUsesVararg argsBlock)
       , Set.disjoint (declaredNamesInActivation body) (namesInBlock argsBlock)
       , Just body' ← pushCallIntoTail body →
-          FunctionCall (Lua.ann (Function [] body')) []
+          let folded =
+                collapseTailLiteralApplication limits (Function [] body')
+           in FunctionCall (Lua.ann folded) []
       | otherwise → original
      where
       argsBlock = [Lua.ann (Return args)]
@@ -283,7 +292,7 @@ foldCallThroughScopeCall = \case
         (c,) <$> case statement of
           Return [returnedValue] →
             Just . Return . pure . Lua.ann $
-              foldCallThroughScopeCall (FunctionCall returnedValue args)
+              foldCallThroughScopeCall limits (FunctionCall returnedValue args)
           IfThenElse p thenBlock elseBlock
             | atomicArgs →
                 IfThenElse p

--- a/lib/Language/PureScript/Backend/Lua/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/Lua/Optimizer.hs
@@ -21,6 +21,7 @@ import Language.PureScript.Backend.Lua.Types
   , Comments
   , Exp
   , ExpF (..)
+  , ParamF (..)
   , Statement
   , StatementF (..)
   , TableRowF (..)
@@ -71,7 +72,7 @@ rewriteRulesInOrder limits =
   [ reduceTableDefinitionAccessor
   , foldFieldProjectionThroughScopeCall limits
   , foldCallThroughScopeCall
-  , collapseTailScopeCall limits
+  , collapseTailLiteralApplication limits
   , foldNotEqual
   ]
 
@@ -199,7 +200,7 @@ no-argument, immediately-invoked function is folded into its @return@s.
 The shape is how the code generator runs a selected thunk — "pick an
 effect, then run it" lowers to a scope call immediately applied — and
 folding the application inward exposes a plain scope call that
-'collapseTailScopeCall' can then splice away. The freshly built call is
+'collapseTailLiteralApplication' can then splice away. The freshly built call is
 folded once more by this same rule, in case the returned expression is
 itself an applied scope call.
 
@@ -319,12 +320,16 @@ declaredNamesInActivation = foldMap (declared . Lua.unAnn)
     CallStatement {} → mempty
     Break → mempty
 
-{- | Rewrites @function(…) …; return (function() <stmts> end)() end@ to
-@function(…) …; <stmts> end@: a no-argument, immediately-invoked function
-in tail position is spliced into the enclosing function body. The shape is
-what magic-do's chunked statement sequences lower to inside an n-ary
-function literal — one closure allocation and one extra call on every
-invocation. See issue #230.
+{- | Rewrites @function(…) …; return (function(p1, …) <stmts> end)(a1, …)
+end@ to @function(…) …; local p1, … = a1, …; <stmts> end@: an
+immediately-applied function literal in tail position is spliced into the
+enclosing function body, its parameters bound as locals (no binding
+statement when the literal is nullary). The nullary shape is what
+magic-do's chunked statement sequences lower to inside an n-ary function
+literal (issue #230); the parameterized shape is the beta-redex
+'foldCallThroughScopeCall' leaves behind when the tail it pushed the
+application into returned a literal (issue #295). Either way the cost is
+one closure allocation and one extra call on every invocation.
 
 Tail position is what makes the splice safe. The parent's @return call@
 forwarded /all/ of the call's results (an explicit 'Paren' would adjust
@@ -340,55 +345,94 @@ function closed over, and the locals they declare — including
 re-declarations of a name the parent already binds, which are legal and
 shadow only from that point on — cannot capture any later read.
 
+The one-statement @local@ is the exact translation of Lua's call binding:
+the whole initializer list is evaluated before any name binds (so an
+argument reading an outer @x@ can never see a parameter named @x@), a
+multi-valued expression last in the list expands, missing values fill
+with @nil@, and extra values are evaluated, then discarded — the same
+adjustment rules the call performed. And the arguments do not move across
+a scope boundary: the call site already was the parent's last statement,
+so they are evaluated in the same environment at the same program point
+in both forms — which is also why @...@ among the arguments needs no
+check, unlike in 'foldCallThroughScopeCall'.
+
 Conditions checked:
 
+* Every parameter of the called literal is a 'ParamNamed', no name
+  repeating: a 'ParamVararg' cannot be bound by a @local@, a
+  'ParamUnused' has no name to bind, and while @local x, x = …@ does
+  reproduce a duplicate-parameter call — both bind the last occurrence —
+  declining removes the need to reason about it. IR-derived literals
+  always name their parameters distinctly, so declining costs nothing.
+
+* A nullary literal applied to arguments declines: no @local@ binds zero
+  names, and dropping the arguments would drop their effects.
+
 * The spliced statements must not mention @...@ in their own scope
-  ('chunkScopeUsesVararg'): a no-parameter function cannot legally do so,
-  but on such (only ever hand-written) input the splice would rebind
+  ('chunkScopeUsesVararg'): a parameterless function cannot legally do
+  so, but on such (only ever hand-written) input the splice would rebind
   @...@ to the parent's varargs instead of failing to load.
 
 * A local budget: the splice undoes exactly the chunking with which
   magic-do keeps any single function's locals bounded (issue #19), so the
-  merged body must fit the same 'workingLocalCeiling' the storage passes
-  budget against — parameters plus 'activationLocalSlots'. One magic-do
-  chunk ('Language.PureScript.Backend.IR.MagicDo.chunkSize' statements)
-  fits a typical parent, while two adjacent chunks exceed the ceiling and
-  keep their boundary. The passes running later stay sound either way:
+  merged body — parameter binding included — must fit the same
+  'workingLocalCeiling' the storage passes budget against: parameters
+  plus 'activationLocalSlots'. One magic-do chunk
+  ('Language.PureScript.Backend.IR.MagicDo.chunkSize' statements) fits a
+  typical parent, while two adjacent chunks exceed the ceiling and keep
+  their boundary. The passes running later stay sound either way:
   'localizeChunk' budgets its cache locals against what is actually
   declared after the splice, and only gains upvalue headroom from the
   disappearing proto.
 
 The rule re-applies itself to the merged function: the new tail may again
-be a scope-call return — 'foldCallThroughScopeCall' builds such tails at
-depths the bottom-up driver has already passed — and every round
+be an applied-literal return — 'foldCallThroughScopeCall' builds such
+tails at depths the bottom-up driver has already passed — and every round
 re-checks the conditions above.
 -}
-collapseTailScopeCall ∷ LuaLimits → RewriteRule
-collapseTailScopeCall limits = \case
+collapseTailLiteralApplication ∷ LuaLimits → RewriteRule
+collapseTailLiteralApplication limits = \case
   Function params body
-    | Just (leading, spliced) ← matchTailScopeCall body
+    | Just (leading, binding, spliced) ← matchTailLiteralApplication body
     , not (chunkScopeUsesVararg spliced)
-    , let merged = leading <> spliced
+    , let merged = leading <> binding <> spliced
     , length params + activationLocalSlots merged
         <= workingLocalCeiling limits →
-        -- The merged tail may itself be a scope-call return — one
+        -- The merged tail may itself be an applied-literal return — one
         -- 'foldCallThroughScopeCall' built after the bottom-up driver had
         -- already passed that depth — so keep collapsing while the budget
         -- admits it; every round consumes one nesting level.
-        collapseTailScopeCall limits (Function params merged)
+        collapseTailLiteralApplication limits (Function params merged)
   e → e
  where
   -- Splits a function body whose last statement is a single-valued
-  -- 'Return' of a no-argument immediately-invoked function literal into
-  -- the leading statements and the statements to splice.
-  matchTailScopeCall
+  -- 'Return' of an immediately-applied function literal into the leading
+  -- statements, the parameter binding (one simultaneous 'Local', or
+  -- nothing for a nullary literal), and the statements to splice.
+  matchTailLiteralApplication
     ∷ [Annotated Comments StatementF]
-    → Maybe ([Annotated Comments StatementF], [Annotated Comments StatementF])
-  matchTailScopeCall body = case reverse body of
-    Ann (Return [Ann (FunctionCall (Ann (Function [] spliced)) [])])
-      : reverseLeading →
-        Just (reverse reverseLeading, spliced)
+    → Maybe
+        ( [Annotated Comments StatementF]
+        , [Annotated Comments StatementF]
+        , [Annotated Comments StatementF]
+        )
+  matchTailLiteralApplication body = case reverse body of
+    Ann (Return [Ann (FunctionCall (Ann (Function params spliced)) args)])
+      : reverseLeading → do
+        names ← traverse namedParam params
+        binding ← case nonEmpty names of
+          Nothing → [] <$ guard (null args)
+          Just paramNames → do
+            guard (length names == length (ordNub names))
+            Just [Lua.ann (Local paramNames args)]
+        pure (reverse reverseLeading, binding, spliced)
     _ → Nothing
+
+  namedParam ∷ Annotated Comments ParamF → Maybe Lua.Name
+  namedParam (Ann param) = case param of
+    ParamNamed paramName → Just paramName
+    ParamUnused → Nothing
+    ParamVararg → Nothing
 
 {- | Over-approximates the local-variable slots a block occupies in the
 activation of its enclosing function: declarations at every block depth

--- a/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Backend.Lua.Optimizer.Spec where
 import Language.PureScript.Backend.Lua.Limits (LuaLimits (..), lua51Limits)
 import Language.PureScript.Backend.Lua.Name (name)
 import Language.PureScript.Backend.Lua.Optimizer
-  ( collapseTailScopeCall
+  ( collapseTailLiteralApplication
   , foldCallThroughScopeCall
   , foldFieldProjectionThroughScopeCall
   , foldNotEqual
@@ -351,7 +351,7 @@ spec = describe "Lua AST Optimizer" do
       assertEqual (toString $ pShow original) original $
         rewriteExpWithRule foldCallThroughScopeCall original
 
-    it "composes with collapseTailScopeCall into a zero-closure tail" do
+    it "composes with the tail-literal collapse into a zero-closure tail" do
       -- The end-to-end #230-family result: `return (function() if c then
       -- return f else return g end end)()()` in a function tail loses
       -- both the closure and the extra calls.
@@ -384,7 +384,7 @@ spec = describe "Lua AST Optimizer" do
       assertEqual (toString $ pShow original) expected $
         optimizeStatement lua51Limits original
 
-  describe "collapseTailScopeCall" do
+  describe "collapseTailLiteralApplication" do
     it "splices a tail scope call into the enclosing function body" do
       -- The residual magic-do shape from issue #230: an effectful
       -- uncurried definition runs its do-chunk through a tail IIFE.
@@ -407,7 +407,7 @@ spec = describe "Lua AST Optimizer" do
               , Lua.return (Lua.varName [name|c|])
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
     it "re-collapses a tail exposed by its own merge, without a traversal" do
       -- The bare rule (no bottom-up driver) must flatten both levels:
@@ -431,7 +431,7 @@ spec = describe "Lua AST Optimizer" do
               , Lua.return (Lua.varName [name|a|])
               ]
       assertEqual (toString $ pShow original) expected $
-        collapseTailScopeCall lua51Limits original
+        collapseTailLiteralApplication lua51Limits original
 
     it "splices nested tail scope calls bottom-up in one pass" do
       let original ∷ Lua.Exp =
@@ -457,7 +457,7 @@ spec = describe "Lua AST Optimizer" do
               , Lua.return (Lua.varName [name|b|])
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
     it "splices past a leading early return" do
       -- An early return among the leading statements exits the parent on
@@ -481,7 +481,7 @@ spec = describe "Lua AST Optimizer" do
               , Lua.return (Lua.Integer 2)
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
     it "splices a body that falls off the end (zero return values)" do
       -- Both before and after, the parent returns no values.
@@ -499,9 +499,59 @@ spec = describe "Lua AST Optimizer" do
               , Lua.CallStatement (Lua.ann (Lua.error "eff"))
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
-    it "declines when the called literal takes parameters" do
+    it "splices an applied literal, binding its parameters as locals" do
+      -- The beta-redex 'foldCallThroughScopeCall' leaves behind (#295):
+      -- the parameter binding becomes a simultaneous `local`.
+      let original ∷ Lua.Exp =
+            Lua.functionDef
+              [Lua.ParamNamed [name|b|]]
+              [ Lua.return
+                  ( Lua.functionCall
+                      ( Lua.functionDef
+                          [Lua.ParamNamed [name|x|]]
+                          [Lua.return (Lua.varName [name|x|])]
+                      )
+                      [Lua.varName [name|b|]]
+                  )
+              ]
+          expected ∷ Lua.Exp =
+            Lua.functionDef
+              [Lua.ParamNamed [name|b|]]
+              [ Lua.local1 [name|x|] (Lua.varName [name|b|])
+              , Lua.return (Lua.varName [name|x|])
+              ]
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
+
+    it "binds parameters missing an argument to nil, as the call did" do
+      -- One `local x, y = 1` nil-fills y exactly as Lua's call
+      -- adjustment did.
+      let original ∷ Lua.Exp =
+            Lua.functionDef
+              []
+              [ Lua.return
+                  ( Lua.functionCall
+                      ( Lua.functionDef
+                          [Lua.ParamNamed [name|x|], Lua.ParamNamed [name|y|]]
+                          [Lua.return (Lua.varName [name|y|])]
+                      )
+                      [Lua.Integer 1]
+                  )
+              ]
+          expected ∷ Lua.Exp =
+            Lua.functionDef
+              []
+              [ Lua.localN ([name|x|] :| [[name|y|]]) (Lua.Integer 1)
+              , Lua.return (Lua.varName [name|y|])
+              ]
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
+
+    it "re-collapses through a parameterized merge, without a traversal" do
+      -- The bare rule must flatten both levels when the outer merge
+      -- exposes another applied literal in tail position.
       let original ∷ Lua.Exp =
             Lua.functionDef
               []
@@ -509,13 +559,117 @@ spec = describe "Lua AST Optimizer" do
                   ( Lua.functionCall
                       ( Lua.functionDef
                           [Lua.ParamNamed [name|x|]]
-                          [Lua.return (Lua.varName [name|x|])]
+                          [ Lua.return
+                              ( Lua.functionCall
+                                  ( Lua.functionDef
+                                      [Lua.ParamNamed [name|y|]]
+                                      [Lua.return (Lua.varName [name|x|])]
+                                  )
+                                  [Lua.Integer 2]
+                              )
+                          ]
                       )
                       [Lua.Integer 1]
                   )
               ]
+          expected ∷ Lua.Exp =
+            Lua.functionDef
+              []
+              [ Lua.local1 [name|x|] (Lua.Integer 1)
+              , Lua.local1 [name|y|] (Lua.Integer 2)
+              , Lua.return (Lua.varName [name|x|])
+              ]
+      assertEqual (toString $ pShow original) expected $
+        collapseTailLiteralApplication lua51Limits original
+
+    it "declines a nullary literal applied to arguments" do
+      -- There is no `local` binding zero names, and dropping the
+      -- arguments would drop their effects.
+      let original ∷ Lua.Exp =
+            Lua.functionDef
+              []
+              [ Lua.return
+                  ( Lua.functionCall
+                      (Lua.functionDef [] [Lua.return (Lua.Integer 1)])
+                      [Lua.Integer 2]
+                  )
+              ]
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
+
+    it "declines vararg and unused parameters" do
+      -- Neither `...` nor an unnamed parameter can be bound by a `local`.
+      let decline ∷ Lua.Param → IO ()
+          decline param = do
+            let original ∷ Lua.Exp =
+                  Lua.functionDef
+                    []
+                    [ Lua.return
+                        ( Lua.functionCall
+                            ( Lua.functionDef
+                                [param]
+                                [Lua.return (Lua.Integer 1)]
+                            )
+                            [Lua.Integer 2]
+                        )
+                    ]
+            assertEqual (toString $ pShow original) original $
+              rewriteExpWithRule
+                (collapseTailLiteralApplication lua51Limits)
+                original
+      decline Lua.ParamVararg
+      decline Lua.ParamUnused
+
+    it "declines a duplicate parameter name" do
+      -- `local x, x = 1, 2` does bind the last occurrence, like the
+      -- call did, but the shape never comes out of lowering — declining
+      -- is simpler than reasoning about it.
+      let original ∷ Lua.Exp =
+            Lua.functionDef
+              []
+              [ Lua.return
+                  ( Lua.functionCall
+                      ( Lua.functionDef
+                          [Lua.ParamNamed [name|x|], Lua.ParamNamed [name|x|]]
+                          [Lua.return (Lua.varName [name|x|])]
+                      )
+                      [Lua.Integer 1, Lua.Integer 2]
+                  )
+              ]
+      assertEqual (toString $ pShow original) original $
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
+
+    it "counts bound parameters against the local budget" do
+      -- With maxLocals = 22 the working ceiling is 2: one parameter,
+      -- one leading local and the bound parameter (3 slots) must not
+      -- merge into one activation; one more slot of headroom admits the
+      -- same splice.
+      let tinyLimits = lua51Limits {maxLocals = 22}
+          roomyLimits = lua51Limits {maxLocals = 23}
+          original ∷ Lua.Exp =
+            Lua.functionDef
+              [Lua.ParamNamed [name|a|]]
+              [ Lua.local1 [name|b|] (Lua.Integer 1)
+              , Lua.return
+                  ( Lua.functionCall
+                      ( Lua.functionDef
+                          [Lua.ParamNamed [name|c|]]
+                          [Lua.return (Lua.varName [name|c|])]
+                      )
+                      [Lua.varName [name|b|]]
+                  )
+              ]
+          expected ∷ Lua.Exp =
+            Lua.functionDef
+              [Lua.ParamNamed [name|a|]]
+              [ Lua.local1 [name|b|] (Lua.Integer 1)
+              , Lua.local1 [name|c|] (Lua.varName [name|b|])
+              , Lua.return (Lua.varName [name|c|])
+              ]
+      assertEqual (toString $ pShow original) original $
+        rewriteExpWithRule (collapseTailLiteralApplication tinyLimits) original
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule (collapseTailLiteralApplication roomyLimits) original
 
     it "declines when the merged body exceeds the local budget" do
       -- With maxLocals = 22 the working ceiling is 2: one parameter plus
@@ -542,9 +696,9 @@ spec = describe "Lua AST Optimizer" do
               , Lua.return (Lua.varName [name|c|])
               ]
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule (collapseTailScopeCall tinyLimits) original
+        rewriteExpWithRule (collapseTailLiteralApplication tinyLimits) original
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall roomyLimits) original
+        rewriteExpWithRule (collapseTailLiteralApplication roomyLimits) original
 
     it "declines when the spliced statements use varargs in their scope" do
       -- A no-parameter function cannot legally mention `...`; on such
@@ -555,7 +709,7 @@ spec = describe "Lua AST Optimizer" do
               [Lua.ParamVararg]
               [Lua.return (Lua.scope [Lua.Return [Lua.ann Lua.Vararg]])]
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
     it "splices past varargs owned by a nested function literal" do
       let inner ∷ [Lua.Statement] =
@@ -572,7 +726,7 @@ spec = describe "Lua AST Optimizer" do
             Lua.functionDef [] [Lua.return (Lua.scope inner)]
           expected ∷ Lua.Exp = Lua.functionDef [] inner
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule (collapseTailScopeCall lua51Limits) original
+        rewriteExpWithRule (collapseTailLiteralApplication lua51Limits) original
 
   describe "foldNotEqual" do
     it "rewrites not (a == b) to a ~= b" do

--- a/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Optimizer/Spec.hs
@@ -205,7 +205,7 @@ spec = describe "Lua AST Optimizer" do
                   (Lua.functionCall (Lua.varName [name|f|]) [Lua.varName [name|b|]])
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "folds a zero-argument run into both branches of a tail if" do
       -- The thunk-selection shape: `(function() if c then return f else
@@ -228,9 +228,12 @@ spec = describe "Lua AST Optimizer" do
                   [Lua.return (Lua.functionCall (Lua.varName [name|g|]) [])]
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "re-folds when the returned expression is itself a scope call" do
+      -- The re-fold pushes the call into the inner scope call, and the
+      -- collapse chained onto each rebuilt literal then flattens the
+      -- nesting into a single scope call.
       let original ∷ Lua.Exp =
             Lua.functionCall
               (Lua.scope [Lua.return (Lua.scope [Lua.return (Lua.varName [name|f|])])])
@@ -238,17 +241,13 @@ spec = describe "Lua AST Optimizer" do
           expected ∷ Lua.Exp =
             Lua.scope
               [ Lua.return
-                  ( Lua.scope
-                      [ Lua.return
-                          ( Lua.functionCall
-                              (Lua.varName [name|f|])
-                              [Lua.varName [name|b|]]
-                          )
-                      ]
+                  ( Lua.functionCall
+                      (Lua.varName [name|f|])
+                      [Lua.varName [name|b|]]
                   )
               ]
       assertEqual (toString $ pShow original) expected $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "declines when a leading statement contains an early return" do
       let original ∷ Lua.Exp =
@@ -263,7 +262,7 @@ spec = describe "Lua AST Optimizer" do
               )
               []
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "declines on a fall-off path (tail if without an else)" do
       -- Falling off the end yields nil, which the original code then
@@ -279,7 +278,7 @@ spec = describe "Lua AST Optimizer" do
               )
               []
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "declines on a multi-valued tail return" do
       let original ∷ Lua.Exp =
@@ -289,7 +288,7 @@ spec = describe "Lua AST Optimizer" do
               )
               []
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "declines when an argument name collides with a body local" do
       -- Moved inside, `x` would resolve to the callee's local, not the
@@ -303,7 +302,7 @@ spec = describe "Lua AST Optimizer" do
               )
               [Lua.varName [name|x|]]
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "declines non-atomic arguments on a branching tail" do
       -- Branch pushing duplicates the arguments into every return site;
@@ -339,9 +338,9 @@ spec = describe "Lua AST Optimizer" do
                   ]
               ]
       assertEqual (toString $ pShow nonAtomic) nonAtomic $
-        rewriteExpWithRule foldCallThroughScopeCall nonAtomic
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) nonAtomic
       assertEqual (toString $ pShow atomic) pushed $
-        rewriteExpWithRule foldCallThroughScopeCall atomic
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) atomic
 
     it "declines varargs among the arguments" do
       let original ∷ Lua.Exp =
@@ -349,7 +348,35 @@ spec = describe "Lua AST Optimizer" do
               (Lua.scope [Lua.return (Lua.varName [name|f|])])
               [Lua.Vararg]
       assertEqual (toString $ pShow original) original $
-        rewriteExpWithRule foldCallThroughScopeCall original
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
+
+    it "re-collapses the literal it rebuilds, in any position" do
+      -- The pushed application may land on a returned function literal —
+      -- a beta-redex built at a depth the bottom-up driver has already
+      -- passed. The fold hands the rebuilt literal to
+      -- 'collapseTailLiteralApplication' itself, so the redex reduces
+      -- even when the scope call sits in expression position (a table
+      -- row, an operand), where no enclosing function tail would.
+      let original ∷ Lua.Exp =
+            Lua.functionCall
+              ( Lua.scope
+                  [ Lua.local1 [name|h|] (Lua.Integer 1)
+                  , Lua.return
+                      ( Lua.functionDef
+                          [Lua.ParamNamed [name|x|]]
+                          [Lua.return (Lua.varName [name|x|])]
+                      )
+                  ]
+              )
+              [Lua.varName [name|b|]]
+          expected ∷ Lua.Exp =
+            Lua.scope
+              [ Lua.local1 [name|h|] (Lua.Integer 1)
+              , Lua.local1 [name|x|] (Lua.varName [name|b|])
+              , Lua.return (Lua.varName [name|x|])
+              ]
+      assertEqual (toString $ pShow original) expected $
+        rewriteExpWithRule (foldCallThroughScopeCall lua51Limits) original
 
     it "composes with the tail-literal collapse into a zero-closure tail" do
       -- The end-to-end #230-family result: `return (function() if c then

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
@@ -115,22 +115,20 @@ return (function()
     [2] = Data_Unit_unit,
     [3] = Data_Unit_unit
   }
-  return (function()
-    local _ = Data_Foldable_foldableArray.foldr(function(x_S_940)
-      local dictApply_S_925 = Effect_applicativeEffect.Apply0()
-      local a_S_926 = Effect_Console_logShow_S_w({
-        show = function() return "unit" end
-      }, x_S_940)
-      return function(b_S_927)
-        return dictApply_S_925.apply((dictApply_S_925.Functor0()).map(function()
-          return function(x_S_934) return x_S_934 end
-        end)(a_S_926))(b_S_927)
-      end
-    end)(Effect_pureE(Data_Unit_unit))(arr_S_0)()
-    return Effect_Console_logShow_S_w({
-      show = Data_Show_foreign.showIntImpl
-    }, Data_Foldable_foldableArray.foldl(function(c_S_913)
-      return function() return 1 + c_S_913 end
-    end)(0)(arr_S_0))()
-  end)()
+  local _ = Data_Foldable_foldableArray.foldr(function(x_S_940)
+    local dictApply_S_925 = Effect_applicativeEffect.Apply0()
+    local a_S_926 = Effect_Console_logShow_S_w({
+      show = function() return "unit" end
+    }, x_S_940)
+    return function(b_S_927)
+      return dictApply_S_925.apply((dictApply_S_925.Functor0()).map(function()
+        return function(x_S_934) return x_S_934 end
+      end)(a_S_926))(b_S_927)
+    end
+  end)(Effect_pureE(Data_Unit_unit))(arr_S_0)()
+  return Effect_Console_logShow_S_w({
+    show = Data_Show_foreign.showIntImpl
+  }, Data_Foldable_foldableArray.foldl(function(c_S_913)
+    return function() return 1 + c_S_913 end
+  end)(0)(arr_S_0))()
 end)()

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.lua
@@ -118,15 +118,14 @@ return (function()
   return (function()
     local _ = Data_Foldable_foldableArray.foldr(function(x_S_940)
       local dictApply_S_925 = Effect_applicativeEffect.Apply0()
-      return (function(a_S_926)
-        return function(b_S_927)
-          return dictApply_S_925.apply((dictApply_S_925.Functor0()).map(function(  )
-            return function(x_S_934) return x_S_934 end
-          end)(a_S_926))(b_S_927)
-        end
-      end)(Effect_Console_logShow_S_w({
+      local a_S_926 = Effect_Console_logShow_S_w({
         show = function() return "unit" end
-      }, x_S_940))
+      }, x_S_940)
+      return function(b_S_927)
+        return dictApply_S_925.apply((dictApply_S_925.Functor0()).map(function()
+          return function(x_S_934) return x_S_934 end
+        end)(a_S_926))(b_S_927)
+      end
     end)(Effect_pureE(Data_Unit_unit))(arr_S_0)()
     return Effect_Console_logShow_S_w({
       show = Data_Show_foreign.showIntImpl

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.lua
@@ -75,29 +75,28 @@ Golden_BugListGenericEq_Test_eqList = function(dictEq)
             return { "Data.Generic.Rep∷Sum.Inr", x[2] }
           end
         end)()
-        return (function(v1_S_14)
-          local _S_cse270 = v1_S_14[1]
-          local _S_cse269 = v_S_13[1]
-          if "Data.Generic.Rep∷Sum.Inl" == _S_cse269 then
-            return "Data.Generic.Rep∷Sum.Inl" == _S_cse270
-          else
-            return "Data.Generic.Rep∷Sum.Inr" == _S_cse269 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse270 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
-              eqRecord = function()
-                return function() return function() return true end end
-              end
-            }, nil, {
-              reflectSymbol = function() return "tail" end
-            }, Golden_BugListGenericEq_Test_eqList(dictEq)), nil, {
-              reflectSymbol = function() return "head" end
-            }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_13[2])(v1_S_14[2]))
-          end
-        end)((function()
+        local v1_S_14 = (function()
           if "Golden.BugListGenericEq.Test∷List.Nil" == y[1] then
             return _S_cse268
           else
             return { "Data.Generic.Rep∷Sum.Inr", y[2] }
           end
-        end)())
+        end)()
+        local _S_cse270 = v1_S_14[1]
+        local _S_cse269 = v_S_13[1]
+        if "Data.Generic.Rep∷Sum.Inl" == _S_cse269 then
+          return "Data.Generic.Rep∷Sum.Inl" == _S_cse270
+        else
+          return "Data.Generic.Rep∷Sum.Inr" == _S_cse269 and ("Data.Generic.Rep∷Sum.Inr" == _S_cse270 and (Data_Eq_eqRowCons_S_w(Data_Eq_eqRowCons_S_w({
+            eqRecord = function()
+              return function() return function() return true end end
+            end
+          }, nil, {
+            reflectSymbol = function() return "tail" end
+          }, Golden_BugListGenericEq_Test_eqList(dictEq)), nil, {
+            reflectSymbol = function() return "head" end
+          }, dictEq)).eqRecord(Type_Proxy_Proxy)(v_S_13[2])(v1_S_14[2]))
+        end
       end
     end
   }

--- a/test/ps/output/Golden.Issue37.Test/golden.lua
+++ b/test/ps/output/Golden.Issue37.Test/golden.lua
@@ -70,23 +70,21 @@ return {
   baz = (function()
     local Bind1_S_1 = Effect_monadEffect.Bind1()
     local pure_S_4 = (Effect_monadEffect.Applicative0()).pure
-    return (function(f_S_6)
-      return Bind1_S_1.bind(f_S_6)(function()
-        return Bind1_S_1.bind(pure_S_4({
-          [1] = (function()
-            local Bind1_S_216 = Effect_monadEffect.Bind1()
-            return (function(fn1_S_218)
+    local f_S_6 = Effect_pureE(Data_Unit_unit)
+    return Bind1_S_1.bind(f_S_6)(function()
+      return Bind1_S_1.bind(pure_S_4({
+        [1] = (function()
+          local Bind1_S_216 = Effect_monadEffect.Bind1()
+          local fn1_S_218 = f_S_6
+          return Bind1_S_216.bind(fn1_S_218)(function()
+            return Bind1_S_216.bind(fn1_S_218)(function()
               return Bind1_S_216.bind(fn1_S_218)(function()
-                return Bind1_S_216.bind(fn1_S_218)(function()
-                  return Bind1_S_216.bind(fn1_S_218)(function()
-                    return fn1_S_218
-                  end)
-                end)
+                return fn1_S_218
               end)
-            end)(f_S_6)
-          end)()
-        }))(function() return pure_S_4(Data_Unit_unit) end)
-      end)
-    end)(Effect_pureE(Data_Unit_unit))
+            end)
+          end)
+        end)()
+      }))(function() return pure_S_4(Data_Unit_unit) end)
+    end)
   end)()
 }

--- a/test/ps/output/Golden.LongApplyChain.Test/golden.lua
+++ b/test/ps/output/Golden.LongApplyChain.Test/golden.lua
@@ -11,17 +11,16 @@ local Golden_LongApplyChain_Test_applySecond_S_w = function(a_S_133, b_S_134)
       return Data_Maybe_Nothing
     end
   end)()
-  return (function(v1_S_626)
-    if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
-      if "Data.Maybe∷Maybe.Just" == v1_S_626[1] then
-        return { "Data.Maybe∷Maybe.Just", (v_S_625[2](v1_S_626[2])) }
-      else
-        return Data_Maybe_Nothing
-      end
+  local v1_S_626 = b_S_134
+  if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
+    if "Data.Maybe∷Maybe.Just" == v1_S_626[1] then
+      return { "Data.Maybe∷Maybe.Just", (v_S_625[2](v1_S_626[2])) }
     else
       return Data_Maybe_Nothing
     end
-  end)(b_S_134)
+  else
+    return Data_Maybe_Nothing
+  end
 end
 local Golden_LongApplyChain_Test_compute = (function()
   local _S_tmp646 = Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w(Golden_LongApplyChain_Test_applySecond_S_w({

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.lua
@@ -1,3 +1,4 @@
+local M = {}
 local Data_Unit_foreign = { unit = {} }
 local Data_Unit_unit = Data_Unit_foreign.unit
 local Data_Semigroup_foreign = {
@@ -37,7 +38,7 @@ local Data_Identity_applicativeIdentity = {
   pure = function(x_S_505) return x_S_505 end,
   Apply0 = function() return Data_Identity_applyIdentity end
 }
-local Control_Monad_Writer_Trans_applyWriterT_S_w = function( dictSemigroup
+M.Control_Monad_Writer_Trans_applyWriterT_S_w = function( dictSemigroup
 , dictApply )
   local Functor0 = dictApply.Functor0()
   return {
@@ -207,16 +208,9 @@ local Golden_LongWriterBind_Test_go = (function()
                                                                                       return Data_Semigroup_semigroupArray
                                                                                     end
                                                                                   }
-                                                                                  return ((function( dictApplicative_S_518 )
-                                                                                    return {
-                                                                                      pure = function( a_S_519 )
-                                                                                        return dictApplicative_S_518.pure(Data_Tuple_Tuple_S_w(a_S_519, dictMonoid_S_517.mempty))
-                                                                                      end,
-                                                                                      Apply0 = function(  )
-                                                                                        return Control_Monad_Writer_Trans_applyWriterT_S_w(dictMonoid_S_517.Semigroup0(), dictApplicative_S_518.Apply0())
-                                                                                      end
-                                                                                    }
-                                                                                  end)(Data_Identity_applicativeIdentity)).pure(42)
+                                                                                  local dictApplicative_S_518 = Data_Identity_applicativeIdentity
+                                                                                  local a_S_519 = 42
+                                                                                  return dictApplicative_S_518.pure(Data_Tuple_Tuple_S_w(a_S_519, dictMonoid_S_517.mempty))
                                                                                 end)
                                                                               end)
                                                                             end)

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.lua
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.lua
@@ -318,15 +318,14 @@ local Data_String_CodePoints_unsafeCodePointAt0 = Data_String_CodePoints_foreign
   local cu0_S_25 = Data_String_CodePoints_fromEnum(Data_String_Unsafe_charAt(0)(s_S_24))
   if Data_String_CodePoints_conj(Data_String_CodePoints_conj(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, 55296, cu0_S_25))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, cu0_S_25, 56319)))("Data.Ordering∷Ordering.GT" == ((function(  )
     local x_S_1600 = Data_String_CodeUnits_length(s_S_24)
-    return (function(y_S_1601)
-      if x_S_1600 < y_S_1601 then
-        return Data_Ordering_LT
-      elseif x_S_1600 == y_S_1601 then
-        return Data_Ordering_EQ
-      else
-        return Data_Ordering_GT
-      end
-    end)(1)
+    local y_S_1601 = 1
+    if x_S_1600 < y_S_1601 then
+      return Data_Ordering_LT
+    elseif x_S_1600 == y_S_1601 then
+      return Data_Ordering_EQ
+    else
+      return Data_Ordering_GT
+    end
   end)())[1]) then
     local cu1_S_27 = Data_String_CodePoints_fromEnum(Data_String_Unsafe_charAt(1)(s_S_24))
     if Data_String_CodePoints_conj(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, 56320, cu1_S_27))(Data_Ord_lessThanOrEq_S_w(Data_Ord_ordInt, cu1_S_27, 57343)) then


### PR DESCRIPTION
Closes #295.

## What

Generalizes the tail-position IIFE collapse (#230) to an applied function literal with named parameters, and renames the rule accordingly: `collapseTailScopeCall` → `collapseTailLiteralApplication`. When a function body ends in `return (function(p1, …) <stmts> end)(a1, …)`, the rule now binds the parameters as one simultaneous `local` and splices the body; the nullary shape degenerates to no binding statement, so #230's behaviour is the special case. On `Golden.LongApplyChain.Test`'s `applySecond` — the shape PR #294 deliberately left behind, one closure allocation and one extra call per node of the 40-deep apply chain:

```lua
return (function(v1_S_626)
  if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
    ...
  end
end)(b_S_134)
```

becomes straight-line:

```lua
local v1_S_626 = b_S_134
if "Data.Maybe∷Maybe.Just" == v_S_625[1] then
  ...
end
```

## Why the `local` is exact

The one-statement `local p1, … = a1, …` is the literal translation of Lua's call binding: the whole initializer list evaluates before any name binds (an argument reading an outer `x` can never see a parameter named `x`), a multi-valued expression last in the list expands, missing values fill with `nil`, and extra values evaluate and drop — the same adjustment rules the call performed. Unlike #294's fold, the arguments cross no scope boundary: the call site already was the parent's last statement, so they evaluate in the same environment at the same program point — which is also why `...` among the arguments needs no check here.

Conditions on top of #230's (vararg check on the spliced statements, the #19 local budget — now counting the parameter binding — and the self-re-application): every parameter is `ParamNamed` with no name repeating, and a nullary literal applied to arguments declines (no `local` binds zero names, and dropping the arguments would drop their effects).

## The second commit: re-collapse in expression position

The first commit alone moved only 3 goldens; `Golden.Issue37.Test` and `Golden.StringCodePoints.Test` — both named in #295 — did not budge. The reason: their redexes sit in scope calls in *expression position* (a table row, an `==` operand), and the tail `return (function(fn1) … end)(f)` inside those scope calls is *built by `foldCallThroughScopeCall` itself* at a depth the bottom-up driver has already passed — the callee literal is visited before the enclosing call node, so nobody revisits the rebuilt literal. A literal in a function tail recovers when the driver reaches the enclosing function (`collapseTailLiteralApplication` fires there and re-applies); a literal in expression position had no later chance.

The fold now hands each literal it rebuilds to `collapseTailLiteralApplication` directly — the same eager re-optimization `foldFieldProjectionThroughScopeCall` already does with its projected return, and the reason the fold now takes `LuaLimits`. In `Golden.Issue37.Test`:

```lua
[1] = (function()
  local Bind1_S_216 = Effect_monadEffect.Bind1()
  return (function(fn1_S_218)
    return Bind1_S_216.bind(fn1_S_218)(function()
      ...
    end)
  end)(f_S_6)
end)()
```

becomes

```lua
[1] = (function()
  local Bind1_S_216 = Effect_monadEffect.Bind1()
  local fn1_S_218 = f_S_6
  return Bind1_S_216.bind(fn1_S_218)(function()
    ...
  end)
end)()
```

In `Golden.LongWriterBind.Test` the chain composes end-to-end — fold, collapse, projection fold, table-constructor fold — reducing `((function(dictApplicative_S_518) return { pure = …, Apply0 = … } end)(Data_Identity_applicativeIdentity)).pure(42)` to

```lua
local dictApplicative_S_518 = Data_Identity_applicativeIdentity
local a_S_519 = 42
return dictApplicative_S_518.pure(Data_Tuple_Tuple_S_w(a_S_519, dictMonoid_S_517.mempty))
```

The folded-away `Apply0` row held the *only* read of `Control_Monad_Writer_Trans_applyWriterT_S_w` (2 occurrences on main → 1 now: just the initializer), so `promoteChunk` correctly declines to promote a zero-read binding — that is why `local M = {}` reappears in this golden with the now-dead initializer parked as `M.Control_Monad_Writer_Trans_applyWriterT_S_w = …`. One golden also lost a nesting level that main's own output would have collapsed if re-fed to the optimizer (`Golden.ArrayOfUnits.Test`'s main): the nesting was fold residue at a passed depth, the class this commit removes.

## Verification

- 20 unit tests for the rule pair, written red-first: the parameterized splice, nil-fill via `local x, y = 1`, the bare-rule re-collapse through a parameterized merge, declines (nullary-with-arguments, vararg/unused/duplicate parameters, budget counting the bound parameters), and the fold's re-collapse in expression position. One existing fold expectation updated: the nested-scope-call re-fold now flattens to a single scope call (strictly better output, same purpose).
- 7 `golden.lua` moved across the two commits (`LongApplyChain`, `BugListGenericEq`, `ArrayOfUnits`, `Issue37`, `StringCodePoints`, `LongWriterBind`); `golden.ir` untouched. All **eval goldens byte-identical** — the semantic oracle is never auto-accepted.
- `bench/ci --accept` produced no diffs: the bench modules carried none of the residual shapes after #294.
- `cabal test all` clean (1044 examples), `fourmolu` + `hlint` clean.
