### PR TITLE
Choose case columns by Maranget's pbaN composite

### DIFF
--- a/changelog.d/20260727_100000_unisay_pban_column_heuristic.md
+++ b/changelog.d/20260727_100000_unisay_pban_column_heuristic.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Case expressions choose the next column to test by Maranget's `pbaN`
+  composite ("Compiling Pattern Matching to Good Decision Trees"): the column
+  needed by the longest prefix of remaining clauses wins, ties fall to the
+  column with the fewest distinct patterns, then the fewest exposed sub-tests,
+  then the leftmost. The previous single metric — the column tested by the
+  most other clauses — could re-test a wide column inside every branch of a
+  narrow one, emitting a larger decision tree (#237).

--- a/lib/Language/PureScript/Backend/IR.hs
+++ b/lib/Language/PureScript/Backend/IR.hs
@@ -29,7 +29,7 @@ import Language.PureScript.PSString
   , decodeString
   , decodeStringEscaping
   )
-import Relude.Extra (toFst)
+import Relude.Extra (minimumOn1)
 import Text.Megaparsec qualified as Megaparsec
 import Text.Pretty.Simple (pShow)
 import Text.Show (Show (..))
@@ -544,9 +544,16 @@ the shared binding each use would re-emit (and the codegen re-evaluate) the
 whole expression. String, array, and object scrutinees are bound too.
 
 Column-selection heuristic ('matchChosenByHeuristic'): when a clause has
-several outstanding matches, pick the one shared by the most other clauses
-('countAffectedClauses'). Testing a shared sub-value first lets one test serve
-many clauses, which keeps the tree small.
+several outstanding matches, the column to test next (a column is a focused
+sub-value: scrutinee plus 'stepsToFocus') is chosen by Maranget's pbaN
+composite ("Compiling Pattern Matching to Good Decision Trees", ML'08),
+adapted to this clause-per-row representation. Maximise p, the number of
+consecutive clauses starting from the current one that test the column — a
+test every following clause needs cannot be wasted; break ties by minimal
+b, the number of distinct patterns tested on the column across all
+remaining clauses — a column with fewer distinct tests is retired sooner;
+then by minimal a, the number of sub-tests those patterns expose once
+passed — the cheaper look-ahead; finally leftmost (N).
 
 Match-history pruning ('MatchHistory'): every test emitted on a given
 scrutinee — a constructor tag, a literal equality, an array length — is
@@ -690,29 +697,42 @@ matchChosenByHeuristic thisClause otherClauses =
   case clauseMatches thisClause of
     [] → Nothing
     [match] → Just (match, thisClause {clauseMatches = []})
-    matches →
-      -- select a match that is present in the maximum number of other clauses
-      sortOn
-        (Down . fst)
-        (toFst (countAffectedClauses otherClauses) <$> matches)
-        & uncons
-        & fmap \(match, remainingMatches) →
-          (snd match, thisClause {clauseMatches = snd <$> remainingMatches})
+    matches → do
+      indexed ← nonEmpty (zip [0 ∷ Int ..] matches)
+      let bestIndex = fst $ minimumOn1 (\(i, m) → (score m, i)) indexed
+      (chosen, after) ← uncons (drop bestIndex matches)
+      pure (chosen, thisClause {clauseMatches = take bestIndex matches <> after})
  where
-  countAffectedClauses ∷ [CaseClause] → Match → Int
-  countAffectedClauses clauses Match {matchExp = expr, stepsToFocus = steps} =
-    foldr count 0 clauses
+  -- The pbaN composite, ordered so that the minimal score wins:
+  -- maximal needed prefix (p), fewest distinct patterns tested on the
+  -- column (b), fewest sub-tests those patterns expose once passed (a).
+  -- Pairing the score with the match position resolves ties to the
+  -- leftmost match (N).
+  score ∷ Match → (Down Int, Int, Int)
+  score Match {matchExp = expr, stepsToFocus = steps} =
+    ( Down (length (takeWhile (not . Map.null) rows))
+    , Map.size column
+    , sum column
+    )
    where
-    count ∷ CaseClause → Int → Int
-    count clause counter =
-      maybe counter (\_ → counter + 1) $
-        allClauseMatches clause & find \case
-          Match {matchPat = PatAny} → False
-          Match {matchExp, stepsToFocus}
-            | matchExp == expr, stepsToFocus == steps → True
-          _ → False
+    -- Per clause: the patterns it tests on the column, each mapped to
+    -- the number of sub-tests it exposes (a pattern determines its
+    -- sub-test count, so the maps agree on shared keys).
+    rows ∷ [Map Pattern Int]
+    rows =
+      clauseForests <&> \forest →
+        Map.fromList
+          [ (matchPat, length nestedMatches)
+          | Match {matchExp, stepsToFocus, matchPat, nestedMatches} ← forest
+          , matchPat /= PatAny
+          , matchExp == expr
+          , stepsToFocus == steps
+          ]
+    column = Map.unions rows
 
-    allClauseMatches ∷ CaseClause → [Match]
+  clauseForests ∷ [[Match]]
+  clauseForests = allClauseMatches <$> (thisClause : otherClauses)
+   where
     allClauseMatches CaseClause {clauseMatches} = go [] clauseMatches
      where
       go acc = \case

--- a/test/Language/PureScript/Backend/IR/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Spec.hs
@@ -711,6 +711,76 @@ spec = describe "IR representation" do
                     )
               )
 
+      it "tests the column with fewer distinct patterns first" do
+        {-
+
+        Five clauses over two columns; every clause tests both columns
+        (equal neededness), but column 1 carries four distinct tests
+        ('a'/'b'/'c'/'d') while column 2 carries two ('p'/'q'):
+
+        case 'x', 'y' of
+          'a', 'p' -> 1
+          'b', 'p' -> 2
+          'c', 'p' -> 3
+          'd', 'p' -> 4
+          'a', 'q' -> 5
+
+        Testing column 2 first retires it after one test per branch and
+        the column-1 chain follows once per outcome — 8 tests.  Testing
+        column 1 first re-tests column 2 inside every branch of the
+        four-way chain — 9 tests.
+
+        -}
+        representedCase
+          [cfnCharE 'x', cfnCharE 'y']
+          [ Cfn.CaseAlternative
+              { caseAlternativeBinders =
+                  [cfnLitB (cfnCharL c1), cfnLitB (cfnCharL c2)]
+              , caseAlternativeResult = Right $ cfnInt r
+              }
+          | (c1, c2, r) ←
+              [ ('a', 'p', 1)
+              , ('b', 'p', 2)
+              , ('c', 'p', 3)
+              , ('d', 'p', 4)
+              , ('a', 'q', 5)
+              ]
+          ]
+          >>= ( `shouldBe`
+                  ifThenElse
+                    (literalChar 'p' `eq` literalChar 'y')
+                    ( ifThenElse
+                        (literalChar 'a' `eq` literalChar 'x')
+                        (literalInt 1)
+                        ( ifThenElse
+                            (literalChar 'b' `eq` literalChar 'x')
+                            (literalInt 2)
+                            ( ifThenElse
+                                (literalChar 'c' `eq` literalChar 'x')
+                                (literalInt 3)
+                                ( ifThenElse
+                                    (literalChar 'd' `eq` literalChar 'x')
+                                    (literalInt 4)
+                                    (exception "No patterns matched")
+                                )
+                            )
+                        )
+                    )
+                    ( ifThenElse
+                        (literalChar 'd' `eq` literalChar 'x')
+                        (exception "No patterns matched")
+                        ( ifThenElse
+                            (literalChar 'a' `eq` literalChar 'x')
+                            ( ifThenElse
+                                (literalChar 'q' `eq` literalChar 'y')
+                                (literalInt 5)
+                                (exception "No patterns matched")
+                            )
+                            (exception "No patterns matched")
+                        )
+                    )
+              )
+
   describe "collectDataDeclarations" do
     it "classifies data types regardless of constructor order" do
       let cfnCtor tyName ctorName =

--- a/test/ps/output/Golden.CasePruning.Test/golden.ir
+++ b/test/ps/output/Golden.CasePruning.Test/golden.ir
@@ -87,9 +87,9 @@ UberModule
               )
             )
             ( IfThenElse Nothing
-              ( Eq Nothing ( LiteralInt Nothing 2 ) ( Ref Nothing ( Local ( Name "v" ) ) ) )
+              ( Eq Nothing ( LiteralInt Nothing 2 ) ( Ref Nothing ( Local ( Name "v1" ) ) ) )
               ( IfThenElse Nothing
-                ( Eq Nothing ( LiteralInt Nothing 2 ) ( Ref Nothing ( Local ( Name "v1" ) ) ) )
+                ( Eq Nothing ( LiteralInt Nothing 2 ) ( Ref Nothing ( Local ( Name "v" ) ) ) )
                 ( LiteralInt Nothing 2 )
                 ( LiteralInt Nothing 4 )
               )
@@ -139,12 +139,12 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.CasePruning.Test∷T.B" )
-                    ( Ref Nothing ( Local ( Name "$cse248" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse249" ) ) )
                   )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.CasePruning.Test∷T.B" )
-                      ( Ref Nothing ( Local ( Name "$cse249" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse248" ) ) )
                     )
                     ( LiteralInt Nothing 2 )
                     ( LiteralInt Nothing 4 )

--- a/test/ps/output/Golden.CasePruning.Test/golden.lua
+++ b/test/ps/output/Golden.CasePruning.Test/golden.lua
@@ -17,8 +17,8 @@ local Golden_CasePruning_Test_literalNegatives = function(v)
   return function(v1)
     if 1 == v then
       if 1 == v1 then return 1 elseif 2 == v1 then return 3 else return 4 end
-    elseif 2 == v then
-      if 2 == v1 then return 2 else return 4 end
+    elseif 2 == v1 then
+      if 2 == v then return 2 else return 4 end
     else
       return 4
     end
@@ -36,8 +36,8 @@ local Golden_CasePruning_Test_ctorRetest = function(v)
       else
         return 4
       end
-    elseif "Golden.CasePruning.Test∷T.B" == _S_cse1 then
-      if "Golden.CasePruning.Test∷T.B" == _S_cse0 then
+    elseif "Golden.CasePruning.Test∷T.B" == _S_cse0 then
+      if "Golden.CasePruning.Test∷T.B" == _S_cse1 then
         return 2
       else
         return 4


### PR DESCRIPTION
Closes #237.

`mkCase` compiles a PureScript `case` to a decision tree of nested if/else tests, choosing at every step which outstanding pattern test to emit next — a "column" here is a focused sub-value of a scrutinee (the scrutinee expression plus the projection steps into it). The chooser, `matchChosenByHeuristic`, used a single metric: pick the column tested by the most other clauses. This PR replaces that metric with the `pbaN` composite from Maranget's "Compiling Pattern Matching to Good Decision Trees" (ML 2008), adapted to the clause-per-row representation. Candidates are scored lexicographically: **p** — the number of consecutive clauses, starting from the current one, that test the column (a test every following clause needs cannot be wasted); **b** — fewest distinct patterns tested on the column across the remaining clauses (a column with fewer distinct tests is retired sooner); **a** — fewest sub-tests those patterns expose once passed; **N** — leftmost on full ties. Everything around the choice is untouched, including the `MatchHistory` pruning that skips tests whose outcome is already decided on a path.

Where the metrics disagree, the composite emits a smaller tree. The new unit test (`test/Language/PureScript/Backend/IR/Spec.hs`, "tests the column with fewer distinct patterns first") compiles this five-clause matrix, where every clause tests both columns — so the old total-count metric ties (4 vs 4) and falls back to the left column — while pbaN sees four distinct patterns on column 1 against two on column 2 and tests column 2 first:

```purescript
case 'x', 'y' of
  'a', 'p' -> 1
  'b', 'p' -> 2
  'c', 'p' -> 3
  'd', 'p' -> 4
  'a', 'q' -> 5
```

The pre-change compiler (captured by the test's red run before the fix) produces 9 tests — the column-2 test `'p' == 'y'` is re-emitted inside every branch of the four-way column-1 chain:

```
if 'a'=='x' then (if 'p'=='y' then 1 else if 'q'=='y' then 5 else fail)
else if 'b'=='x' then (if 'p'=='y' then 2 else fail)
else if 'c'=='x' then (if 'p'=='y' then 3 else fail)
else if 'd'=='x' then (if 'p'=='y' then 4 else fail)
else fail
```

With pbaN the column-2 test runs once and the column-1 chain follows once per outcome — 8 tests (this is the tree the unit test asserts):

```
if 'p'=='y' then
  (if 'a'=='x' then 1 else if 'b'=='x' then 2
   else if 'c'=='x' then 3 else if 'd'=='x' then 4 else fail)
else
  (if 'd'=='x' then fail
   else if 'a'=='x' then (if 'q'=='y' then 5 else fail) else fail)
```

Across the golden corpus the change is a wash, which is the intended safety property: exactly one module moves, and only by an order swap with an identical test count. In `Golden.CasePruning.Test`'s `literalNegatives` (`1 1 -> 1; 2 2 -> 2; 1 2 -> 3; _ _ -> 4`), once `1 == v` has failed the remaining clauses only ever test the second scrutinee `v1` against `2` (one distinct pattern) while the first scrutinee `v` still carries two, so pbaN retires `v1` first — verbatim from the golden diff:

```diff
-    elseif 2 == v then
-      if 2 == v1 then return 2 else return 4 end
+    elseif 2 == v1 then
+      if 2 == v then return 2 else return 4 end
```

Verification: the corpus eval goldens (hand-verified runtime-output oracles, never auto-accepted) pass unchanged, so only tree shape moved, not semantics; `./bench/ci` reports `bench counters match goldens`, so the LuaJIT FNEW/TNEW censuses and trace reports over the linked bench artifacts are byte-identical; the full suite is green and the IR spec group was re-run 10 times with fresh seeds. Code-size delta across the corpus is zero lines.
