### PR TITLE
Push `not` through ordering comparisons to their complement

### DIFF
--- a/changelog.d/20260727_120000_unisay_not_through_ordering.md
+++ b/changelog.d/20260727_120000_unisay_not_through_ordering.md
@@ -1,0 +1,13 @@
+### Added
+
+- The IR optimizer pushes logical `not` through an ordering comparison to
+  its complement — `not (a < b)` becomes `a >= b`, and likewise for `<=`,
+  `>`, `>=` (#238). The flip is exact only over a domain Lua orders totally,
+  so it is gated on a literal operand of a NaN-free kind (`Int`, `Char`, or
+  `String`); a `Float` literal is no witness, because the other operand can
+  be NaN at runtime, where PureScript's `>=` on `Number` (true, via
+  `compare NaN b = GT`) disagrees with Lua's raw `>=` (false). The dominant
+  beneficiary is the residual a `>` comparison leaves once its `Ordering`
+  decision tree folds: `not(n < 0) and n ~= 0` now emits as
+  `n >= 0 and n ~= 0`. The other half of #238, fusing one-armed boolean
+  conditionals into `and`/`or`, already ships since #203.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -1234,15 +1234,48 @@ foldPrimBinOp op l r = case (op, l, r) of
   isFinite ∷ Double → Bool
   isFinite d = not (isNaN d || isInfinite d)
 
-{- | Fold logical @not@ over a boolean literal, and eliminate a double
-negation (@not (not e)@ ⟶ @e@, sound since @e@ is a 'Bool'). See
-Note [IR primops].
+{- | Fold logical @not@ over a boolean literal, eliminate a double
+negation (@not (not e)@ ⟶ @e@, sound since @e@ is a 'Bool'), and push
+@not@ through an ordering comparison to its complement
+(@not (a < b)@ ⟶ @a >= b@, issue #238). See Note [IR primops].
+
+The complement flip is exact iff Lua orders the compared domain
+totally, and a literal operand of a NaN-free kind is the witness: an
+Int, Char, or String literal pins both operands' type (Note [IR is
+assumed well-typed]), Int values are integral doubles, and Lua's
+string order is total for any byte content — the flip needs totality
+only, so unlike the constant fold it covers non-ASCII chars. A Float
+literal is no witness: the other operand can be NaN at runtime, where
+every Lua comparison is false — @not (NaN < b)@ is true while Lua's
+@NaN >= b@ is false — and the wrapped form is exactly PureScript's
+@>=@ on Number, which must be true there (@ordNumberImpl@ maps NaN to
+@GT@). Two non-literal operands are likewise unwitnessed and stay
+wrapped.
 -}
 foldPrimNot ∷ Exp → Maybe Exp
 foldPrimNot = \case
   LiteralBool _ b → Just (literalBool (not b))
   PrimNot _ e → Just e
+  PrimBinOp ann op a b
+    | Just flipped ← complementOrdering op
+    , isTotalOrderWitness a || isTotalOrderWitness b →
+        Just (PrimBinOp ann flipped a b)
   _ → Nothing
+ where
+  complementOrdering ∷ PrimOp → Maybe PrimOp
+  complementOrdering = \case
+    PrimLt → Just PrimGe
+    PrimLe → Just PrimGt
+    PrimGt → Just PrimLe
+    PrimGe → Just PrimLt
+    _ → Nothing
+
+  isTotalOrderWitness ∷ Exp → Bool
+  isTotalOrderWitness = \case
+    LiteralInt {} → True
+    LiteralChar {} → True
+    LiteralString {} → True
+    _ → False
 
 {- | Fold an equality of two scalar literals, or 'Nothing' when either
 side is not a scalar literal. Two literals of different kinds also

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -1314,6 +1314,59 @@ spec = describe "IR Optimizer" do
       let original = ifThenElse p r (refLocal (Name "s"))
       optimizedExpression original `shouldBe` original
 
+  -- The complement flip is exact only over a domain Lua orders
+  -- totally; a literal operand of a NaN-free kind witnesses that (see
+  -- 'foldPrimNot').
+  describe "pushes not through a total-order comparison (#238)" do
+    let x = refLocal (Name "x")
+
+    it "flips each ordering to its complement (int literal witness)" do
+      optimizedExpression (primNot (primBinOp PrimLt x (literalInt 3)))
+        `shouldBe` primBinOp PrimGe x (literalInt 3)
+      optimizedExpression (primNot (primBinOp PrimLe x (literalInt 3)))
+        `shouldBe` primBinOp PrimGt x (literalInt 3)
+      optimizedExpression (primNot (primBinOp PrimGt x (literalInt 3)))
+        `shouldBe` primBinOp PrimLe x (literalInt 3)
+      optimizedExpression (primNot (primBinOp PrimGe x (literalInt 3)))
+        `shouldBe` primBinOp PrimLt x (literalInt 3)
+
+    it "accepts the witness on either side" do
+      optimizedExpression (primNot (primBinOp PrimLt (literalInt 0) x))
+        `shouldBe` primBinOp PrimGe (literalInt 0) x
+
+    it "accepts a char or string literal witness" do
+      optimizedExpression (primNot (primBinOp PrimLt x (literalChar 'a')))
+        `shouldBe` primBinOp PrimGe x (literalChar 'a')
+      optimizedExpression (primNot (primBinOp PrimLt x (literalString "a")))
+        `shouldBe` primBinOp PrimGe x (literalString "a")
+
+    it "flips on a non-ASCII char literal (totality, not order)" do
+      -- The constant fold declines non-ASCII chars (bytes vs 'Text'
+      -- order), but the flip needs only totality of Lua's string
+      -- order, which any byte content satisfies.
+      optimizedExpression (primNot (primBinOp PrimLe x (literalChar 'é')))
+        `shouldBe` primBinOp PrimGt x (literalChar 'é')
+
+    it "keeps not over an unwitnessed comparison (possible NaN)" do
+      -- Two variables can be Numbers: not (x < y) is true when either
+      -- operand is NaN, while x >= y is false — and PureScript's >= on
+      -- Number requires the former (compare NaN y is GT).
+      let original = primNot (primBinOp PrimLt x (refLocal (Name "y")))
+      optimizedExpression original `shouldBe` original
+
+    it "keeps not over a float-literal comparison (possible NaN)" do
+      let original = primNot (primBinOp PrimLt x (literalFloat 1.5))
+      optimizedExpression original `shouldBe` original
+
+    it "collapses if (x < 0) then False else r to x >= 0 and r" do
+      -- The residual a > comparison leaves once its Ordering decision
+      -- tree folds: the half-literal collapse builds not (x < 0), and
+      -- the flip finishes it in the same pass.
+      let r = refLocal (Name "r")
+      optimizedExpression
+        (ifThenElse (primBinOp PrimLt x (literalInt 0)) (literalBool False) r)
+        `shouldBe` primBinOp PrimAnd (primBinOp PrimGe x (literalInt 0)) r
+
   -- A pattern match on a Boolean compiles to a three-way if with a
   -- synthesized default: the scrutinee is re-tested behind the first
   -- branch (`false == a`) and the default is unreachable, since
@@ -1645,9 +1698,14 @@ spec = describe "IR Optimizer" do
     it "collapses a GT comparison to a flat boolean expression" do
       -- Two leaves fold to False and one to True, so the collapsed tree
       -- is a half-literal if; the and/or fold then flattens it, leaving
-      -- no decision tree in expression position at all.
+      -- no decision tree in expression position at all. The negated
+      -- n < 0 flips to its complement (#238) — the int literal
+      -- witnesses a total order.
       optimizedExpression (eq gt orderingTree)
-        `shouldBe` primBinOp PrimAnd (primNot isNeg) (primNot isZero)
+        `shouldBe` primBinOp
+          PrimAnd
+          (primBinOp PrimGe n (literalInt 0))
+          (primNot isZero)
 
     it "leaves the comparison alone when a leaf cannot fold" do
       -- A non-literal leaf would survive as a residual comparison, so

--- a/test/ps/output/Golden.CprResult.Test/golden.ir
+++ b/test/ps/output/Golden.CprResult.Test/golden.ir
@@ -130,11 +130,9 @@ UberModule
         ( ParamNamed Nothing ( Name "n" ) :| [] )
         ( IfThenElse Nothing
           ( PrimBinOp Nothing PrimAnd
-            ( PrimNot Nothing
-              ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "n" ) ) )
-                ( LiteralInt Nothing 0 )
-              )
+            ( PrimBinOp Nothing PrimGe
+              ( Ref Nothing ( Local ( Name "n" ) ) )
+              ( LiteralInt Nothing 0 )
             )
             ( PrimNot Nothing
               ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )

--- a/test/ps/output/Golden.CprResult.Test/golden.lua
+++ b/test/ps/output/Golden.CprResult.Test/golden.lua
@@ -23,7 +23,7 @@ end
 M.Golden_CprResult_Test_useStep = function(n) return n * 2 + (n + 1) end
 local Golden_CprResult_Test_pair = Data_Tuple_Tuple_S_w(20, 11)
 local Golden_CprResult_Test_branchy_S_r = function(n)
-  if not(n < 0) and n ~= 0 then
+  if n >= 0 and n ~= 0 then
     local b1 = n + 7
     local b2 = b1 + n
     local b3 = b2 - 4

--- a/test/ps/output/Golden.JoinPoints.Test/golden.ir
+++ b/test/ps/output/Golden.JoinPoints.Test/golden.ir
@@ -131,11 +131,9 @@ UberModule
                 ( ParamNamed Nothing ( Name "acc" ) :| [ ParamNamed Nothing ( Name "k" ) ] )
                 ( IfThenElse Nothing
                   ( PrimBinOp Nothing PrimAnd
-                    ( PrimNot Nothing
-                      ( PrimBinOp Nothing PrimLt
-                        ( Ref Nothing ( Local ( Name "k" ) ) )
-                        ( LiteralInt Nothing 0 )
-                      )
+                    ( PrimBinOp Nothing PrimGe
+                      ( Ref Nothing ( Local ( Name "k" ) ) )
+                      ( LiteralInt Nothing 0 )
                     )
                     ( PrimNot Nothing
                       ( Eq Nothing ( Ref Nothing ( Local ( Name "k" ) ) ) ( LiteralInt Nothing 0 ) )
@@ -159,11 +157,9 @@ UberModule
           )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 100 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 100 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 100 ) )
@@ -210,11 +206,9 @@ UberModule
           )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )
@@ -259,11 +253,9 @@ UberModule
           )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )

--- a/test/ps/output/Golden.JoinPoints.Test/golden.lua
+++ b/test/ps/output/Golden.JoinPoints.Test/golden.lua
@@ -24,19 +24,19 @@ local Golden_JoinPoints_Test_escaping = function(n)
 end
 local Golden_JoinPoints_Test_collatzish = function(n)
   local acc, k
-  if not(n < 100) and n ~= 100 then acc, k = 0, n else acc, k = 1, n + 3 end
+  if n >= 100 and n ~= 100 then acc, k = 0, n else acc, k = 1, n + 3 end
   while true do
-    if not(k < 0) and k ~= 0 then acc, k = acc + 1, k - 2 else return acc end
+    if k >= 0 and k ~= 0 then acc, k = acc + 1, k - 2 else return acc end
   end
 end
 local Golden_JoinPoints_Test_classify = function(n)
   local r
-  if not(n < 0) and n ~= 0 then r = n + 1 else r = 0 - n end
+  if n >= 0 and n ~= 0 then r = n + 1 else r = 0 - n end
   return (r * 10 + r) * 2 - r
 end
 local Golden_JoinPoints_Test_chooseEff = function(n)
   local m
-  if not(n < 0) and n ~= 0 then m = n else m = 0 - n end
+  if n >= 0 and n ~= 0 then m = n else m = 0 - n end
   return Effect_Console_log(Data_Show_showIntImpl(m * 2))
 end
 return (function()

--- a/test/ps/output/Golden.Loopification.Test/golden.ir
+++ b/test/ps/output/Golden.Loopification.Test/golden.ir
@@ -166,11 +166,9 @@ UberModule
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 100 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 100 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 100 ) )
@@ -204,11 +202,9 @@ UberModule
           ( ParamNamed Nothing ( Name "n" ) :| [] )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )

--- a/test/ps/output/Golden.Loopification.Test/golden.lua
+++ b/test/ps/output/Golden.Loopification.Test/golden.lua
@@ -39,7 +39,7 @@ end
 local Golden_Loopification_Test_mc91
 Golden_Loopification_Test_mc91 = function(n)
   while true do
-    if not(n < 100) and n ~= 100 then
+    if n >= 100 and n ~= 100 then
       return n - 10
     else
       n = Golden_Loopification_Test_mc91(n + 11)
@@ -47,7 +47,7 @@ Golden_Loopification_Test_mc91 = function(n)
   end
 end
 local Golden_Loopification_Test_countdown = function(n)
-  while true do if not(n < 0) and n ~= 0 then n = n - 1 else return 0 end end
+  while true do if n >= 0 and n ~= 0 then n = n - 1 else return 0 end end
 end
 local Golden_Loopification_Test_countDrop_S_w = function(n)
   while true do if n == 0 then return 0 else n = n - 1 end end

--- a/test/ps/output/Golden.MutualLoopification.Test/golden.ir
+++ b/test/ps/output/Golden.MutualLoopification.Test/golden.ir
@@ -243,11 +243,9 @@ UberModule
             ( Ref Nothing ( Local ( Name "acc" ) ) )
             ( IfThenElse Nothing
               ( PrimBinOp Nothing PrimAnd
-                ( PrimNot Nothing
-                  ( PrimBinOp Nothing PrimLt
-                    ( Ref Nothing ( Local ( Name "n" ) ) )
-                    ( LiteralInt Nothing 10 )
-                  )
+                ( PrimBinOp Nothing PrimGe
+                  ( Ref Nothing ( Local ( Name "n" ) ) )
+                  ( LiteralInt Nothing 10 )
                 )
                 ( PrimNot Nothing
                   ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 10 ) )

--- a/test/ps/output/Golden.MutualLoopification.Test/golden.lua
+++ b/test/ps/output/Golden.MutualLoopification.Test/golden.lua
@@ -102,7 +102,7 @@ local Golden_MutualLoopification_Test_stepSelf_S_w_S_loop = function( _S_sel2
       local acc, n = _S_a5, _S_a6
       if n == 0 then
         return acc
-      elseif not(n < 10) and n ~= 10 then
+      elseif n >= 10 and n ~= 10 then
         _S_sel2, _S_a5, _S_a6 = 1, acc + 10, n - 10
       else
         _S_sel2, _S_a5, _S_a6 = 2, acc, n

--- a/test/ps/output/Golden.NativeLoopsGuard.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoopsGuard.Test/golden.ir
@@ -484,11 +484,9 @@ UberModule
                       ( AbsN Nothing
                         ( ParamNamed Nothing ( Name "v$1" ) :| [] )
                         ( PrimBinOp Nothing PrimAnd
-                          ( PrimNot Nothing
-                            ( PrimBinOp Nothing PrimLt
-                              ( Ref Nothing ( Local ( Name "v$1" ) ) )
-                              ( LiteralInt Nothing 0 )
-                            )
+                          ( PrimBinOp Nothing PrimGe
+                            ( Ref Nothing ( Local ( Name "v$1" ) ) )
+                            ( LiteralInt Nothing 0 )
                           )
                           ( PrimNot Nothing
                             ( Eq Nothing

--- a/test/ps/output/Golden.NativeLoopsGuard.Test/golden.lua
+++ b/test/ps/output/Golden.NativeLoopsGuard.Test/golden.lua
@@ -125,7 +125,7 @@ return (function()
   }, Effect_Console_log)()
   local r_S_0 = Effect_Ref_foreign._new(3)()
   local _ = Golden_NativeLoopsGuard_Test_whileE_S_w(Effect_functorEffect.map(function( v_S_1 )
-    return not(v_S_1 < 0) and v_S_1 ~= 0
+    return v_S_1 >= 0 and v_S_1 ~= 0
   end)(Effect_Ref_read(r_S_0)), function()
     local n_S_0 = Effect_Ref_read(r_S_0)()
     local _ = Effect_Console_log(Data_Show_showIntImpl(n_S_0))()

--- a/test/ps/output/Golden.NativeLoopsST.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoopsST.Test/golden.ir
@@ -331,11 +331,9 @@ UberModule
                             ( AbsN Nothing
                               ( ParamNamed Nothing ( Name "v" ) :| [] )
                               ( PrimBinOp Nothing PrimAnd
-                                ( PrimNot Nothing
-                                  ( PrimBinOp Nothing PrimLt
-                                    ( Ref Nothing ( Local ( Name "v" ) ) )
-                                    ( LiteralInt Nothing 0 )
-                                  )
+                                ( PrimBinOp Nothing PrimGe
+                                  ( Ref Nothing ( Local ( Name "v" ) ) )
+                                  ( LiteralInt Nothing 0 )
                                 )
                                 ( PrimNot Nothing
                                   ( Eq Nothing

--- a/test/ps/output/Golden.NativeLoopsST.Test/golden.lua
+++ b/test/ps/output/Golden.NativeLoopsST.Test/golden.lua
@@ -80,7 +80,7 @@ local Golden_NativeLoopsST_Test_countDown = function(start)
     local value = Control_Monad_ST_Internal_new(start)()
     do
       local _S_cond0 = Control_Monad_ST_Internal_map_(function(v)
-        return not(v < 0) and v ~= 0
+        return v >= 0 and v ~= 0
       end)(Control_Monad_ST_Internal_read(value))
       while _S_cond0() do
         local _ = Control_Monad_ST_Internal_modifyImpl(function(s_S_2)

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -107,11 +107,9 @@ UberModule
           ( ParamNamed Nothing ( Name "acc" ) :| [ ParamNamed Nothing ( Name "n" ) ] )
           ( IfThenElse Nothing
             ( PrimBinOp Nothing PrimAnd
-              ( PrimNot Nothing
-                ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "n" ) ) )
-                  ( LiteralInt Nothing 0 )
-                )
+              ( PrimBinOp Nothing PrimGe
+                ( Ref Nothing ( Local ( Name "n" ) ) )
+                ( LiteralInt Nothing 0 )
               )
               ( PrimNot Nothing
                 ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 0 ) )

--- a/test/ps/output/Golden.Primops.Test/golden.lua
+++ b/test/ps/output/Golden.Primops.Test/golden.lua
@@ -26,7 +26,7 @@ local Effect_Console_logShow_S_w = function(dictShow, a)
 end
 local Golden_Primops_Test_sumTo_S_w = function(acc, n)
   while true do
-    if not(n < 0) and n ~= 0 then acc, n = acc + n, n - 1 else return acc end
+    if n >= 0 and n ~= 0 then acc, n = acc + n, n - 1 else return acc end
   end
 end
 M.Golden_Primops_Test_sumTo = function(sumTo_S_p1)

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.ir
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.ir
@@ -154,11 +154,9 @@ UberModule
             ( AppN Nothing
               ( IfThenElse Nothing
                 ( PrimBinOp Nothing PrimAnd
-                  ( PrimNot Nothing
-                    ( PrimBinOp Nothing PrimLt
-                      ( Ref Nothing ( Local ( Name "n" ) ) )
-                      ( LiteralInt Nothing 1 )
-                    )
+                  ( PrimBinOp Nothing PrimGe
+                    ( Ref Nothing ( Local ( Name "n" ) ) )
+                    ( LiteralInt Nothing 1 )
                   )
                   ( PrimNot Nothing
                     ( Eq Nothing ( Ref Nothing ( Local ( Name "n" ) ) ) ( LiteralInt Nothing 1 ) )

--- a/test/ps/output/Golden.UncurryEffect.Test/golden.lua
+++ b/test/ps/output/Golden.UncurryEffect.Test/golden.lua
@@ -29,7 +29,7 @@ local Golden_UncurryEffect_Test_countdown_S_w = function(n)
     local _ = Effect_Console_log("tick")()
     return Effect_Console_log(Data_Show_showIntImpl(n))()
   end)()
-  if not(n < 1) and n ~= 1 then
+  if n >= 1 and n ~= 1 then
     return Golden_UncurryEffect_Test_countdown(n - 1)()
   else
     return Effect_Console_log("done")()


### PR DESCRIPTION
Closes #238.

Issue #238 asks for two boolean peepholes: fusing one-armed conditionals into `and`/`or`, and pushing `not` through the four ordering comparisons. The first half already ships: `reduceBooleanIf` (the IR rule that collapses an `if` with boolean-literal branches into short-circuit operators) has covered `if p then b else false → p and b` and `if p then true else b → p or b` since #203, with tests under "collapses a half-literal boolean if to and/or". No evaluation-order gate is needed there because Lua's `and`/`or` short-circuit exactly like the branch did. This PR implements the second half.

`foldPrimNot` (the constant-folding case for the IR's logical-`not` node, which previously only folded a boolean literal and cancelled double negation) now pushes `not` through an ordering primop to its complement: `not (a < b)` becomes `a >= b`, and likewise `<=`→`>`, `>`→`<=`, `>=`→`<`.

The flip is not unconditionally sound, which is where the design effort went. `not (a < b) ⟷ a >= b` holds only when the compared domain is totally ordered, and Lua numbers are not: every comparison against NaN is false. Worse, the wrapped form is exactly what PureScript's `Number` semantics require. The prelude's `ordNumberImpl` maps NaN to `GT` (its body is `if x < y then lt elseif x == y then eq else gt`, and both tests are false for NaN), so PureScript's `NaN >= b` is *true*, which the residual `not (NaN < b)` computes correctly, while raw Lua `NaN >= b` is *false*. An ungated flip would change the observable output of a well-typed program.

The gate: the rewrite fires only when one operand is a literal of a NaN-free kind — `Int`, `Char`, or `String`. Under the optimizer's standing well-typedness assumption (Note [IR is assumed well-typed]) such a literal pins both operands' type to a domain Lua orders totally: well-typed `Int` values are integral doubles, and Lua's string order is total for any byte content — the flip needs only totality, not agreement with codepoint order, so unlike the ASCII-gated constant fold of #222 it covers non-ASCII `Char` literals too. A `Float` literal is no witness (the other operand can still be NaN), and a comparison of two non-literals stays wrapped. The Lua-level `foldNotEqual` (which rewrites `not (a == b)` to `a ~= b` — sound by definition of `~=`) is deliberately not extended: it also runs over raw hand-written FFI code, where no typing licence exists and a NaN can legitimately flow through an author's `not (a < b)`.

The dominant beneficiary is the residual a `>` comparison leaves behind once its `Ordering` decision tree folds (#180/#203): `compare a b == GT` collapses to `not (a < b) and not (a == b)`. With the flip, `Golden.Primops.Test/golden.lua` moves from

```lua
if not(n < 0) and n ~= 0 then acc, n = acc + n, n - 1 else return acc end
```

to

```lua
if n >= 0 and n ~= 0 then acc, n = acc + n, n - 1 else return acc end
```

and the same one-negation-per-site shrink lands in seven more goldens (JoinPoints, Loopification, MutualLoopification, NativeLoopsGuard, NativeLoopsST, CprResult, UncurryEffect).

Verification: seven focused optimizer tests, written and confirmed red before the implementation — one per flip direction and witness kind, the non-ASCII `Char` case, the two decline cases (no witness, `Float` witness), and the end-to-end collapse of `if (x < 0) then false else r` to `x >= 0 and r`. One existing #203 expectation updated to the improved residual. All structural golden churn is exactly the flip shape shown above; the hand-verified `eval/golden.txt` oracles are untouched, which is the semantic safety net. Full suite green (1142 examples), and the "IR Optimizer" spec group was additionally re-run 66× with fresh seeds (the rule strictly removes one `not` node per firing, so it cannot loop with the fixpoint driver).
