### PR TITLE
Renumber minted binders before rendering the .ir goldens (#338)

### DIFF
--- a/changelog.d/20260728_170000_unisay_renumber_ir_goldens.md
+++ b/changelog.d/20260728_170000_unisay_renumber_ir_goldens.md
@@ -1,0 +1,17 @@
+### Changed
+
+- The `.ir` golden files no longer churn on compiler-minted name indices
+  (#338). Every IR pass draws fresh binder names from one pipeline-global
+  counter, so the index a name carries records how much supply the passes
+  before it happened to consume: an optimizer change that mints one extra
+  name anywhere renumbers every name after it, and the structural goldens
+  then diff on lines whose only change is the counter. The golden harness now
+  renumbers each top-level site's minted binders in first-occurrence order
+  before rendering, so `m$590` prints as `m$0` and a site's names depend only
+  on that site's own structure. Restarting the whole pipeline's supply at
+  1000 leaves every golden — `.ir`, `.lua` and `eval/golden.txt` alike —
+  byte-identical. The digit-run classifier this shares with the Lua emission
+  renumberer moved to `Language.PureScript.Backend.Renumber`, carrying
+  Note [Supply-drawn digit runs]; structural suffixes (`f$w`, `f$p1`,
+  `pong$sc1Tuple`, uniquification's `x0`) are left alone as before.
+  Generated Lua is unchanged.

--- a/lib/Language/PureScript/Backend/IR/Renumber.hs
+++ b/lib/Language/PureScript/Backend/IR/Renumber.hs
@@ -1,0 +1,136 @@
+{- | Renumbering of the compiler-minted binders of an IR module.
+
+The IR pipeline mints names by drawing an index from one monotone supply
+shared by every pass ("Language.PureScript.Backend.IR.Supply"), so the
+index a binder carries records how much supply the passes that ran before
+it happened to consume. Rendering a module — the @.ir@ golden files, a
+pass trace — therefore shows names that shift wholesale whenever an
+unrelated pass starts consuming more or fewer names, burying the
+structural change under renumbered lines.
+
+'renumberUberModule' reassigns those indices in first-occurrence order,
+one allocation per top-level site, making every minted name a function of
+its own site's structure: a pass that consumes extra supply while
+building one site cannot renumber another. See Note [Supply-drawn digit
+runs] in "Language.PureScript.Backend.Renumber" for which digit runs
+qualify — the positional suffixes of uncurrying (@f$w@, @f$p1@),
+call-pattern specialization (@f$sc1Tuple@) and uniquification (@x0@) are
+structural already and pass through.
+
+The renaming is applied per site as a plain name-to-name map, with no
+scope threading, which the GUC discipline (@UniqueBinders@) licenses:
+within one site at most one binder carries any given name, so a local
+reference belongs to the binder its name matches. The one local
+reference a site may leave free is the runtime lazy factory (see
+Note [The PSLUA_runtime_lazy coupling] in "Language.PureScript.Names"),
+whose name holds no digit run and so is never an image of the
+renumbering. Top-level names are drawn from source identifiers and
+structural suffixes, never from the supply, so a site's renaming cannot
+reach another site.
+-}
+module Language.PureScript.Backend.IR.Renumber (renumberUberModule) where
+
+import Control.Lens (foldMapOf, over)
+import Data.Map qualified as Map
+import Language.PureScript.Backend.IR.Linker (UberModule (..))
+import Language.PureScript.Backend.IR.Names (Name (..), Qualified (Local))
+import Language.PureScript.Backend.IR.Types
+  ( Grouping
+  , Parameter (..)
+  , RawExp (..)
+  , bindingNames
+  , listGrouping
+  , paramName
+  , subexpressions
+  )
+import Language.PureScript.Backend.Renumber
+  ( Allocation
+  , Delimiter (Delimiter)
+  , noAllocation
+  , renumberedText
+  )
+
+--------------------------------------------------------------------------------
+-- Renumbering -----------------------------------------------------------------
+
+{- | Renumber the minted binders of every top-level site — each binding,
+foreign binding and export — independently of the others.
+-}
+renumberUberModule ∷ UberModule → UberModule
+renumberUberModule uberModule =
+  uberModule
+    { uberModuleBindings =
+        fmap renumberSite <<$>> uberModuleBindings uberModule
+    , uberModuleForeigns = renumberSite <<$>> uberModuleForeigns uberModule
+    , uberModuleExports = renumberSite <<$>> uberModuleExports uberModule
+    }
+
+-- | Renumber one site: allocate for its binders, then apply the renaming.
+renumberSite ∷ RawExp ann → RawExp ann
+renumberSite e = rename (siteRenaming (binders e)) e
+
+{- | The renaming of a site's minted binder names, allocated in the order
+'binders' visits them. Names carrying no supply-drawn index are absent,
+which leaves them — and the references resolving to them — untouched.
+-}
+siteRenaming ∷ [Name] → Map Name Name
+siteRenaming names =
+  Map.fromList . catMaybes $
+    evaluatingState noAllocation (traverse allocated names)
+ where
+  allocated ∷ Name → State Allocation (Maybe (Name, Name))
+  allocated name =
+    case renumberedText (Delimiter "$") noneReserved (nameToText name) of
+      Nothing → pure Nothing
+      Just mint → Just . (name,) . Name <$> mint
+
+  -- Every image carries a @$@-delimited digit run, which no source
+  -- identifier and no structural suffix can spell, so the allocation has
+  -- no spelling to withhold.
+  noneReserved ∷ Text → Bool
+  noneReserved _spelling = False
+
+-- | The site's binder names, in traversal order.
+binders ∷ ∀ ann. RawExp ann → [Name]
+binders = \case
+  AbsN _ann params body → paramNames params <> binders body
+  -- The RHS is outside the binders' scope (Note [Multi-value results]).
+  LetValues _ann params rhs body →
+    binders rhs <> paramNames params <> binders body
+  Let _ann binds body →
+    (bindingNames =<< toList binds)
+      <> foldMap boundBinders (toList binds)
+      <> binders body
+  -- No other constructor binds a name ('ForeignImport' included: its
+  -- name list holds the export keys of the foreign source file):
+  other → foldMapOf subexpressions binders other
+ where
+  paramNames ∷ NonEmpty (Parameter ann) → [Name]
+  paramNames = mapMaybe paramName . toList
+
+  boundBinders ∷ Grouping (ann, Name, RawExp ann) → [Name]
+  boundBinders = foldMap (\(_ann, _name, e) → binders e) . listGrouping
+
+-- | Rewrite every binder and every local reference through the renaming.
+rename ∷ ∀ ann. Map Name Name → RawExp ann → RawExp ann
+rename renames = go
+ where
+  renamed ∷ Name → Name
+  renamed name = Map.findWithDefault name name renames
+
+  go ∷ RawExp ann → RawExp ann
+  go = \case
+    Ref ann (Local name) → Ref ann (Local (renamed name))
+    AbsN ann params body → AbsN ann (renameParam <$> params) (go body)
+    LetValues ann params rhs body →
+      LetValues ann (renameParam <$> params) (go rhs) (go body)
+    Let ann binds body → Let ann (fmap renameBound <$> binds) (go body)
+    other → over subexpressions go other
+
+  renameBound ∷ (ann, Name, RawExp ann) → (ann, Name, RawExp ann)
+  renameBound (ann, name, e) = (ann, renamed name, go e)
+
+  renameParam ∷ Parameter ann → Parameter ann
+  renameParam = \case
+    p@(ParamUnused _ann) → p
+    ParamNamed ann name → ParamNamed ann (renamed name)

--- a/lib/Language/PureScript/Backend/Lua/Renumber.hs
+++ b/lib/Language/PureScript/Backend/Lua/Renumber.hs
@@ -5,25 +5,31 @@ monotone supply: suffix-minted as @base$N@ (uniquification, inline-paste
 freshening, deep-bind flattening) or prefix-minted as @$tagN@ (CSE's
 @$cse@, codegen's @$sel@\/@$a@ dispatch locals, the native-loop @$xs@\/@$f@
 atomizers, …), with 'Language.PureScript.Backend.Lua.Name.makeSafe'
-mangling @$@ to @_S_@ on the way into the Lua AST. The index a name carries
-is pipeline history, not artifact structure: any upstream change that
-shifts how much supply earlier code consumes renames every later binder,
-churning emitted modules that are semantically identical.
+mangling @$@ to @_S_@ on the way into the Lua AST.
 
 'renumberChunk' erases that history immediately before printing: every
 supply-drawn index occurring in a local binder is renumbered in
 first-occurrence order, and the binder's references follow
 scope-consistently. Emitted names become a function of the chunk's own
 structure — byte-stable under any upstream change that only perturbs
-supply consumption. See Note [Supply-drawn digit runs] for the domain
-and the safety argument.
+supply consumption. See Note [Supply-drawn digit runs] in
+"Language.PureScript.Backend.Renumber" for which digit runs qualify.
+
+PureScript identifiers cannot contain @$@, so compiler-minted names are
+the only source of the renumbered shapes; a hand-written FFI local that
+happens to spell one is renumbered too, which alpha-renames it
+consistently and is semantically inert. Binders are renamed together
+with exactly their in-scope references, so the rewrite is an
+alpha-renaming; a reference the environment does not bind is a global —
+an FFI file's stdlib or host-API read — and stays untouched, with
+allocation skipping any index whose direct @prefix_S_index@ spelling
+occurs free in the chunk, so a renamed binder cannot capture such a
+global either.
 -}
 module Language.PureScript.Backend.Lua.Renumber (renumberChunk) where
 
-import Data.Char qualified as Char
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Data.Text qualified as Text
 import Language.PureScript.Backend.Lua.Name (Name)
 import Language.PureScript.Backend.Lua.Name qualified as Name
 import Language.PureScript.Backend.Lua.Types
@@ -38,42 +44,12 @@ import Language.PureScript.Backend.Lua.Types
   , TableRowF (..)
   , VarF (..)
   )
-
-{- Note [Supply-drawn digit runs]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-A maximal digit run inside a (mangled) name is /supply-drawn/ — an index
-that leaks pipeline history — in exactly two shapes, mirroring the two
-minting grammars:
-
-  * it forms a whole @_S_@-delimited segment: @x_S_223@, and the same
-    run embedded deeper in a derived name, @b_S_5_S_loop@ (the dispatcher
-    a recursive group's leader @b$5@ lends its name to);
-
-  * it terminates the tag of a prefix-minted name — one starting with
-    @_S_@ — as in @$cse1413@ → @_S_cse1413@ or @$a1@ → @_S_a1@.
-
-Digit runs anywhere else are spelling, not supply: @add3@ keeps its @3@,
-and SpecConstr's positional @…_S_sc1Tuple@ keeps its @1@. PureScript
-identifiers cannot contain @$@, so compiler-minted names are the only
-source of these shapes; a hand-written FFI local that happens to spell
-one is renumbered too, which alpha-renames it consistently and is
-semantically inert.
-
-Renumbering assigns each distinct (piece-prefix, run) pair a fresh index
-per prefix, counted up from 0 in first-occurrence order. Keying by the
-run's original spelling keeps a derived name in step with the binder it
-embeds: @b_S_5@ and @b_S_5_S_loop@ renumber to @b_S_0@ and
-@b_S_0_S_loop@. The mapping is injective (same prefix → distinct
-indices; different prefixes → images differ outside their digit runs),
-and an image can never collide with a name the pass leaves alone,
-because every image contains a supply-drawn run and untouched names by
-definition contain none. Binders are renamed together with exactly their
-in-scope references, so the rewrite is an alpha-renaming; a reference
-the environment does not bind is a global — an FFI file's stdlib or
-host-API read — and stays untouched, with allocation skipping any index
-whose direct @prefix_S_index@ spelling occurs free in the chunk, so a
-renamed binder cannot capture such a global either.
--}
+import Language.PureScript.Backend.Renumber
+  ( Allocation
+  , Delimiter (Delimiter)
+  , noAllocation
+  , renumberedText
+  )
 
 --------------------------------------------------------------------------------
 -- Renumbering pass ------------------------------------------------------------
@@ -81,14 +57,7 @@ renamed binder cannot capture such a global either.
 -- | Original binder name → renumbered name, for the binders in scope.
 type Env = Map Name Name
 
-data Supply = Supply
-  { assigned ∷ Map (Text, Text) Natural
-  -- ^ (piece-prefix, original digit run) → allocated index.
-  , counters ∷ Map Text Natural
-  -- ^ Next index to allocate, per piece-prefix.
-  }
-
-type M = State Supply
+type M = State Allocation
 
 {- | Renumber every supply-drawn digit run occurring in a local binder —
 'Local', 'LocalFunction', 'ForNum', 'ForIn' and function parameters — in
@@ -99,7 +68,7 @@ image of the pass is a fixpoint.
 -}
 renumberChunk ∷ Chunk → Chunk
 renumberChunk chunk =
-  evaluatingState (Supply mempty mempty) (goStatements Map.empty chunk)
+  evaluatingState noAllocation (goStatements Map.empty chunk)
  where
   free = freeVarNames chunk
 
@@ -207,11 +176,12 @@ renumberChunk chunk =
       VarField e n → (`VarField` n) <$> goExpA env e
 
   bindName ∷ Env → Name → M (Env, Name)
-  bindName env n = case renumberedText (Name.toText n) of
-    Nothing → pure (env, n)
-    Just mintText → do
-      n' ← Name.unsafeName <$> mintText
-      pure (Map.insert n n' env, n')
+  bindName env n =
+    case renumberedText (Delimiter "_S_") (`Set.member` free) (Name.toText n) of
+      Nothing → pure (env, n)
+      Just mintText → do
+        n' ← Name.unsafeName <$> mintText
+        pure (Map.insert n n' env, n')
 
   bindNames ∷ Env → NonEmpty Name → M (Env, NonEmpty Name)
   bindNames env (n :| ns) = do
@@ -238,51 +208,6 @@ renumberChunk chunk =
         other → pure (env, other)
       (envFinal, rest') ← bindParams env' rest
       pure (envFinal, (c, param') : rest')
-
-  -- 'Just' only when the text contains a supply-drawn run (see Note
-  -- [Supply-drawn digit runs]); the action allocates the new indices.
-  renumberedText ∷ Text → Maybe (M Text)
-  renumberedText whole
-    | any supplyDrawn piecesInContext =
-        Just $
-          Text.concat <$> forM piecesInContext \piece@(run, prefix, _next) →
-            if supplyDrawn piece then allocate prefix run else pure run
-    | otherwise = Nothing
-   where
-    -- Maximal runs of digits alternating with runs of non-digits.
-    pieces = Text.groupBy (\a b → Char.isDigit a == Char.isDigit b) whole
-    piecesInContext =
-      [ (p, Text.concat (take i pieces), pieces !!? (i + 1))
-      | (i, p) ← zip [0 ..] pieces
-      ]
-    supplyDrawn (p, prefix, next)
-      | not (Text.all Char.isDigit p) = False
-      | otherwise =
-          atSegmentEnd
-            && ( "_S_" `Text.isSuffixOf` prefix -- whole segment: base$N
-                   || ( "_S_" `Text.isPrefixOf` whole -- prefix-minted: $tagN
-                          && not ("_S_" `Text.isInfixOf` Text.drop 3 prefix)
-                      )
-               )
-     where
-      atSegmentEnd = maybe True ("_S_" `Text.isPrefixOf`) next
-
-  allocate ∷ Text → Text → M Text
-  allocate prefix run = do
-    Supply {assigned, counters} ← get
-    show <$> case Map.lookup (prefix, run) assigned of
-      Just i → pure i
-      Nothing → do
-        let nextClear c
-              | (prefix <> show c) `Set.member` free = nextClear (c + 1)
-              | otherwise = c
-            i = nextClear (Map.findWithDefault 0 prefix counters)
-        put
-          Supply
-            { assigned = Map.insert (prefix, run) i assigned
-            , counters = Map.insert prefix (i + 1) counters
-            }
-        pure i
 
 --------------------------------------------------------------------------------
 -- Free variables --------------------------------------------------------------

--- a/lib/Language/PureScript/Backend/Renumber.hs
+++ b/lib/Language/PureScript/Backend/Renumber.hs
@@ -1,0 +1,141 @@
+{- | The renumbering core shared by the IR and Lua renumberers.
+
+A compiler-minted name carries an index drawn from a monotone supply,
+either suffix-minted as @base\<delim\>N@ or prefix-minted as
+@\<delim\>tagN@. That index is pipeline history, not artifact structure:
+any upstream change shifting how much supply earlier code consumes
+renames every later binder, churning artifacts that are semantically
+identical. A renumberer erases the history by reassigning the indices in
+first-occurrence order, making a name a function of the artifact's own
+structure.
+
+Held here are the two delimiter-generic halves of that job: deciding
+which digit runs of a name are supply-drawn and allocating their
+replacements ('renumberedText'). The scope discipline — which references
+a renamed binder must carry along — differs per artifact and stays with
+each renumberer: 'Language.PureScript.Backend.IR.Renumber' (delimiter
+@$@, which no source identifier can contain) and
+'Language.PureScript.Backend.Lua.Renumber' (delimiter @_S_@, the
+mangling 'Language.PureScript.Backend.Lua.Name.makeSafe' gives @$@ on
+the way into the Lua AST).
+-}
+module Language.PureScript.Backend.Renumber
+  ( Allocation
+  , Delimiter (..)
+  , noAllocation
+  , renumberedText
+  ) where
+
+import Data.Char qualified as Char
+import Data.Map qualified as Map
+import Data.Text qualified as Text
+
+{- Note [Supply-drawn digit runs]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A maximal digit run inside a name is /supply-drawn/ — an index that leaks
+pipeline history — in exactly two shapes, mirroring the two minting
+grammars (spelled below with the IR's @$@ delimiter):
+
+  * it forms a whole delimited segment: @x$223@, and the same run
+    embedded deeper in a derived name, @b$5$loop@ (the dispatcher a
+    recursive group's leader @b$5@ lends its name to);
+
+  * it terminates the tag of a prefix-minted name — one starting with the
+    delimiter — as in @$cse1413@ or @$a1@.
+
+Digit runs anywhere else are spelling, not supply: @add3@ keeps its @3@,
+uncurrying's positional @f$p1@ keeps its @1@, and call-pattern
+specialization's @pong$sc1Tuple@ keeps its @1@.
+
+Renumbering assigns each distinct (piece-prefix, run) pair a fresh index
+per prefix, counted up from 0 in first-occurrence order. Keying by the
+run's original spelling keeps a derived name in step with the binder it
+embeds: @b$5@ and @b$5$loop@ renumber to @b$0@ and @b$0$loop@. The
+mapping is injective (same prefix → distinct indices; different prefixes
+→ images differ outside their digit runs), and an image can never collide
+with a name the renumbering leaves alone, because every image contains a
+supply-drawn run and untouched names by definition contain none.
+-}
+
+--------------------------------------------------------------------------------
+-- Allocation ------------------------------------------------------------------
+
+{- | The separator between the segments of a minted name: @$@ in the IR,
+its @_S_@ mangling in the Lua AST.
+-}
+newtype Delimiter = Delimiter Text
+
+-- | The indices allocated so far, threaded through a renumbering.
+data Allocation = Allocation
+  { assigned ∷ Map (Text, Text) Natural
+  -- ^ (piece-prefix, original digit run) → allocated index.
+  , counters ∷ Map Text Natural
+  -- ^ Next index to allocate, per piece-prefix.
+  }
+
+{- | The empty allocation. A renumberer restarts from it for each
+namespace it renumbers independently of the others.
+-}
+noAllocation ∷ Allocation
+noAllocation = Allocation mempty mempty
+
+--------------------------------------------------------------------------------
+-- Renumbering -----------------------------------------------------------------
+
+{- | The name with every supply-drawn digit run replaced by a freshly
+allocated index, or 'Nothing' when the name carries no such run (see
+Note [Supply-drawn digit runs]) — which tells a caller the name is not
+compiler-minted, rather than that it renumbered to itself. The predicate
+reports spellings the allocation must not produce, for a caller whose
+namespace also holds names it cannot rename.
+-}
+renumberedText
+  ∷ Delimiter
+  → (Text → Bool)
+  → Text
+  → Maybe (State Allocation Text)
+renumberedText (Delimiter delim) reserved whole
+  | any supplyDrawn piecesInContext =
+      Just $
+        Text.concat <$> forM piecesInContext \piece@(run, prefix, _next) →
+          if supplyDrawn piece then allocate prefix run else pure run
+  | otherwise = Nothing
+ where
+  -- Maximal runs of digits alternating with runs of non-digits.
+  pieces = Text.groupBy (\a b → Char.isDigit a == Char.isDigit b) whole
+  piecesInContext =
+    [ (p, Text.concat (take i pieces), pieces !!? (i + 1))
+    | (i, p) ← zip [0 ..] pieces
+    ]
+
+  supplyDrawn (p, prefix, next)
+    | not (Text.all Char.isDigit p) = False
+    | otherwise =
+        atSegmentEnd
+          && ( delim `Text.isSuffixOf` prefix -- whole segment: base$N
+                 || ( delim `Text.isPrefixOf` whole -- prefix-minted: $tagN
+                        && not
+                          ( delim
+                              `Text.isInfixOf` Text.drop (Text.length delim) prefix
+                          )
+                    )
+             )
+   where
+    atSegmentEnd = maybe True (delim `Text.isPrefixOf`) next
+
+  allocate ∷ Text → Text → State Allocation Text
+  allocate prefix run = do
+    Allocation {assigned, counters} ← get
+    show <$> case Map.lookup (prefix, run) assigned of
+      Just i → pure i
+      Nothing → do
+        let nextClear c
+              | reserved (prefix <> show c) = nextClear (c + 1)
+              | otherwise = c
+            i = nextClear (Map.findWithDefault 0 prefix counters)
+        put
+          Allocation
+            { assigned = Map.insert (prefix, run) i assigned
+            , counters = Map.insert prefix (i + 1) counters
+            }
+        pure i

--- a/pslua.cabal
+++ b/pslua.cabal
@@ -143,6 +143,7 @@ library
     Language.PureScript.Backend.IR.Pass
     Language.PureScript.Backend.IR.Query
     Language.PureScript.Backend.IR.RecordSurgery
+    Language.PureScript.Backend.IR.Renumber
     Language.PureScript.Backend.IR.SpecConstr
     Language.PureScript.Backend.IR.Supply
     Language.PureScript.Backend.IR.Types
@@ -169,6 +170,7 @@ library
     Language.PureScript.Backend.Lua.Traversal
     Language.PureScript.Backend.Lua.Types
     Language.PureScript.Backend.Output
+    Language.PureScript.Backend.Renumber
     Language.PureScript.Backend.Types
     Language.PureScript.Comments
     Language.PureScript.CoreFn
@@ -200,6 +202,7 @@ test-suite spec
     Language.PureScript.Backend.IR.MagicDo.Spec
     Language.PureScript.Backend.IR.Optimizer.Spec
     Language.PureScript.Backend.IR.Pass.Spec
+    Language.PureScript.Backend.IR.Renumber.Spec
     Language.PureScript.Backend.IR.Spec
     Language.PureScript.Backend.IR.SpecUtils
     Language.PureScript.Backend.IR.Types.Spec

--- a/test/Language/PureScript/Backend/IR/Renumber/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Renumber/Spec.hs
@@ -1,0 +1,268 @@
+module Language.PureScript.Backend.IR.Renumber.Spec where
+
+import Data.List qualified as List
+import Hedgehog (forAll, (===))
+import Language.PureScript.Backend.IR.Gen qualified as Gen
+import Language.PureScript.Backend.IR.Linker (UberModule (..))
+import Language.PureScript.Backend.IR.Linter
+  ( lintUniqueBinders
+  , lintWellScoped
+  )
+import Language.PureScript.Backend.IR.Names
+  ( Name (..)
+  , QName (..)
+  , moduleNameFromString
+  )
+import Language.PureScript.Backend.IR.Renumber (renumberUberModule)
+import Language.PureScript.Backend.IR.SpecUtils
+  ( applyPassToExpression
+  , emptyUberModule
+  )
+import Language.PureScript.Backend.IR.Supply (SupplyM, freshName, runSupply)
+import Language.PureScript.Backend.IR.Types
+  ( Exp
+  , Grouping (..)
+  , RawExp (ForeignImport)
+  , abstraction
+  , application
+  , freshenBinders
+  , lets
+  , literalInt
+  , noAnn
+  , paramNamed
+  , refLocal
+  )
+import Language.PureScript.Backend.IR.Uniquify (uniquifyNamesInExpr)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Expectations.Pretty (shouldBe)
+import Test.Hspec.Hedgehog.Extended (prop)
+
+spec ∷ Spec
+spec = describe "IR renumbering of minted binders (issue #338)" do
+  describe "a site's names are invariant under supply history" do
+    -- The indices the pipeline mints depend on how much supply ran out
+    -- before the minting pass reached the site, so the same site emerges
+    -- with different names when unrelated code upstream mints more or
+    -- fewer of them. Renumbering must map both spellings to one.
+    it "suffix-minted binders (base$N)" do
+      renumbered (letWithMintedLocals 100)
+        `shouldBe` renumbered (letWithMintedLocals 0)
+
+    it "prefix-minted binders ($tagN)" do
+      renumbered (letWithMintedTags 100)
+        `shouldBe` renumbered (letWithMintedTags 0)
+
+    prop 300 "any freshened site, at any supply offset" do
+      e ← forAll Gen.scopedExp
+      let atOffset k =
+            renumbered
+              (runSupply (burn k *> freshenBinders (uniquifyNamesInExpr e)))
+      atOffset 1000 === atOffset 0
+
+  describe "each site is renumbered from its own allocation" do
+    -- Per-site allocation is what confines a change: were the indices
+    -- handed out module-wide, a site minting one more name would shift
+    -- every site printed after it.
+    it "a site's names ignore what earlier sites consumed" do
+      secondSiteAfter (letWithMintedLocals 0)
+        `shouldBe` secondSiteAfter (soleMintedLocal 0)
+
+    it "sibling sites reuse the same renumbered names" do
+      let sites = uberModuleExports (renumberUberModule twoSiteModule)
+      fmap snd sites `shouldBe` [renumbered site | (_name, site) ← twoSites]
+
+  describe "renumberUberModule" do
+    it "renumbers a suffix-minted binder and its references" do
+      renumbered (boundTo "x$223" (literalInt 1) (refLocal (Name "x$223")))
+        `shouldBe` boundTo "x$0" (literalInt 1) (refLocal (Name "x$0"))
+
+    it "allocates per base name in first-occurrence order" do
+      renumbered
+        ( lets
+            ( Standalone (noAnn, Name "v$1437", literalInt 1)
+                :| [Standalone (noAnn, Name "v$921", refLocal (Name "v$1437"))]
+            )
+            (refLocal (Name "v$921"))
+        )
+        `shouldBe` lets
+          ( Standalone (noAnn, Name "v$0", literalInt 1)
+              :| [Standalone (noAnn, Name "v$1", refLocal (Name "v$0"))]
+          )
+          (refLocal (Name "v$1"))
+
+    it "renumbers a prefix-minted binder" do
+      renumbered (boundTo "$cse1413" (literalInt 1) (refLocal (Name "$cse1413")))
+        `shouldBe` boundTo "$cse0" (literalInt 1) (refLocal (Name "$cse0"))
+
+    it "keeps a derived name in step with the binder it embeds" do
+      -- The uncurried worker of $kont7 spells the index mid-name, and
+      -- must land on the same index as the helper it is derived from.
+      renumbered
+        ( lets
+            ( Standalone
+                ( noAnn
+                , Name "$kont7"
+                , abstraction (paramNamed (Name "n$9")) (refLocal (Name "n$9"))
+                )
+                :| [ Standalone
+                       (noAnn, Name "$kont7$w", refLocal (Name "$kont7"))
+                   ]
+            )
+            (refLocal (Name "$kont7$w"))
+        )
+        `shouldBe` lets
+          ( Standalone
+              ( noAnn
+              , Name "$kont0"
+              , abstraction (paramNamed (Name "n$0")) (refLocal (Name "n$0"))
+              )
+              :| [Standalone (noAnn, Name "$kont0$w", refLocal (Name "$kont0"))]
+          )
+          (refLocal (Name "$kont0$w"))
+
+    it "leaves structural indices and source spellings alone" do
+      -- Uncurrying's worker and parameter suffixes, call-pattern
+      -- specialization's shape suffix, uniquification's digit suffix,
+      -- magic-do's marker and a source name that merely ends in a digit.
+      unchanged $
+        lets
+          ( Standalone (noAnn, Name "add3", literalInt 1)
+              :| [ Standalone (noAnn, Name "f$w", literalInt 2)
+                 , Standalone (noAnn, Name "f$p1", literalInt 3)
+                 , Standalone (noAnn, Name "pong$sc1Tuple", literalInt 4)
+                 , Standalone (noAnn, Name "x0", literalInt 5)
+                 , Standalone (noAnn, Name "$magicDoRun", literalInt 6)
+                 ]
+          )
+          (refLocal (Name "x0"))
+
+    it "leaves a foreign import's export keys alone" do
+      unchanged $
+        ForeignImport
+          noAnn
+          (moduleNameFromString "Foreign.M")
+          "m.lua"
+          [(noAnn, Name "key$5")]
+
+    prop 300 "is the identity on sites without minted names" do
+      e ← forAll Gen.scopedExp
+      renumbered e === e
+
+    prop 300 "is idempotent" do
+      e ← forAll (freshened <$> Gen.scopedExp)
+      renumbered (renumbered e) === renumbered e
+
+    prop 300 "preserves well-scopedness and binder uniqueness" do
+      e ← forAll (freshened <$> Gen.scopedExp)
+      let renumberedModule = renumberUberModule (inAllSites e)
+      lintWellScoped renumberedModule === []
+      lintUniqueBinders renumberedModule === []
+
+--------------------------------------------------------------------------------
+-- Fixtures --------------------------------------------------------------------
+
+{- | A name as the IR passes mint them: @base$N@, with @N@ drawn from the
+pipeline-global supply. The offset added to every index in a fixture
+stands for supply consumed earlier by unrelated code.
+-}
+minted ∷ Text → Natural → Name
+minted base k = Name (base <> "$" <> show k)
+
+{- | @let v$k = 1; f$(k+1) = \\x$(k+2) → x$(k+2) in f$(k+1) v$k@ — three
+suffix-minted binders.
+-}
+letWithMintedLocals ∷ Natural → Exp
+letWithMintedLocals k =
+  lets
+    ( Standalone (noAnn, minted "v" k, literalInt 1)
+        :| [ Standalone
+               ( noAnn
+               , minted "f" (k + 1)
+               , abstraction
+                   (paramNamed (minted "x" (k + 2)))
+                   (refLocal (minted "x" (k + 2)))
+               )
+           ]
+    )
+    (application (refLocal (minted "f" (k + 1))) (refLocal (minted "v" k)))
+
+{- | The prefix-minted counterpart: CSE's @$cseN@ shared binding holding
+the continuation helper @$kontN@ that deep-bind flattening lifts out.
+-}
+letWithMintedTags ∷ Natural → Exp
+letWithMintedTags k =
+  lets
+    ( Standalone
+        ( noAnn
+        , Name ("$kont" <> show k)
+        , abstraction
+            (paramNamed (minted "n" (k + 1)))
+            (refLocal (minted "n" (k + 1)))
+        )
+        :| [ Standalone
+               ( noAnn
+               , Name ("$cse" <> show (k + 2))
+               , refLocal (Name ("$kont" <> show k))
+               )
+           ]
+    )
+    (refLocal (Name ("$cse" <> show (k + 2))))
+
+-- | One minted binder — a site consuming less supply than the others.
+soleMintedLocal ∷ Natural → Exp
+soleMintedLocal k =
+  boundTo ("v$" <> show k) (literalInt 1) (refLocal (minted "v" k))
+
+twoSites ∷ [(Name, Exp)]
+twoSites = [(Name "first", letWithMintedLocals 0), (Name "second", secondSite)]
+
+-- | The site whose renumbering must not move when its neighbour changes.
+secondSite ∷ Exp
+secondSite = letWithMintedLocals 700
+
+twoSiteModule ∷ UberModule
+twoSiteModule = emptyUberModule {uberModuleExports = twoSites}
+
+inAllSites ∷ Exp → UberModule
+inAllSites e =
+  UberModule
+    { uberModuleBindings = [Standalone (qname, e)]
+    , uberModuleForeigns = [(qname, e)]
+    , uberModuleExports = [(Name "it", e)]
+    }
+ where
+  qname = QName (moduleNameFromString "Main") (Name "it")
+
+--------------------------------------------------------------------------------
+-- Helper Functions ------------------------------------------------------------
+
+renumbered ∷ HasCallStack ⇒ Exp → Exp
+renumbered = applyPassToExpression "renumberUberModule" renumberUberModule
+
+unchanged ∷ HasCallStack ⇒ Exp → IO ()
+unchanged e = renumbered e `shouldBe` e
+
+boundTo ∷ Text → Exp → Exp → Exp
+boundTo name rhs = lets (Standalone (noAnn, Name name, rhs) :| [])
+
+{- | The second of two sites, renumbered with the first replaced by the
+given site — the same site, following neighbours of different sizes.
+-}
+secondSiteAfter ∷ Exp → Maybe Exp
+secondSiteAfter firstSite =
+  List.lookup (Name "second") . uberModuleExports . renumberUberModule $
+    emptyUberModule
+      { uberModuleExports =
+          [(Name "first", firstSite), (Name "second", secondSite)]
+      }
+
+{- | Rename every binder to a supply-minted name, as an inline paste
+does. Freshening requires the unique binders the entry pass establishes,
+so the site is uniquified first, exactly as the pipeline orders them.
+-}
+freshened ∷ Exp → Exp
+freshened = runSupply . freshenBinders . uniquifyNamesInExpr
+
+-- | Consume the given number of fresh names, as earlier passes do.
+burn ∷ Natural → SupplyM ()
+burn k = replicateM_ (fromIntegral k) (freshName "burn$")

--- a/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
+++ b/test/Language/PureScript/Backend/Lua/Golden/Spec.hs
@@ -20,6 +20,7 @@ import Language.PureScript.Backend.IR.Optimizer (optimizedUberModuleChecked)
 import Language.PureScript.Backend.IR.Pass
   ( PassCheckFailure (ResultDanglingImports)
   )
+import Language.PureScript.Backend.IR.Renumber (renumberUberModule)
 import Language.PureScript.Backend.Lua qualified as Lua
 import Language.PureScript.Backend.Lua.ForeignLift qualified as ForeignLift
 import Language.PureScript.Backend.Lua.Limits (LuaLimits, lua51Limits)
@@ -118,6 +119,11 @@ spec = do
         it irTestName do
           acceptableGolden irGolden (Just irActual) do
             uberModule ← compileCorefn (Tagged (Rel psOutputPath)) moduleName
+            -- The indices the pipeline mints into binder names record how
+            -- much supply ran out before each was minted, so an unrelated
+            -- pass consuming one more name renumbers every name after it.
+            -- Renumbering makes each site's names a function of its own
+            -- structure, leaving this golden to move only when the IR does.
             pure . toStrict $
               pShowOpt
                 defaultOutputOptionsNoColor
@@ -125,7 +131,7 @@ spec = do
                   , outputOptionsPageWidth = 100
                   , outputOptionsCompact = True
                   }
-                uberModule
+                (renumberUberModule uberModule)
         -- lua golden
         let evalGolden =
               modulePath </> $(mkRelDir "eval") </> $(mkRelFile "golden.txt")

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,6 +11,7 @@ import Language.PureScript.Backend.IR.Linter.Spec qualified as IRLinter
 import Language.PureScript.Backend.IR.MagicDo.Spec qualified as MagicDo
 import Language.PureScript.Backend.IR.Optimizer.Spec qualified as IROptimizer
 import Language.PureScript.Backend.IR.Pass.Spec qualified as IRPass
+import Language.PureScript.Backend.IR.Renumber.Spec qualified as IRRenumber
 import Language.PureScript.Backend.IR.Spec qualified as IR
 import Language.PureScript.Backend.IR.Types.Spec qualified as Types
 import Language.PureScript.Backend.IR.Uncurry.Spec qualified as IRUncurry
@@ -48,6 +49,7 @@ main = hspec do
   IRCpr.spec
   IRUncurry.spec
   IRUniquify.spec
+  IRRenumber.spec
   LuaOptimizer.spec
   LuaLocalize.spec
   LuaPromote.spec

--- a/test/ps/output/Golden.Annotations.M2/golden.ir
+++ b/test/ps/output/Golden.Annotations.M2/golden.ir
@@ -13,25 +13,25 @@ UberModule
         ( ParamNamed Nothing ( Name "i$0" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "v$2", Let Nothing
+            ( Nothing, Name "v$0", Let Nothing
               ( Standalone
-                ( Nothing, Name "v$4", IfThenElse Nothing
+                ( Nothing, Name "v$1", IfThenElse Nothing
                   ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "i$0" ) ) ) )
                   ( LiteralInt Nothing 2 )
                   ( Ref Nothing ( Local ( Name "i$0" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
-                ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "v$4" ) ) ) )
+                ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "v$1" ) ) ) )
                 ( LiteralInt Nothing 2 )
-                ( Ref Nothing ( Local ( Name "v$4" ) ) )
+                ( Ref Nothing ( Local ( Name "v$1" ) ) )
               )
             ) :| []
           )
           ( IfThenElse Nothing
-            ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "v$2" ) ) ) )
+            ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
             ( LiteralInt Nothing 2 )
-            ( Ref Nothing ( Local ( Name "v$2" ) ) )
+            ( Ref Nothing ( Local ( Name "v$0" ) ) )
           )
         )
       ),

--- a/test/ps/output/Golden.ArrayOfUnits.Test/golden.ir
+++ b/test/ps/output/Golden.ArrayOfUnits.Test/golden.ir
@@ -64,7 +64,7 @@ UberModule
             ( PropName "foldMap", AbsN Nothing
               ( ParamNamed Nothing ( Name "dictMonoid" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "f$914" ) :| [] )
+                ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                 ( AppN Nothing
                   ( AppN Nothing
                     ( ObjectProp Nothing
@@ -74,9 +74,9 @@ UberModule
                       ( PropName "foldr" )
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "x$915" ) :| [] )
+                      ( ParamNamed Nothing ( Name "x$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "acc$916" ) :| [] )
+                        ( ParamNamed Nothing ( Name "acc$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
                             ( ObjectProp Nothing
@@ -92,11 +92,11 @@ UberModule
                               ( PropName "append" )
                             )
                             ( AppN Nothing
-                              ( Ref Nothing ( Local ( Name "f$914" ) ) )
-                              ( Ref Nothing ( Local ( Name "x$915" ) ) :| [] ) :| []
+                              ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                              ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] ) :| []
                             )
                           )
-                          ( Ref Nothing ( Local ( Name "acc$916" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "acc$0" ) ) :| [] )
                         )
                       ) :| []
                     )
@@ -172,9 +172,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$929" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$930" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -198,10 +198,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$929" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$930" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -222,7 +222,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$689", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -238,23 +238,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$691" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$692" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$689" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$691" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$693" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$689" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$692" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$694" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -277,8 +277,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$693" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$694" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -334,7 +334,7 @@ UberModule
                         ( AppN Nothing
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "dictApply$945", AppN Nothing
+                              ( Nothing, Name "dictApply$0", AppN Nothing
                                 ( ObjectProp Nothing
                                   ( Ref Nothing
                                     ( Imported
@@ -350,13 +350,13 @@ UberModule
                               ) :| []
                             )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "a$946" ) :| [] )
+                              ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "b$947" ) :| [] )
+                                ( ParamNamed Nothing ( Name "b$0" ) :| [] )
                                 ( AppN Nothing
                                   ( AppN Nothing
                                     ( ObjectProp Nothing
-                                      ( Ref Nothing ( Local ( Name "dictApply$945" ) ) )
+                                      ( Ref Nothing ( Local ( Name "dictApply$0" ) ) )
                                       ( PropName "apply" )
                                     )
                                     ( AppN Nothing
@@ -364,7 +364,7 @@ UberModule
                                         ( ObjectProp Nothing
                                           ( AppN Nothing
                                             ( ObjectProp Nothing
-                                              ( Ref Nothing ( Local ( Name "dictApply$945" ) ) )
+                                              ( Ref Nothing ( Local ( Name "dictApply$0" ) ) )
                                               ( PropName "Functor0" )
                                             )
                                             ( Ref Nothing
@@ -379,15 +379,15 @@ UberModule
                                         ( AbsN Nothing
                                           ( ParamUnused Nothing :| [] )
                                           ( AbsN Nothing
-                                            ( ParamNamed Nothing ( Name "x$948" ) :| [] )
-                                            ( Ref Nothing ( Local ( Name "x$948" ) ) )
+                                            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                                            ( Ref Nothing ( Local ( Name "x$0" ) ) )
                                           ) :| []
                                         )
                                       )
-                                      ( Ref Nothing ( Local ( Name "a$946" ) ) :| [] ) :| []
+                                      ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
                                     )
                                   )
-                                  ( Ref Nothing ( Local ( Name "b$947" ) ) :| [] )
+                                  ( Ref Nothing ( Local ( Name "b$0" ) ) :| [] )
                                 )
                               )
                             )
@@ -431,12 +431,12 @@ UberModule
                           ( PropName "foldl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "c$911" ) :| [] )
+                          ( ParamNamed Nothing ( Name "c$0" ) :| [] )
                           ( AbsN Nothing
                             ( ParamUnused Nothing :| [] )
                             ( PrimBinOp Nothing PrimAdd
                               ( LiteralInt Nothing 1 )
-                              ( Ref Nothing ( Local ( Name "c$911" ) ) )
+                              ( Ref Nothing ( Local ( Name "c$0" ) ) )
                             )
                           ) :| []
                         )

--- a/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
+++ b/test/ps/output/Golden.BugListGenericEq.Test/golden.ir
@@ -65,28 +65,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$218" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$219" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$0" ) :| [] )
                 ( PrimBinOp Nothing PrimAnd
-                  ( Ref Nothing ( Local ( Name "b1$218" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$219" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$0" ) ) )
                 )
               )
             ),
             ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$216" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$1" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$217" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$1" ) :| [] )
                 ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$216" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$217" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1" ) ) )
                 )
               )
             ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$215" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$215" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$0" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$0" ) ) ) )
             )
           ]
         ) :| []
@@ -171,7 +171,7 @@ UberModule
                   ( ParamNamed Nothing ( Name "y" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse305", Ctor Nothing SumType
+                      ( Nothing, Name "$cse0", Ctor Nothing SumType
                         ( ModuleName "Data.Generic.Rep" )
                         ( TyName "Sum" )
                         ( CtorName "Inl" )
@@ -185,12 +185,12 @@ UberModule
                     ( AppN Nothing
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v$7", IfThenElse Nothing
+                          ( Nothing, Name "v$0", IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Nil" )
                               ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "x" ) ) ) )
                             )
-                            ( Ref Nothing ( Local ( Name "$cse305" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                             ( Ctor Nothing SumType
                               ( ModuleName "Data.Generic.Rep" )
                               ( TyName "Sum" )
@@ -202,22 +202,22 @@ UberModule
                           ) :| []
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v1$8" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "$cse310", DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$8" ) ) )
+                              ( Nothing, Name "$cse1", DataArgumentByIndex Nothing SumType 0
+                                ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                               ) :| []
                             )
                             ( Let Nothing
                               ( Standalone
-                                ( Nothing, Name "$cse309", DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$7" ) ) )
+                                ( Nothing, Name "$cse2", DataArgumentByIndex Nothing SumType 0
+                                  ( Ref Nothing ( Local ( Name "v$0" ) ) )
                                 ) :| []
                               )
                               ( Let Nothing
                                 ( Standalone
-                                  ( Nothing, Name "$cse308", ObjectProp Nothing
+                                  ( Nothing, Name "$cse3", ObjectProp Nothing
                                     ( Ref Nothing
                                       ( Imported
                                         ( ModuleName "Data.HeytingAlgebra" )
@@ -229,54 +229,54 @@ UberModule
                                 )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "$cse307", ReflectCtor Nothing
-                                      ( Ref Nothing ( Local ( Name "v1$8" ) ) )
+                                    ( Nothing, Name "$cse4", ReflectCtor Nothing
+                                      ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                                     ) :| []
                                   )
                                   ( Let Nothing
                                     ( Standalone
-                                      ( Nothing, Name "$cse306", ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "v$7" ) ) )
+                                      ( Nothing, Name "$cse5", ReflectCtor Nothing
+                                        ( Ref Nothing ( Local ( Name "v$0" ) ) )
                                       ) :| []
                                     )
                                     ( IfThenElse Nothing
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                        ( Ref Nothing ( Local ( Name "$cse306" ) ) )
+                                        ( Ref Nothing ( Local ( Name "$cse5" ) ) )
                                       )
                                       ( Eq Nothing
                                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                                        ( Ref Nothing ( Local ( Name "$cse307" ) ) )
+                                        ( Ref Nothing ( Local ( Name "$cse4" ) ) )
                                       )
                                       ( PrimBinOp Nothing PrimAnd
                                         ( Eq Nothing
                                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                                          ( Ref Nothing ( Local ( Name "$cse306" ) ) )
+                                          ( Ref Nothing ( Local ( Name "$cse5" ) ) )
                                         )
                                         ( PrimBinOp Nothing PrimAnd
                                           ( Eq Nothing
                                             ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                                            ( Ref Nothing ( Local ( Name "$cse307" ) ) )
+                                            ( Ref Nothing ( Local ( Name "$cse4" ) ) )
                                           )
                                           ( Let Nothing
                                             ( Standalone
-                                              ( Nothing, Name "key$254", LiteralString Nothing "head"
+                                              ( Nothing, Name "key$0", LiteralString Nothing "head"
                                               ) :|
                                               [ Standalone
-                                                ( Nothing, Name "get$255", AppN Nothing
+                                                ( Nothing, Name "get$0", AppN Nothing
                                                   ( Ref Nothing
                                                     ( Imported
                                                       ( ModuleName "Record.Unsafe" )
                                                       ( Name "unsafeGet" )
                                                     )
                                                   )
-                                                  ( Ref Nothing ( Local ( Name "key$254" ) ) :| [] )
+                                                  ( Ref Nothing ( Local ( Name "key$0" ) ) :| [] )
                                                 )
                                               ]
                                             )
                                             ( AppN Nothing
                                               ( AppN Nothing
-                                                ( Ref Nothing ( Local ( Name "$cse308" ) ) )
+                                                ( Ref Nothing ( Local ( Name "$cse3" ) ) )
                                                 ( AppN Nothing
                                                   ( AppN Nothing
                                                     ( ObjectProp Nothing
@@ -284,26 +284,26 @@ UberModule
                                                       ( PropName "eq" )
                                                     )
                                                     ( AppN Nothing
-                                                      ( Ref Nothing ( Local ( Name "get$255" ) ) )
+                                                      ( Ref Nothing ( Local ( Name "get$0" ) ) )
                                                       ( Ref Nothing
-                                                        ( Local ( Name "$cse309" ) ) :| []
+                                                        ( Local ( Name "$cse2" ) ) :| []
                                                       ) :| []
                                                     )
                                                   )
                                                   ( AppN Nothing
-                                                    ( Ref Nothing ( Local ( Name "get$255" ) ) )
+                                                    ( Ref Nothing ( Local ( Name "get$0" ) ) )
                                                     ( Ref Nothing
-                                                      ( Local ( Name "$cse310" ) ) :| []
+                                                      ( Local ( Name "$cse1" ) ) :| []
                                                     ) :| []
                                                   ) :| []
                                                 )
                                               )
                                               ( Let Nothing
                                                 ( Standalone
-                                                  ( Nothing, Name "key$244", LiteralString Nothing "tail"
+                                                  ( Nothing, Name "key$1", LiteralString Nothing "tail"
                                                   ) :|
                                                   [ Standalone
-                                                    ( Nothing, Name "get$245", AppN Nothing
+                                                    ( Nothing, Name "get$1", AppN Nothing
                                                       ( Ref Nothing
                                                         ( Imported
                                                           ( ModuleName "Record.Unsafe" )
@@ -311,14 +311,14 @@ UberModule
                                                         )
                                                       )
                                                       ( Ref Nothing
-                                                        ( Local ( Name "key$244" ) ) :| []
+                                                        ( Local ( Name "key$1" ) ) :| []
                                                       )
                                                     )
                                                   ]
                                                 )
                                                 ( AppN Nothing
                                                   ( AppN Nothing
-                                                    ( Ref Nothing ( Local ( Name "$cse308" ) ) )
+                                                    ( Ref Nothing ( Local ( Name "$cse3" ) ) )
                                                     ( AppN Nothing
                                                       ( AppN Nothing
                                                         ( ObjectProp Nothing
@@ -337,19 +337,17 @@ UberModule
                                                         )
                                                         ( AppN Nothing
                                                           ( Ref Nothing
-                                                            ( Local ( Name "get$245" ) )
+                                                            ( Local ( Name "get$1" ) )
                                                           )
                                                           ( Ref Nothing
-                                                            ( Local ( Name "$cse309" ) ) :| []
+                                                            ( Local ( Name "$cse2" ) ) :| []
                                                           ) :| []
                                                         )
                                                       )
                                                       ( AppN Nothing
+                                                        ( Ref Nothing ( Local ( Name "get$1" ) ) )
                                                         ( Ref Nothing
-                                                          ( Local ( Name "get$245" ) )
-                                                        )
-                                                        ( Ref Nothing
-                                                          ( Local ( Name "$cse310" ) ) :| []
+                                                          ( Local ( Name "$cse1" ) ) :| []
                                                         ) :| []
                                                       ) :| []
                                                     )
@@ -374,7 +372,7 @@ UberModule
                           ( LiteralString Nothing "Golden.BugListGenericEq.Test∷List.Nil" )
                           ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "y" ) ) ) )
                         )
-                        ( Ref Nothing ( Local ( Name "$cse305" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( Ctor Nothing SumType
                           ( ModuleName "Data.Generic.Rep" )
                           ( TyName "Sum" )
@@ -402,12 +400,12 @@ UberModule
           ( LiteralObject Nothing
             [
               ( PropName "eq", AbsN Nothing
-                ( ParamNamed Nothing ( Name "r1$222" ) :| [] )
+                ( ParamNamed Nothing ( Name "r1$0" ) :| [] )
                 ( AbsN Nothing
-                  ( ParamNamed Nothing ( Name "r2$223" ) :| [] )
+                  ( ParamNamed Nothing ( Name "r2$0" ) :| [] )
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "r1$222" ) ) )
-                    ( Ref Nothing ( Local ( Name "r2$223" ) ) )
+                    ( Ref Nothing ( Local ( Name "r1$0" ) ) )
+                    ( Ref Nothing ( Local ( Name "r2$0" ) ) )
                   )
                 )
               )
@@ -425,17 +423,17 @@ UberModule
         ( Imported ( ModuleName "Golden.BugListGenericEq.Test" ) ( Name "Cons" ) )
       ),
       ( Name "cons", AbsN Nothing
-        ( ParamNamed Nothing ( Name "cons$p1$229" ) :| [] )
+        ( ParamNamed Nothing ( Name "cons$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "cons$p2$230" ) :| [] )
+          ( ParamNamed Nothing ( Name "cons$p2$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.BugListGenericEq.Test" )
             ( TyName "List" )
             ( CtorName "Cons" )
             [ LiteralObject Nothing
               [
-                ( PropName "head", Ref Nothing ( Local ( Name "cons$p1$229" ) ) ),
-                ( PropName "tail", Ref Nothing ( Local ( Name "cons$p2$230" ) ) )
+                ( PropName "head", Ref Nothing ( Local ( Name "cons$p1$0" ) ) ),
+                ( PropName "tail", Ref Nothing ( Local ( Name "cons$p2$0" ) ) )
               ]
             ]
           )
@@ -445,7 +443,7 @@ UberModule
         ( ParamUnused Nothing :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse312", Ctor Nothing SumType
+            ( Nothing, Name "$cse0", Ctor Nothing SumType
               ( ModuleName "Golden.BugListGenericEq.Test" )
               ( TyName "List" )
               ( CtorName "Cons" )
@@ -461,14 +459,14 @@ UberModule
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse311", Ctor Nothing SumType
+              ( Nothing, Name "$cse1", Ctor Nothing SumType
                 ( ModuleName "Golden.BugListGenericEq.Test" )
                 ( TyName "List" )
                 ( CtorName "Cons" )
                 [ LiteralObject Nothing
                   [
                     ( PropName "head", LiteralInt Nothing 1 ),
-                    ( PropName "tail", Ref Nothing ( Local ( Name "$cse312" ) ) )
+                    ( PropName "tail", Ref Nothing ( Local ( Name "$cse0" ) ) )
                   ]
                 ]
               ) :| []
@@ -517,9 +515,9 @@ UberModule
                                 ( Name "eq" )
                               )
                             )
-                            ( Ref Nothing ( Local ( Name "$cse311" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "$cse1" ) ) :| [] )
                           )
-                          ( Ref Nothing ( Local ( Name "$cse311" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "$cse1" ) ) :| [] )
                         )
                         ( LiteralString Nothing "true" )
                         ( LiteralString Nothing "false" ) :| []
@@ -555,7 +553,7 @@ UberModule
                           ] :| []
                         )
                       )
-                      ( Ref Nothing ( Local ( Name "$cse312" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                     )
                     ( LiteralString Nothing "true" )
                     ( LiteralString Nothing "false" ) :| []

--- a/test/ps/output/Golden.CSE.Test/golden.ir
+++ b/test/ps/output/Golden.CSE.Test/golden.ir
@@ -52,7 +52,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.CSE.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$222" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -63,19 +63,19 @@ UberModule
               )
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) :| [] )
             )
-            ( Ref Nothing ( Local ( Name "a$222" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.CSE.Test", qnameName = Name "logShow1"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$218" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "a$218" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -124,15 +124,15 @@ UberModule
           ( ParamNamed Nothing ( Name "x" ) :| [] )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse280", ObjectProp Nothing
+              ( Nothing, Name "$cse0", ObjectProp Nothing
                 ( Ref Nothing ( Local ( Name "r" ) ) )
                 ( PropName "run" )
               ) :| []
             )
             ( AppN Nothing
-              ( Ref Nothing ( Local ( Name "$cse280" ) ) )
+              ( Ref Nothing ( Local ( Name "$cse0" ) ) )
               ( AppN Nothing
-                ( Ref Nothing ( Local ( Name "$cse280" ) ) )
+                ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                 ( Ref Nothing ( Local ( Name "x" ) ) :| [] ) :| []
               )
             )
@@ -145,7 +145,7 @@ UberModule
         ( ParamNamed Nothing ( Name "e" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse281", DataArgumentByIndex Nothing SumType 0
+            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
               ( Ref Nothing ( Local ( Name "e" ) ) )
             ) :| []
           )
@@ -157,14 +157,14 @@ UberModule
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Golden.CSE.Test∷E.Num" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse281" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.CSE.Test∷N.Zero" )
                   ( ReflectCtor Nothing
                     ( DataArgumentByIndex Nothing SumType 0
-                      ( Ref Nothing ( Local ( Name "$cse281" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                     )
                   )
                 )
@@ -174,7 +174,7 @@ UberModule
                     ( LiteralString Nothing "Golden.CSE.Test∷N.Succ" )
                     ( ReflectCtor Nothing
                       ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "$cse281" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                       )
                     )
                   )
@@ -185,7 +185,7 @@ UberModule
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.CSE.Test∷E.Not" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse281" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                 )
                 ( LiteralInt Nothing 2 )
                 ( Exception Nothing "No patterns matched" )
@@ -194,13 +194,13 @@ UberModule
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Golden.CSE.Test∷N.Zero" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse281" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
               )
               ( LiteralInt Nothing 3 )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.CSE.Test∷N.Succ" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse281" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                 )
                 ( LiteralInt Nothing 4 )
                 ( Exception Nothing "No patterns matched" )
@@ -215,7 +215,7 @@ UberModule
         ( ParamNamed Nothing ( Name "f" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse282", LiteralArray Nothing
+            ( Nothing, Name "$cse0", LiteralArray Nothing
               [ LiteralInt Nothing 1, LiteralInt Nothing 2, LiteralInt Nothing 3 ]
             ) :| []
           )
@@ -224,12 +224,12 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "append" ) ) )
               ( AppN Nothing
                 ( Ref Nothing ( Local ( Name "f" ) ) )
-                ( Ref Nothing ( Local ( Name "$cse282" ) ) :| [] ) :| []
+                ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] ) :| []
               )
             )
             ( AppN Nothing
               ( Ref Nothing ( Local ( Name "f" ) ) )
-              ( Ref Nothing ( Local ( Name "$cse282" ) ) :| [] ) :| []
+              ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] ) :| []
             )
           )
         )
@@ -242,7 +242,7 @@ UberModule
           ( ParamNamed Nothing ( Name "xs" ) :| [] )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse283", AbsN Nothing
+              ( Nothing, Name "$cse0", AbsN Nothing
                 ( ParamNamed Nothing ( Name "i" ) :| [] )
                 ( PrimBinOp Nothing PrimAdd
                   ( Ref Nothing ( Local ( Name "i" ) ) )
@@ -256,7 +256,7 @@ UberModule
                 ( AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "map" ) ) )
-                    ( Ref Nothing ( Local ( Name "$cse283" ) ) :| [] )
+                    ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                   )
                   ( Ref Nothing ( Local ( Name "xs" ) ) :| [] ) :| []
                 )
@@ -264,7 +264,7 @@ UberModule
               ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "map" ) ) )
-                  ( Ref Nothing ( Local ( Name "$cse283" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( Ref Nothing ( Local ( Name "xs" ) ) :| [] ) :| []
               )
@@ -294,7 +294,7 @@ UberModule
         ( ParamUnused Nothing :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse285", Ctor Nothing SumType
+            ( Nothing, Name "$cse0", Ctor Nothing SumType
               ( ModuleName "Golden.CSE.Test" )
               ( TyName "E" )
               ( CtorName "Num" )
@@ -303,11 +303,11 @@ UberModule
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse284", Ctor Nothing SumType
+              ( Nothing, Name "$cse1", Ctor Nothing SumType
                 ( ModuleName "Golden.CSE.Test" )
                 ( TyName "E" )
                 ( CtorName "Not" )
-                [ Ref Nothing ( Local ( Name "$cse285" ) ) ]
+                [ Ref Nothing ( Local ( Name "$cse0" ) ) ]
               ) :| []
             )
             ( Let Nothing
@@ -389,9 +389,9 @@ UberModule
                           ( LiteralObject Nothing
                             [
                               ( PropName "run", AbsN Nothing
-                                ( ParamNamed Nothing ( Name "i0$1" ) :| [] )
+                                ( ParamNamed Nothing ( Name "i0$0" ) :| [] )
                                 ( PrimBinOp Nothing PrimSub
-                                  ( Ref Nothing ( Local ( Name "i0$1" ) ) )
+                                  ( Ref Nothing ( Local ( Name "i0$0" ) ) )
                                   ( LiteralInt Nothing 1 )
                                 )
                               )
@@ -417,9 +417,9 @@ UberModule
                             ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "map" ) )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "v$2" ) :| [] )
+                            ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                             ( PrimBinOp Nothing PrimMul
-                              ( Ref Nothing ( Local ( Name "v$2" ) ) )
+                              ( Ref Nothing ( Local ( Name "v$0" ) ) )
                               ( LiteralInt Nothing 3 )
                             ) :| []
                           ) :| []
@@ -438,8 +438,8 @@ UberModule
                           ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "catBoth" ) )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "x$209" ) :| [] )
-                          ( Ref Nothing ( Local ( Name "x$209" ) ) ) :| []
+                          ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                          ( Ref Nothing ( Local ( Name "x$0" ) ) ) :| []
                         ) :| []
                       )
                     )
@@ -454,7 +454,7 @@ UberModule
                         ( Ref Nothing
                           ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "classify" ) )
                         )
-                        ( Ref Nothing ( Local ( Name "$cse285" ) ) :| [] ) :| []
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] ) :| []
                       )
                     )
                     ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -494,7 +494,7 @@ UberModule
                         ( Ref Nothing
                           ( Imported ( ModuleName "Golden.CSE.Test" ) ( Name "classify" ) )
                         )
-                        ( Ref Nothing ( Local ( Name "$cse284" ) ) :| [] ) :| []
+                        ( Ref Nothing ( Local ( Name "$cse1" ) ) :| [] ) :| []
                       )
                     )
                     ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -512,7 +512,7 @@ UberModule
                       ( ModuleName "Golden.CSE.Test" )
                       ( TyName "E" )
                       ( CtorName "Not" )
-                      [ Ref Nothing ( Local ( Name "$cse284" ) ) ] :| []
+                      [ Ref Nothing ( Local ( Name "$cse1" ) ) ] :| []
                     ) :| []
                   )
                 )

--- a/test/ps/output/Golden.CasePruning.Test/golden.ir
+++ b/test/ps/output/Golden.CasePruning.Test/golden.ir
@@ -16,7 +16,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.CasePruning.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
@@ -27,7 +27,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -106,31 +106,31 @@ UberModule
           ( ParamNamed Nothing ( Name "v1" ) :| [] )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse283", ReflectCtor Nothing
+              ( Nothing, Name "$cse0", ReflectCtor Nothing
                 ( Ref Nothing ( Local ( Name "v1" ) ) )
               ) :| []
             )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse282", ReflectCtor Nothing
+                ( Nothing, Name "$cse1", ReflectCtor Nothing
                   ( Ref Nothing ( Local ( Name "v" ) ) )
                 ) :| []
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.CasePruning.Test∷T.A" )
-                  ( Ref Nothing ( Local ( Name "$cse282" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.CasePruning.Test∷T.A" )
-                    ( Ref Nothing ( Local ( Name "$cse283" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                   )
                   ( LiteralInt Nothing 1 )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.CasePruning.Test∷T.B" )
-                      ( Ref Nothing ( Local ( Name "$cse283" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                     )
                     ( LiteralInt Nothing 3 )
                     ( LiteralInt Nothing 4 )
@@ -139,12 +139,12 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.CasePruning.Test∷T.B" )
-                    ( Ref Nothing ( Local ( Name "$cse283" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                   )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.CasePruning.Test∷T.B" )
-                      ( Ref Nothing ( Local ( Name "$cse282" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                     )
                     ( LiteralInt Nothing 2 )
                     ( LiteralInt Nothing 4 )

--- a/test/ps/output/Golden.CaseStatements.Test/golden.ir
+++ b/test/ps/output/Golden.CaseStatements.Test/golden.ir
@@ -5,12 +5,12 @@ UberModule
       ( Name "b", LiteralChar Nothing 'b' ),
       ( Name "c", LiteralInt Nothing 42 ),
       ( Name "J", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$16" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.CaseStatements.Test" )
           ( TyName "M" )
           ( CtorName "J" )
-          [ Ref Nothing ( Local ( Name "value0$16" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "N", Ctor Nothing SumType
@@ -19,19 +19,19 @@ UberModule
         ( CtorName "N" ) []
       ),
       ( Name "d", AbsN Nothing
-        ( ParamNamed Nothing ( Name "m$10" ) :| [] )
+        ( ParamNamed Nothing ( Name "m$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "n$11" ) :| [] )
+          ( ParamNamed Nothing ( Name "n$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$12" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "v$13", AbsN Nothing
+                ( Nothing, Name "v$0", AbsN Nothing
                   ( ParamUnused Nothing :| [] )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralChar Nothing 'y' )
-                      ( Ref Nothing ( Local ( Name "x$12" ) ) )
+                      ( Ref Nothing ( Local ( Name "x$0" ) ) )
                     )
                     ( LiteralInt Nothing 0 )
                     ( LiteralInt Nothing 1 )
@@ -39,35 +39,32 @@ UberModule
                 ) :| []
               )
               ( IfThenElse Nothing
-                ( Eq Nothing
-                  ( LiteralChar Nothing 'x' )
-                  ( Ref Nothing ( Local ( Name "x$12" ) ) )
-                )
+                ( Eq Nothing ( LiteralChar Nothing 'x' ) ( Ref Nothing ( Local ( Name "x$0" ) ) ) )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.CaseStatements.Test∷M.J" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "m$10" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "m$0" ) ) ) )
                   )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.CaseStatements.Test∷M.N" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "n$11" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "n$0" ) ) ) )
                     )
                     ( DataArgumentByIndex Nothing SumType 0
-                      ( Ref Nothing ( Local ( Name "m$10" ) ) )
+                      ( Ref Nothing ( Local ( Name "m$0" ) ) )
                     )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "v$13" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$0" ) ) )
                       ( LiteralBool Nothing True :| [] )
                     )
                   )
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "v$13" ) ) )
+                    ( Ref Nothing ( Local ( Name "v$0" ) ) )
                     ( LiteralBool Nothing True :| [] )
                   )
                 )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "v$13" ) ) )
+                  ( Ref Nothing ( Local ( Name "v$0" ) ) )
                   ( LiteralBool Nothing True :| [] )
                 )
               )

--- a/test/ps/output/Golden.CprResult.Test/golden.ir
+++ b/test/ps/output/Golden.CprResult.Test/golden.ir
@@ -28,28 +28,28 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.CprResult.Test", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$535" ) :| [ ParamNamed Nothing ( Name "y$536" ) ] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [ ParamNamed Nothing ( Name "y$0" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$535" ) ) )
-          ( Ref Nothing ( Local ( Name "y$536" ) ) )
+          ( Ref Nothing ( Local ( Name "x$0" ) ) )
+          ( Ref Nothing ( Local ( Name "y$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.CprResult.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$532" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "a$532" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.CprResult.Test", qnameName = Name "logShow1"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$529" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( PrimBinOp Nothing PrimConcat
@@ -58,7 +58,7 @@ UberModule
               ( AppN Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                 ( DataArgumentByIndex Nothing ProductType 0
-                  ( Ref Nothing ( Local ( Name "a$529" ) ) ) :| []
+                  ( Ref Nothing ( Local ( Name "a$0" ) ) ) :| []
                 )
               )
               ( PrimBinOp Nothing PrimConcat
@@ -67,7 +67,7 @@ UberModule
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                     ( DataArgumentByIndex Nothing ProductType 1
-                      ( Ref Nothing ( Local ( Name "a$529" ) ) ) :| []
+                      ( Ref Nothing ( Local ( Name "a$0" ) ) ) :| []
                     )
                   )
                   ( LiteralString Nothing ")" )
@@ -287,7 +287,7 @@ UberModule
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "n" ) :| [] )
         ( LetValues Nothing
-          ( ParamNamed Nothing ( Name "$v628" ) :| [ ParamNamed Nothing ( Name "$v629" ) ] )
+          ( ParamNamed Nothing ( Name "$v0" ) :| [ ParamNamed Nothing ( Name "$v1" ) ] )
           ( AppN Nothing
             ( Ref Nothing
               ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "branchy$r" ) )
@@ -295,8 +295,8 @@ UberModule
             ( Ref Nothing ( Local ( Name "n" ) ) :| [] )
           )
           ( PrimBinOp Nothing PrimSub
-            ( Ref Nothing ( Local ( Name "$v628" ) ) )
-            ( Ref Nothing ( Local ( Name "$v629" ) ) )
+            ( Ref Nothing ( Local ( Name "$v0" ) ) )
+            ( Ref Nothing ( Local ( Name "$v1" ) ) )
           )
         )
       ), Standalone
@@ -443,14 +443,14 @@ UberModule
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "n" ) :| [] )
         ( LetValues Nothing
-          ( ParamNamed Nothing ( Name "$v630" ) :| [ ParamNamed Nothing ( Name "$v631" ) ] )
+          ( ParamNamed Nothing ( Name "$v0" ) :| [ ParamNamed Nothing ( Name "$v1" ) ] )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "big$r" ) ) )
             ( Ref Nothing ( Local ( Name "n" ) ) :| [] )
           )
           ( PrimBinOp Nothing PrimAdd
-            ( Ref Nothing ( Local ( Name "$v630" ) ) )
-            ( Ref Nothing ( Local ( Name "$v631" ) ) )
+            ( Ref Nothing ( Local ( Name "$v0" ) ) )
+            ( Ref Nothing ( Local ( Name "$v1" ) ) )
           )
         )
       )
@@ -511,10 +511,7 @@ UberModule
                     ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "logShow" ) )
                   )
                   ( LetValues Nothing
-                    ( ParamNamed Nothing
-                      ( Name "$v632" ) :|
-                      [ ParamNamed Nothing ( Name "$v633" ) ]
-                    )
+                    ( ParamNamed Nothing ( Name "$v0" ) :| [ ParamNamed Nothing ( Name "$v1" ) ] )
                     ( AppN Nothing
                       ( Ref Nothing
                         ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "branchy$r" ) )
@@ -526,8 +523,8 @@ UberModule
                         ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "sub$w" ) )
                       )
                       ( Ref Nothing
-                        ( Local ( Name "$v632" ) ) :|
-                        [ Ref Nothing ( Local ( Name "$v633" ) ) ]
+                        ( Local ( Name "$v0" ) ) :|
+                        [ Ref Nothing ( Local ( Name "$v1" ) ) ]
                       )
                     ) :| []
                   )
@@ -540,10 +537,7 @@ UberModule
                     ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "logShow" ) )
                   )
                   ( LetValues Nothing
-                    ( ParamNamed Nothing
-                      ( Name "$v634" ) :|
-                      [ ParamNamed Nothing ( Name "$v635" ) ]
-                    )
+                    ( ParamNamed Nothing ( Name "$v2" ) :| [ ParamNamed Nothing ( Name "$v3" ) ] )
                     ( AppN Nothing
                       ( Ref Nothing
                         ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "branchy$r" ) )
@@ -555,8 +549,8 @@ UberModule
                         ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "sub$w" ) )
                       )
                       ( Ref Nothing
-                        ( Local ( Name "$v634" ) ) :|
-                        [ Ref Nothing ( Local ( Name "$v635" ) ) ]
+                        ( Local ( Name "$v2" ) ) :|
+                        [ Ref Nothing ( Local ( Name "$v3" ) ) ]
                       )
                     ) :| []
                   )
@@ -582,7 +576,7 @@ UberModule
                 ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "logShow" ) )
               )
               ( LetValues Nothing
-                ( ParamNamed Nothing ( Name "$v636" ) :| [ ParamNamed Nothing ( Name "$v637" ) ] )
+                ( ParamNamed Nothing ( Name "$v4" ) :| [ ParamNamed Nothing ( Name "$v5" ) ] )
                 ( AppN Nothing
                   ( Ref Nothing
                     ( Imported ( ModuleName "Golden.CprResult.Test" ) ( Name "big$r" ) )
@@ -590,8 +584,8 @@ UberModule
                   ( LiteralInt Nothing 3 :| [] )
                 )
                 ( PrimBinOp Nothing PrimAdd
-                  ( Ref Nothing ( Local ( Name "$v636" ) ) )
-                  ( Ref Nothing ( Local ( Name "$v637" ) ) )
+                  ( Ref Nothing ( Local ( Name "$v4" ) ) )
+                  ( Ref Nothing ( Local ( Name "$v5" ) ) )
                 ) :| []
               )
             )

--- a/test/ps/output/Golden.CprState.Test/golden.ir
+++ b/test/ps/output/Golden.CprState.Test/golden.ir
@@ -44,12 +44,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "map", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "f$511" ) :| [] )
+                  ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "m$512" ) :| [] )
+                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$511" ) ) )
-                      ( Ref Nothing ( Local ( Name "m$512" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "m$0" ) ) :| [] )
                     )
                   )
                 )
@@ -67,8 +67,8 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$513" ) :| [] )
-                  ( Ref Nothing ( Local ( Name "x$513" ) ) )
+                  ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                  ( Ref Nothing ( Local ( Name "x$0" ) ) )
                 ),
                 ( PropName "Apply0", AbsN Nothing
                   ( ParamUnused Nothing :| [] )
@@ -84,12 +84,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "bind", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "v$75" ) :| [] )
+                  ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$76" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$76" ) ) )
-                      ( Ref Nothing ( Local ( Name "v$75" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                     )
                   )
                 ),
@@ -205,7 +205,7 @@ UberModule
               [
                 ( PropName "apply", Let Nothing
                   ( Standalone
-                    ( Nothing, Name "dictMonad$514", AppN Nothing
+                    ( Nothing, Name "dictMonad$0", AppN Nothing
                       ( Ref Nothing
                         ( Imported
                           ( ModuleName "Control.Monad.State.Trans" )
@@ -217,10 +217,10 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$515", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
-                            ( Ref Nothing ( Local ( Name "dictMonad$514" ) ) )
+                            ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                             ( PropName "Bind1" )
                           )
                           ( Ref Nothing
@@ -231,28 +231,28 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$516" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$517" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$515" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$516" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$518" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$515" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$517" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$519" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
                                       ( ObjectProp Nothing
-                                        ( Ref Nothing ( Local ( Name "dictMonad$514" ) ) )
+                                        ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                                         ( PropName "Applicative0" )
                                       )
                                       ( Ref Nothing
@@ -265,8 +265,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$518" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$519" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -282,11 +282,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "map", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "f$507" ) :| [] )
+                        ( ParamNamed Nothing ( Name "f$1" ) :| [] )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$508" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "s$509" ) :| [] )
+                            ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
                                 ( ObjectProp Nothing
@@ -324,24 +324,24 @@ UberModule
                                   ( PropName "map" )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "v1$510" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                                   ( Ctor Nothing ProductType
                                     ( ModuleName "Data.Tuple" )
                                     ( TyName "Tuple" )
                                     ( CtorName "Tuple" )
                                     [ AppN Nothing
-                                      ( Ref Nothing ( Local ( Name "f$507" ) ) )
+                                      ( Ref Nothing ( Local ( Name "f$1" ) ) )
                                       ( DataArgumentByIndex Nothing ProductType 0
-                                        ( Ref Nothing ( Local ( Name "v1$510" ) ) ) :| []
+                                        ( Ref Nothing ( Local ( Name "v1$0" ) ) ) :| []
                                       ), DataArgumentByIndex Nothing ProductType 1
-                                      ( Ref Nothing ( Local ( Name "v1$510" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                                     ]
                                   ) :| []
                                 )
                               )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "v$508" ) ) )
-                                ( Ref Nothing ( Local ( Name "s$509" ) ) :| [] ) :| []
+                                ( Ref Nothing ( Local ( Name "v$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] ) :| []
                               )
                             )
                           )
@@ -413,12 +413,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.CprState.Test", qnameName = Name "get"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$701" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( Ctor Nothing ProductType
           ( ModuleName "Data.Tuple" )
           ( TyName "Tuple" )
           ( CtorName "Tuple" )
-          [ Ref Nothing ( Local ( Name "x$701" ) ), Ref Nothing ( Local ( Name "x$701" ) ) ]
+          [ Ref Nothing ( Local ( Name "x$0" ) ), Ref Nothing ( Local ( Name "x$0" ) ) ]
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.Currying.Test/golden.ir
+++ b/test/ps/output/Golden.Currying.Test/golden.ir
@@ -4,10 +4,10 @@ UberModule
       ( Name "apply", AbsN Nothing
         ( ParamNamed Nothing ( Name "f1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "x$1" ) :| [] )
+          ( ParamNamed Nothing ( Name "x$0" ) :| [] )
           ( AppN Nothing
             ( Ref Nothing ( Local ( Name "f1$0" ) ) )
-            ( Ref Nothing ( Local ( Name "x$1" ) ) :| [] )
+            ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] )
           )
         )
       ),

--- a/test/ps/output/Golden.DataDeclarations.Test1/golden.ir
+++ b/test/ps/output/Golden.DataDeclarations.Test1/golden.ir
@@ -7,31 +7,31 @@ UberModule
         ( CtorName "U" ) []
       ),
       ( Name "P3", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$1" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "value1$2" ) :| [] )
+          ( ParamNamed Nothing ( Name "value1$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "value2$3" ) :| [] )
+            ( ParamNamed Nothing ( Name "value2$0" ) :| [] )
             ( Ctor Nothing ProductType
               ( ModuleName "Golden.DataDeclarations.Test1" )
               ( TyName "TProduct" )
               ( CtorName "P3" )
               [ Ref Nothing
-                ( Local ( Name "value0$1" ) ), Ref Nothing
-                ( Local ( Name "value1$2" ) ), Ref Nothing
-                ( Local ( Name "value2$3" ) )
+                ( Local ( Name "value0$0" ) ), Ref Nothing
+                ( Local ( Name "value1$0" ) ), Ref Nothing
+                ( Local ( Name "value2$0" ) )
               ]
             )
           )
         )
       ),
       ( Name "PF", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$4" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing ProductType
           ( ModuleName "Golden.DataDeclarations.Test1" )
           ( TyName "TProductWithFields" )
           ( CtorName "PF" )
-          [ Ref Nothing ( Local ( Name "value0$4" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "S0", Ctor Nothing SumType
@@ -40,23 +40,23 @@ UberModule
         ( CtorName "S0" ) []
       ),
       ( Name "S1", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$7" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.DataDeclarations.Test1" )
           ( TyName "TSum" )
           ( CtorName "S1" )
-          [ Ref Nothing ( Local ( Name "value0$7" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "S2", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$5" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "value1$6" ) :| [] )
+          ( ParamNamed Nothing ( Name "value1$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.DataDeclarations.Test1" )
             ( TyName "TSum" )
             ( CtorName "S2" )
-            [ Ref Nothing ( Local ( Name "value0$5" ) ), Ref Nothing ( Local ( Name "value1$6" ) ) ]
+            [ Ref Nothing ( Local ( Name "value0$0" ) ), Ref Nothing ( Local ( Name "value1$0" ) ) ]
           )
         )
       ),

--- a/test/ps/output/Golden.DerivedFunctor.Test/golden.ir
+++ b/test/ps/output/Golden.DerivedFunctor.Test/golden.ir
@@ -100,7 +100,7 @@ UberModule
                 ( ParamNamed Nothing ( Name "m" ) :| [] )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "$cse269", ObjectProp Nothing
+                    ( Nothing, Name "$cse0", ObjectProp Nothing
                       ( Ref Nothing
                         ( Imported
                           ( ModuleName "Golden.DerivedFunctor.Test" )
@@ -124,7 +124,7 @@ UberModule
                       ( CtorName "Node" )
                       [ AppN Nothing
                         ( AppN Nothing
-                          ( Ref Nothing ( Local ( Name "$cse269" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           ( Ref Nothing ( Local ( Name "f" ) ) :| [] )
                         )
                         ( DataArgumentByIndex Nothing SumType 0
@@ -135,7 +135,7 @@ UberModule
                           ( Ref Nothing ( Local ( Name "m" ) ) ) :| []
                         ), AppN Nothing
                         ( AppN Nothing
-                          ( Ref Nothing ( Local ( Name "$cse269" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           ( Ref Nothing ( Local ( Name "f" ) ) :| [] )
                         )
                         ( DataArgumentByIndex Nothing SumType 2
@@ -160,7 +160,7 @@ UberModule
               ( ParamNamed Nothing ( Name "m" ) :| [] )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "$cse270", DataArgumentByIndex Nothing SumType 0
+                  ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
                     ( Ref Nothing ( Local ( Name "m" ) ) )
                   ) :| []
                 )
@@ -173,7 +173,7 @@ UberModule
                     ( ModuleName "Golden.DerivedFunctor.Test" )
                     ( TyName "Either" )
                     ( CtorName "Left" )
-                    [ Ref Nothing ( Local ( Name "$cse270" ) ) ]
+                    [ Ref Nothing ( Local ( Name "$cse0" ) ) ]
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Golden.DerivedFunctor.Test" )
@@ -181,7 +181,7 @@ UberModule
                     ( CtorName "Right" )
                     [ AppN Nothing
                       ( Ref Nothing ( Local ( Name "f" ) ) )
-                      ( Ref Nothing ( Local ( Name "$cse270" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                     ]
                   )
                 )
@@ -202,36 +202,36 @@ UberModule
         ( Imported ( ModuleName "Golden.DerivedFunctor.Test" ) ( Name "Leaf" ) )
       ),
       ( Name "Node", AbsN Nothing
-        ( ParamNamed Nothing ( Name "Node$p1$211" ) :| [] )
+        ( ParamNamed Nothing ( Name "Node$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "Node$p2$212" ) :| [] )
+          ( ParamNamed Nothing ( Name "Node$p2$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "Node$p3$213" ) :| [] )
+            ( ParamNamed Nothing ( Name "Node$p3$0" ) :| [] )
             ( Ctor Nothing SumType
               ( ModuleName "Golden.DerivedFunctor.Test" )
               ( TyName "Tree" )
               ( CtorName "Node" )
               [ Ref Nothing
-                ( Local ( Name "Node$p1$211" ) ), Ref Nothing
-                ( Local ( Name "Node$p2$212" ) ), Ref Nothing
-                ( Local ( Name "Node$p3$213" ) )
+                ( Local ( Name "Node$p1$0" ) ), Ref Nothing
+                ( Local ( Name "Node$p2$0" ) ), Ref Nothing
+                ( Local ( Name "Node$p3$0" ) )
               ]
             )
           )
         )
       ),
       ( Name "fromRight", AbsN Nothing
-        ( ParamNamed Nothing ( Name "fromRight$p1$209" ) :| [] )
+        ( ParamNamed Nothing ( Name "fromRight$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "fromRight$p2$210" ) :| [] )
+          ( ParamNamed Nothing ( Name "fromRight$p2$0" ) :| [] )
           ( IfThenElse Nothing
             ( Eq Nothing
               ( LiteralString Nothing "Golden.DerivedFunctor.Test∷Either.Left" )
-              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "fromRight$p2$210" ) ) ) )
+              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "fromRight$p2$0" ) ) ) )
             )
-            ( Ref Nothing ( Local ( Name "fromRight$p1$209" ) ) )
+            ( Ref Nothing ( Local ( Name "fromRight$p1$0" ) ) )
             ( DataArgumentByIndex Nothing SumType 0
-              ( Ref Nothing ( Local ( Name "fromRight$p2$210" ) ) )
+              ( Ref Nothing ( Local ( Name "fromRight$p2$0" ) ) )
             )
           )
         )
@@ -287,9 +287,9 @@ UberModule
                         ( PropName "map" )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v1$2" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                         ( PrimBinOp Nothing PrimMul
-                          ( Ref Nothing ( Local ( Name "v1$2" ) ) )
+                          ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                           ( LiteralInt Nothing 2 )
                         ) :| []
                       )

--- a/test/ps/output/Golden.DirectiveAccessor.Test/golden.ir
+++ b/test/ps/output/Golden.DirectiveAccessor.Test/golden.ir
@@ -196,7 +196,7 @@ UberModule
         ( ParamUnused Nothing :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse347", ObjectProp Nothing
+            ( Nothing, Name "$cse0", ObjectProp Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Golden.DirectiveAccessor.Test" ) ( Name "ops" ) )
               )
@@ -212,7 +212,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                     ( AppN Nothing
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "$cse347" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( LiteralInt Nothing 6 :| [] )
                       )
                       ( LiteralInt Nothing 7 :| [] ) :| []
@@ -231,7 +231,7 @@ UberModule
                       )
                       ( AppN Nothing
                         ( AppN Nothing
-                          ( Ref Nothing ( Local ( Name "$cse347" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           ( LiteralInt Nothing 2 :| [] )
                         )
                         ( LiteralInt Nothing 3 :| [] ) :| []

--- a/test/ps/output/Golden.DirectiveDerived.Test/golden.ir
+++ b/test/ps/output/Golden.DirectiveDerived.Test/golden.ir
@@ -209,7 +209,7 @@ UberModule
         ( Imported ( ModuleName "Golden.DirectiveDerived.Test" ) ( Name "combine" ) )
       ),
       ( Name "onePlusTwo", AbsN Nothing
-        ( ParamNamed Nothing ( Name "c$376" ) :| [] )
+        ( ParamNamed Nothing ( Name "c$0" ) :| [] )
         ( PrimBinOp Nothing PrimSub
           ( PrimBinOp Nothing PrimSub
             ( PrimBinOp Nothing PrimSub
@@ -252,7 +252,7 @@ UberModule
                                                                                       ( PrimBinOp Nothing PrimSub
                                                                                         ( Ref Nothing
                                                                                           ( Local
-                                                                                            ( Name "c$376" )
+                                                                                            ( Name "c$0" )
                                                                                           )
                                                                                         )
                                                                                         ( LiteralInt Nothing 1 )

--- a/test/ps/output/Golden.DirectivePack.Test/golden.ir
+++ b/test/ps/output/Golden.DirectivePack.Test/golden.ir
@@ -84,12 +84,12 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "append", AbsN Nothing
-            ( ParamNamed Nothing ( Name "s1$299" ) :| [] )
+            ( ParamNamed Nothing ( Name "s1$0" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "s2$300" ) :| [] )
+              ( ParamNamed Nothing ( Name "s2$0" ) :| [] )
               ( PrimBinOp Nothing PrimConcat
-                ( Ref Nothing ( Local ( Name "s1$299" ) ) )
-                ( Ref Nothing ( Local ( Name "s2$300" ) ) )
+                ( Ref Nothing ( Local ( Name "s1$0" ) ) )
+                ( Ref Nothing ( Local ( Name "s2$0" ) ) )
               )
             )
           )
@@ -169,9 +169,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$512" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$513" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -195,10 +195,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$512" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$513" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -219,7 +219,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$111", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -235,23 +235,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$113" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$114" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$111" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$113" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$115" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$111" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$114" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$116" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -274,8 +274,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$115" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$116" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -383,13 +383,13 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "show", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$501" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "v$7", IfThenElse Nothing
+                ( Nothing, Name "v$0", IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.DirectivePack.Test∷Fruit.Apple" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "x$501" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "x$0" ) ) ) )
                   )
                   ( Ctor Nothing SumType
                     ( ModuleName "Data.Generic.Rep" )
@@ -406,7 +406,7 @@ UberModule
                     ( TyName "Sum" )
                     ( CtorName "Inr" )
                     [ DataArgumentByIndex Nothing SumType 0
-                      ( Ref Nothing ( Local ( Name "x$501" ) ) )
+                      ( Ref Nothing ( Local ( Name "x$0" ) ) )
                     ]
                   )
                 ) :| []
@@ -414,18 +414,18 @@ UberModule
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$7" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
                 )
                 ( LiteralString Nothing "Apple" )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "v1$490", LiteralArray Nothing
+                    ( Nothing, Name "v1$0", LiteralArray Nothing
                       [ AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                         )
                         ( DataArgumentByIndex Nothing SumType 0
-                          ( Ref Nothing ( Local ( Name "v$7" ) ) ) :| []
+                          ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                         )
                       ]
                     ) :| []
@@ -433,7 +433,7 @@ UberModule
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralInt Nothing 0 )
-                      ( ArrayLength Nothing ( Ref Nothing ( Local ( Name "v1$490" ) ) ) )
+                      ( ArrayLength Nothing ( Ref Nothing ( Local ( Name "v1$0" ) ) ) )
                     )
                     ( LiteralString Nothing "Banana" )
                     ( PrimBinOp Nothing PrimConcat
@@ -459,7 +459,7 @@ UberModule
                               )
                               ( LiteralArray Nothing [ LiteralString Nothing "Banana" ] :| [] )
                             )
-                            ( Ref Nothing ( Local ( Name "v1$490" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "v1$0" ) ) :| [] ) :| []
                           )
                         )
                         ( LiteralString Nothing ")" )
@@ -475,9 +475,9 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.DirectivePack.Test", qnameName = Name "pipeline"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$471" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$471" ) ) )
+          ( Ref Nothing ( Local ( Name "x$0" ) ) )
           ( LiteralInt Nothing 1 )
         )
       ), Standalone
@@ -514,7 +514,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.DirectivePack.Test", qnameName = Name "describeFruit"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$338" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( ObjectProp Nothing
@@ -532,7 +532,7 @@ UberModule
                 ( Imported ( ModuleName "Golden.DirectivePack.Test" ) ( Name "showFruit" ) ) :| []
               )
             )
-            ( Ref Nothing ( Local ( Name "x$338" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -557,9 +557,9 @@ UberModule
         { qnameModuleName = ModuleName "Golden.DirectivePack.Test", qnameName = Name "chain"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "a$365", Let Nothing
+          ( Nothing, Name "a$0", Let Nothing
             ( Standalone
-              ( Nothing, Name "a$377", IfThenElse Nothing
+              ( Nothing, Name "a$1", IfThenElse Nothing
                 ( Eq Nothing
                   ( AppN Nothing
                     ( AppN Nothing
@@ -592,7 +592,7 @@ UberModule
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$377" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$1" ) ) ) )
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
@@ -602,7 +602,7 @@ UberModule
                         ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "intMod" ) )
                       )
                       ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "a$377" ) ) ) :| []
+                        ( Ref Nothing ( Local ( Name "a$1" ) ) ) :| []
                       )
                     )
                     ( LiteralInt Nothing 2 :| [] )
@@ -619,7 +619,7 @@ UberModule
                         ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "intDiv" ) )
                       )
                       ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "a$377" ) ) ) :| []
+                        ( Ref Nothing ( Local ( Name "a$1" ) ) ) :| []
                       )
                     )
                     ( LiteralInt Nothing 2 :| [] )
@@ -634,7 +634,7 @@ UberModule
         ( IfThenElse Nothing
           ( Eq Nothing
             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$365" ) ) ) )
+            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "a$0" ) ) ) )
           )
           ( IfThenElse Nothing
             ( Eq Nothing
@@ -644,7 +644,7 @@ UberModule
                     ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "intMod" ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "a$365" ) ) ) :| []
+                    ( Ref Nothing ( Local ( Name "a$0" ) ) ) :| []
                   )
                 )
                 ( LiteralInt Nothing 2 :| [] )
@@ -661,7 +661,7 @@ UberModule
                     ( Imported ( ModuleName "Data.EuclideanRing" ) ( Name "intDiv" ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "a$365" ) ) ) :| []
+                    ( Ref Nothing ( Local ( Name "a$0" ) ) ) :| []
                   )
                 )
                 ( LiteralInt Nothing 2 :| [] )
@@ -806,18 +806,18 @@ UberModule
                         ( PropName "modifyImpl" )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "s$601" ) :| [] )
+                        ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                         ( Let Nothing
                           ( Standalone
-                            ( Nothing, Name "s'$602", PrimBinOp Nothing PrimMul
-                              ( Ref Nothing ( Local ( Name "s$601" ) ) )
+                            ( Nothing, Name "s'$0", PrimBinOp Nothing PrimMul
+                              ( Ref Nothing ( Local ( Name "s$0" ) ) )
                               ( LiteralInt Nothing 3 )
                             ) :| []
                           )
                           ( LiteralObject Nothing
                             [
-                              ( PropName "state", Ref Nothing ( Local ( Name "s'$602" ) ) ),
-                              ( PropName "value", Ref Nothing ( Local ( Name "s'$602" ) ) )
+                              ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                              ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                             ]
                           )
                         ) :| []
@@ -828,7 +828,7 @@ UberModule
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
-              ( Nothing, Name "v0$2", AppN Nothing
+              ( Nothing, Name "v0$0", AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "foreign" ) ) )
@@ -847,7 +847,7 @@ UberModule
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.DirectivePack.Test" ) ( Name "show" ) )
                 )
-                ( Ref Nothing ( Local ( Name "v0$2" ) ) :| [] ) :| []
+                ( Ref Nothing ( Local ( Name "v0$0" ) ) :| [] ) :| []
               )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )

--- a/test/ps/output/Golden.DistributeIntoIf.Test/golden.ir
+++ b/test/ps/output/Golden.DistributeIntoIf.Test/golden.ir
@@ -79,28 +79,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$201" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$202" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$0" ) :| [] )
                 ( PrimBinOp Nothing PrimAnd
-                  ( Ref Nothing ( Local ( Name "b1$201" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$202" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$0" ) ) )
                 )
               )
             ),
             ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$199" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$1" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$200" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$1" ) :| [] )
                 ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$199" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$200" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1" ) ) )
                 )
               )
             ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$198" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$198" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$0" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$0" ) ) ) )
             )
           ]
         ) :| []

--- a/test/ps/output/Golden.FieldCaching.Test/golden.ir
+++ b/test/ps/output/Golden.FieldCaching.Test/golden.ir
@@ -16,7 +16,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.FieldCaching.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
@@ -27,7 +27,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone

--- a/test/ps/output/Golden.FloatIn.Test/golden.ir
+++ b/test/ps/output/Golden.FloatIn.Test/golden.ir
@@ -70,24 +70,24 @@ UberModule
         ( Imported ( ModuleName "Golden.FloatIn.Test" ) ( Name "expensive" ) )
       ),
       ( Name "pick", AbsN Nothing
-        ( ParamNamed Nothing ( Name "pick$p1$206" ) :| [] )
+        ( ParamNamed Nothing ( Name "pick$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "pick$p2$207" ) :| [] )
+          ( ParamNamed Nothing ( Name "pick$p2$0" ) :| [] )
           ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "pick$p1$206" ) ) )
+            ( Ref Nothing ( Local ( Name "pick$p1$0" ) ) )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "shared$227", PrimBinOp Nothing PrimAdd
+                ( Nothing, Name "shared$0", PrimBinOp Nothing PrimAdd
                   ( PrimBinOp Nothing PrimMul
-                    ( Ref Nothing ( Local ( Name "pick$p2$207" ) ) )
-                    ( Ref Nothing ( Local ( Name "pick$p2$207" ) ) )
+                    ( Ref Nothing ( Local ( Name "pick$p2$0" ) ) )
+                    ( Ref Nothing ( Local ( Name "pick$p2$0" ) ) )
                   )
                   ( LiteralInt Nothing 1 )
                 ) :| []
               )
               ( PrimBinOp Nothing PrimAdd
-                ( Ref Nothing ( Local ( Name "shared$227" ) ) )
-                ( Ref Nothing ( Local ( Name "shared$227" ) ) )
+                ( Ref Nothing ( Local ( Name "shared$0" ) ) )
+                ( Ref Nothing ( Local ( Name "shared$0" ) ) )
               )
             )
             ( LiteralInt Nothing 0 )
@@ -95,35 +95,35 @@ UberModule
         )
       ),
       ( Name "pickShared", AbsN Nothing
-        ( ParamNamed Nothing ( Name "pickShared$p1$208" ) :| [] )
+        ( ParamNamed Nothing ( Name "pickShared$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "pickShared$p2$209" ) :| [] )
+          ( ParamNamed Nothing ( Name "pickShared$p2$0" ) :| [] )
           ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "pickShared$p1$208" ) ) )
+            ( Ref Nothing ( Local ( Name "pickShared$p1$0" ) ) )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "shared$237", AppN Nothing
+                ( Nothing, Name "shared$0", AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Golden.FloatIn.Test" ) ( Name "tick" ) ) )
-                  ( Ref Nothing ( Local ( Name "pickShared$p2$209" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "pickShared$p2$0" ) ) :| [] )
                 ) :| []
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "f$238", AbsN Nothing
+                  ( Nothing, Name "f$0", AbsN Nothing
                     ( ParamUnused Nothing :| [] )
                     ( PrimBinOp Nothing PrimAdd
-                      ( Ref Nothing ( Local ( Name "shared$237" ) ) )
-                      ( Ref Nothing ( Local ( Name "shared$237" ) ) )
+                      ( Ref Nothing ( Local ( Name "shared$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "shared$0" ) ) )
                     )
                   ) :| []
                 )
                 ( PrimBinOp Nothing PrimAdd
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "f$238" ) ) )
+                    ( Ref Nothing ( Local ( Name "f$0" ) ) )
                     ( Ref Nothing ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| [] )
                   )
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "f$238" ) ) )
+                    ( Ref Nothing ( Local ( Name "f$0" ) ) )
                     ( Ref Nothing ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| [] )
                   )
                 )
@@ -165,7 +165,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                     ( Let Nothing
                       ( Standalone
-                        ( Nothing, Name "shared$284", AppN Nothing
+                        ( Nothing, Name "shared$0", AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Golden.FloatIn.Test" ) ( Name "tick" ) )
                           )
@@ -174,23 +174,23 @@ UberModule
                       )
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "f$285", AbsN Nothing
+                          ( Nothing, Name "f$0", AbsN Nothing
                             ( ParamUnused Nothing :| [] )
                             ( PrimBinOp Nothing PrimAdd
-                              ( Ref Nothing ( Local ( Name "shared$284" ) ) )
-                              ( Ref Nothing ( Local ( Name "shared$284" ) ) )
+                              ( Ref Nothing ( Local ( Name "shared$0" ) ) )
+                              ( Ref Nothing ( Local ( Name "shared$0" ) ) )
                             )
                           ) :| []
                         )
                         ( PrimBinOp Nothing PrimAdd
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "f$285" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) )
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| []
                             )
                           )
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "f$285" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) )
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| []
                             )

--- a/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
+++ b/test/ps/output/Golden.GenericEqTwoTypes.Test/golden.ir
@@ -66,28 +66,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$210" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$211" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$0" ) :| [] )
                 ( PrimBinOp Nothing PrimAnd
-                  ( Ref Nothing ( Local ( Name "b1$210" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$211" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$0" ) ) )
                 )
               )
             ),
             ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$208" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$1" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$209" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$1" ) :| [] )
                 ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$208" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$209" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1" ) ) )
                 )
               )
             ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$207" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$207" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$0" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$0" ) ) ) )
             )
           ]
         ) :| []
@@ -96,12 +96,12 @@ UberModule
         { qnameModuleName = ModuleName "Data.Eq", qnameName = Name "eqInt" }, LiteralObject Nothing
         [
           ( PropName "eq", AbsN Nothing
-            ( ParamNamed Nothing ( Name "r1$203" ) :| [] )
+            ( ParamNamed Nothing ( Name "r1$0" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "r2$204" ) :| [] )
+              ( ParamNamed Nothing ( Name "r2$0" ) :| [] )
               ( Eq Nothing
-                ( Ref Nothing ( Local ( Name "r1$203" ) ) )
-                ( Ref Nothing ( Local ( Name "r2$204" ) ) )
+                ( Ref Nothing ( Local ( Name "r1$0" ) ) )
+                ( Ref Nothing ( Local ( Name "r2$0" ) ) )
               )
             )
           )
@@ -265,56 +265,56 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.GenericEqTwoTypes.Test", qnameName = Name "genericEqSum"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "dictGenericEq1$5" ) :| [] )
+        ( ParamNamed Nothing ( Name "dictGenericEq1$0" ) :| [] )
         ( LiteralObject Nothing
           [
             ( PropName "genericEq'", AbsN Nothing
-              ( ParamNamed Nothing ( Name "v$7" ) :| [] )
+              ( ParamNamed Nothing ( Name "v$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "v1$8" ) :| [] )
+                ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "$cse1357", ReflectCtor Nothing
-                      ( Ref Nothing ( Local ( Name "v1$8" ) ) )
+                    ( Nothing, Name "$cse0", ReflectCtor Nothing
+                      ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                     ) :| []
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse1356", ReflectCtor Nothing
-                        ( Ref Nothing ( Local ( Name "v$7" ) ) )
+                      ( Nothing, Name "$cse1", ReflectCtor Nothing
+                        ( Ref Nothing ( Local ( Name "v$0" ) ) )
                       ) :| []
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                        ( Ref Nothing ( Local ( Name "$cse1356" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                       )
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inl" )
-                        ( Ref Nothing ( Local ( Name "$cse1357" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                       )
                       ( PrimBinOp Nothing PrimAnd
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                          ( Ref Nothing ( Local ( Name "$cse1356" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                         )
                         ( PrimBinOp Nothing PrimAnd
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Generic.Rep∷Sum.Inr" )
-                            ( Ref Nothing ( Local ( Name "$cse1357" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           )
                           ( AppN Nothing
                             ( AppN Nothing
                               ( ObjectProp Nothing
-                                ( Ref Nothing ( Local ( Name "dictGenericEq1$5" ) ) )
+                                ( Ref Nothing ( Local ( Name "dictGenericEq1$0" ) ) )
                                 ( PropName "genericEq'" )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v$7" ) ) ) :| []
+                                ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                               )
                             )
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$8" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v1$0" ) ) ) :| []
                             )
                           )
                         )
@@ -330,12 +330,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.GenericEqTwoTypes.Test", qnameName = Name "eqRec"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "dictEqRecord$214" ) :| [] )
+        ( ParamNamed Nothing ( Name "dictEqRecord$0" ) :| [] )
         ( LiteralObject Nothing
           [
             ( PropName "eq", AppN Nothing
               ( ObjectProp Nothing
-                ( Ref Nothing ( Local ( Name "dictEqRecord$214" ) ) )
+                ( Ref Nothing ( Local ( Name "dictEqRecord$0" ) ) )
                 ( PropName "eqRecord" )
               )
               ( Ref Nothing ( Imported ( ModuleName "Type.Proxy" ) ( Name "Proxy" ) ) :| [] )
@@ -347,8 +347,8 @@ UberModule
         { qnameModuleName = ModuleName "Golden.GenericEqTwoTypes.Test", qnameName = Name "eqRowCons$w"
         }, AbsN Nothing
         ( ParamNamed Nothing
-          ( Name "eqRowCons$p3$226" ) :|
-          [ ParamNamed Nothing ( Name "eqRowCons$p4$227" ) ]
+          ( Name "eqRowCons$p3$0" ) :|
+          [ ParamNamed Nothing ( Name "eqRowCons$p4$0" ) ]
         )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Data.Eq" ) ( Name "eqRowCons$w" ) ) )
@@ -364,8 +364,8 @@ UberModule
             ] :|
             [ Ref Nothing
               ( Imported ( ModuleName "Prim" ) ( Name "undefined" ) ), Ref Nothing
-              ( Local ( Name "eqRowCons$p3$226" ) ), Ref Nothing
-              ( Local ( Name "eqRowCons$p4$227" ) )
+              ( Local ( Name "eqRowCons$p3$0" ) ), Ref Nothing
+              ( Local ( Name "eqRowCons$p4$0" ) )
             ]
           )
         )
@@ -513,7 +513,7 @@ UberModule
                   ( ParamNamed Nothing ( Name "y" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse1358", ObjectProp Nothing
+                      ( Nothing, Name "$cse0", ObjectProp Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -628,12 +628,12 @@ UberModule
                           )
                         )
                         ( AppN Nothing
-                          ( Ref Nothing ( Local ( Name "$cse1358" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           ( Ref Nothing ( Local ( Name "x" ) ) :| [] ) :| []
                         )
                       )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "$cse1358" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( Ref Nothing ( Local ( Name "y" ) ) :| [] ) :| []
                       )
                     )
@@ -668,7 +668,7 @@ UberModule
                   ( ParamNamed Nothing ( Name "y" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "$cse1359", ObjectProp Nothing
+                      ( Nothing, Name "$cse0", ObjectProp Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Golden.GenericEqTwoTypes.Test" )
@@ -761,12 +761,12 @@ UberModule
                           )
                         )
                         ( AppN Nothing
-                          ( Ref Nothing ( Local ( Name "$cse1359" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                           ( Ref Nothing ( Local ( Name "x" ) ) :| [] ) :| []
                         )
                       )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "$cse1359" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( Ref Nothing ( Local ( Name "y" ) ) :| [] ) :| []
                       )
                     )
@@ -797,17 +797,17 @@ UberModule
         ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Cons" ) )
       ),
       ( Name "cons", AbsN Nothing
-        ( ParamNamed Nothing ( Name "cons$p1$219" ) :| [] )
+        ( ParamNamed Nothing ( Name "cons$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "cons$p2$220" ) :| [] )
+          ( ParamNamed Nothing ( Name "cons$p2$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.GenericEqTwoTypes.Test" )
             ( TyName "List" )
             ( CtorName "Cons" )
             [ LiteralObject Nothing
               [
-                ( PropName "head", Ref Nothing ( Local ( Name "cons$p1$219" ) ) ),
-                ( PropName "tail", Ref Nothing ( Local ( Name "cons$p2$220" ) ) )
+                ( PropName "head", Ref Nothing ( Local ( Name "cons$p1$0" ) ) ),
+                ( PropName "tail", Ref Nothing ( Local ( Name "cons$p2$0" ) ) )
               ]
             ]
           )
@@ -820,20 +820,20 @@ UberModule
         ( Imported ( ModuleName "Golden.GenericEqTwoTypes.Test" ) ( Name "Node" ) )
       ),
       ( Name "node", AbsN Nothing
-        ( ParamNamed Nothing ( Name "node$p1$221" ) :| [] )
+        ( ParamNamed Nothing ( Name "node$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "node$p2$222" ) :| [] )
+          ( ParamNamed Nothing ( Name "node$p2$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "node$p3$223" ) :| [] )
+            ( ParamNamed Nothing ( Name "node$p3$0" ) :| [] )
             ( Ctor Nothing SumType
               ( ModuleName "Golden.GenericEqTwoTypes.Test" )
               ( TyName "Tree" )
               ( CtorName "Node" )
               [ LiteralObject Nothing
                 [
-                  ( PropName "left", Ref Nothing ( Local ( Name "node$p1$221" ) ) ),
-                  ( PropName "value", Ref Nothing ( Local ( Name "node$p2$222" ) ) ),
-                  ( PropName "right", Ref Nothing ( Local ( Name "node$p3$223" ) ) )
+                  ( PropName "left", Ref Nothing ( Local ( Name "node$p1$0" ) ) ),
+                  ( PropName "value", Ref Nothing ( Local ( Name "node$p2$0" ) ) ),
+                  ( PropName "right", Ref Nothing ( Local ( Name "node$p3$0" ) ) )
                 ]
               ]
             )
@@ -844,7 +844,7 @@ UberModule
         ( ParamUnused Nothing :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse1363", Ctor Nothing SumType
+            ( Nothing, Name "$cse0", Ctor Nothing SumType
               ( ModuleName "Golden.GenericEqTwoTypes.Test" )
               ( TyName "List" )
               ( CtorName "Cons" )
@@ -860,7 +860,7 @@ UberModule
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse1362", Ctor Nothing SumType
+              ( Nothing, Name "$cse1", Ctor Nothing SumType
                 ( ModuleName "Golden.GenericEqTwoTypes.Test" )
                 ( TyName "Tree" )
                 ( CtorName "Node" )
@@ -879,21 +879,21 @@ UberModule
             )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse1361", Ctor Nothing SumType
+                ( Nothing, Name "$cse2", Ctor Nothing SumType
                   ( ModuleName "Golden.GenericEqTwoTypes.Test" )
                   ( TyName "List" )
                   ( CtorName "Cons" )
                   [ LiteralObject Nothing
                     [
                       ( PropName "head", LiteralInt Nothing 1 ),
-                      ( PropName "tail", Ref Nothing ( Local ( Name "$cse1363" ) ) )
+                      ( PropName "tail", Ref Nothing ( Local ( Name "$cse0" ) ) )
                     ]
                   ]
                 ) :| []
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "$cse1360", Ctor Nothing SumType
+                  ( Nothing, Name "$cse3", Ctor Nothing SumType
                     ( ModuleName "Golden.GenericEqTwoTypes.Test" )
                     ( TyName "Tree" )
                     ( CtorName "Node" )
@@ -906,7 +906,7 @@ UberModule
                           )
                         ),
                         ( PropName "value", LiteralInt Nothing 1 ),
-                        ( PropName "right", Ref Nothing ( Local ( Name "$cse1362" ) ) )
+                        ( PropName "right", Ref Nothing ( Local ( Name "$cse1" ) ) )
                       ]
                     ]
                   ) :| []
@@ -925,9 +925,9 @@ UberModule
                                   ( Name "eq1" )
                                 )
                               )
-                              ( Ref Nothing ( Local ( Name "$cse1361" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse2" ) ) :| [] )
                             )
-                            ( Ref Nothing ( Local ( Name "$cse1361" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "$cse2" ) ) :| [] )
                           )
                           ( LiteralString Nothing "true" )
                           ( LiteralString Nothing "false" ) :| []
@@ -969,7 +969,7 @@ UberModule
                                   ] :| []
                                 )
                               )
-                              ( Ref Nothing ( Local ( Name "$cse1363" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                             )
                             ( LiteralString Nothing "true" )
                             ( LiteralString Nothing "false" ) :| []
@@ -993,9 +993,9 @@ UberModule
                                     ( Name "eq" )
                                   )
                                 )
-                                ( Ref Nothing ( Local ( Name "$cse1360" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "$cse3" ) ) :| [] )
                               )
-                              ( Ref Nothing ( Local ( Name "$cse1360" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse3" ) ) :| [] )
                             )
                             ( LiteralString Nothing "true" )
                             ( LiteralString Nothing "false" ) :| []
@@ -1042,7 +1042,7 @@ UberModule
                               ] :| []
                             )
                           )
-                          ( Ref Nothing ( Local ( Name "$cse1362" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "$cse1" ) ) :| [] )
                         )
                         ( LiteralString Nothing "true" )
                         ( LiteralString Nothing "false" ) :| []

--- a/test/ps/output/Golden.Issue37.Test/golden.ir
+++ b/test/ps/output/Golden.Issue37.Test/golden.ir
@@ -85,9 +85,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$218" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$219" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -111,10 +111,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$218" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$219" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -135,7 +135,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$11", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -151,23 +151,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$13" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$14" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$11" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$13" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$15" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$11" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$14" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$16" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -190,8 +190,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$15" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$16" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -221,7 +221,7 @@ UberModule
       ( Name "baz", AppN Nothing
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "Bind1$1", AppN Nothing
+            ( Nothing, Name "Bind1$0", AppN Nothing
               ( ObjectProp Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Effect" ) ( Name "monadEffect" ) ) )
                 ( PropName "Bind1" )
@@ -229,7 +229,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "undefined" ) ) :| [] )
             ) :|
             [ Standalone
-              ( Nothing, Name "pure$4", ObjectProp Nothing
+              ( Nothing, Name "pure$0", ObjectProp Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect" ) ( Name "monadEffect" ) ) )
@@ -242,30 +242,30 @@ UberModule
             ]
           )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "f$6" ) :| [] )
+            ( ParamNamed Nothing ( Name "f$0" ) :| [] )
             ( AppN Nothing
               ( AppN Nothing
                 ( ObjectProp Nothing
-                  ( Ref Nothing ( Local ( Name "Bind1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "Bind1$0" ) ) )
                   ( PropName "bind" )
                 )
-                ( Ref Nothing ( Local ( Name "f$6" ) ) :| [] )
+                ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
               )
               ( AbsN Nothing
                 ( ParamUnused Nothing :| [] )
                 ( AppN Nothing
                   ( AppN Nothing
                     ( ObjectProp Nothing
-                      ( Ref Nothing ( Local ( Name "Bind1$1" ) ) )
+                      ( Ref Nothing ( Local ( Name "Bind1$0" ) ) )
                       ( PropName "bind" )
                     )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "pure$4" ) ) )
+                      ( Ref Nothing ( Local ( Name "pure$0" ) ) )
                       ( LiteralArray Nothing
                         [ AppN Nothing
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "Bind1$211", AppN Nothing
+                              ( Nothing, Name "Bind1$1", AppN Nothing
                                 ( ObjectProp Nothing
                                   ( Ref Nothing
                                     ( Imported ( ModuleName "Effect" ) ( Name "monadEffect" ) )
@@ -278,38 +278,38 @@ UberModule
                               ) :| []
                             )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "fn1$213" ) :| [] )
+                              ( ParamNamed Nothing ( Name "fn1$0" ) :| [] )
                               ( AppN Nothing
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
-                                    ( Ref Nothing ( Local ( Name "Bind1$211" ) ) )
+                                    ( Ref Nothing ( Local ( Name "Bind1$1" ) ) )
                                     ( PropName "bind" )
                                   )
-                                  ( Ref Nothing ( Local ( Name "fn1$213" ) ) :| [] )
+                                  ( Ref Nothing ( Local ( Name "fn1$0" ) ) :| [] )
                                 )
                                 ( AbsN Nothing
                                   ( ParamUnused Nothing :| [] )
                                   ( AppN Nothing
                                     ( AppN Nothing
                                       ( ObjectProp Nothing
-                                        ( Ref Nothing ( Local ( Name "Bind1$211" ) ) )
+                                        ( Ref Nothing ( Local ( Name "Bind1$1" ) ) )
                                         ( PropName "bind" )
                                       )
-                                      ( Ref Nothing ( Local ( Name "fn1$213" ) ) :| [] )
+                                      ( Ref Nothing ( Local ( Name "fn1$0" ) ) :| [] )
                                     )
                                     ( AbsN Nothing
                                       ( ParamUnused Nothing :| [] )
                                       ( AppN Nothing
                                         ( AppN Nothing
                                           ( ObjectProp Nothing
-                                            ( Ref Nothing ( Local ( Name "Bind1$211" ) ) )
+                                            ( Ref Nothing ( Local ( Name "Bind1$1" ) ) )
                                             ( PropName "bind" )
                                           )
-                                          ( Ref Nothing ( Local ( Name "fn1$213" ) ) :| [] )
+                                          ( Ref Nothing ( Local ( Name "fn1$0" ) ) :| [] )
                                         )
                                         ( AbsN Nothing
                                           ( ParamUnused Nothing :| [] )
-                                          ( Ref Nothing ( Local ( Name "fn1$213" ) ) ) :| []
+                                          ( Ref Nothing ( Local ( Name "fn1$0" ) ) ) :| []
                                         )
                                       ) :| []
                                     )
@@ -318,7 +318,7 @@ UberModule
                               )
                             )
                           )
-                          ( Ref Nothing ( Local ( Name "f$6" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                         ] :| []
                       ) :| []
                     )
@@ -326,7 +326,7 @@ UberModule
                   ( AbsN Nothing
                     ( ParamUnused Nothing :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "pure$4" ) ) )
+                      ( Ref Nothing ( Local ( Name "pure$0" ) ) )
                       ( Ref Nothing ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| [] )
                     ) :| []
                   )

--- a/test/ps/output/Golden.JoinPoints.Test/golden.ir
+++ b/test/ps/output/Golden.JoinPoints.Test/golden.ir
@@ -28,22 +28,22 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.JoinPoints.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.JoinPoints.Test", qnameName = Name "negate"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$83" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( PrimBinOp Nothing PrimSub
           ( LiteralInt Nothing 0 )
-          ( Ref Nothing ( Local ( Name "a$83" ) ) )
+          ( Ref Nothing ( Local ( Name "a$0" ) ) )
         )
       ), Standalone
       ( QName

--- a/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
+++ b/test/ps/output/Golden.LongCallbackChain.Test/golden.ir
@@ -66,14 +66,14 @@ UberModule
         { qnameModuleName = ModuleName "Golden.LongCallbackChain.Test", qnameName = Name "compute"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "$kont226", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x280$227" ) :| [] )
+          ( Nothing, Name "$kont0", AbsN Nothing
+            ( ParamNamed Nothing ( Name "x280$0" ) :| [] )
             ( AppN Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
               )
               ( Ref Nothing
-                ( Local ( Name "x280$227" ) ) :|
+                ( Local ( Name "x280$0" ) ) :|
                 [ AbsN Nothing
                   ( ParamNamed Nothing ( Name "x281" ) :| [] )
                   ( AppN Nothing
@@ -398,14 +398,14 @@ UberModule
             )
           ) :|
           [ Standalone
-            ( Nothing, Name "$kont228", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x240$229" ) :| [] )
+            ( Nothing, Name "$kont1", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x240$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x240$229" ) ) :|
+                  ( Local ( Name "x240$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x241" ) :| [] )
                     ( AppN Nothing
@@ -970,7 +970,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont226" )
+                                                                                                                                                                                                                                                                    ( Name "$kont0" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -1100,14 +1100,14 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont230", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x200$231" ) :| [] )
+            ( Nothing, Name "$kont2", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x200$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x200$231" ) ) :|
+                  ( Local ( Name "x200$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x201" ) :| [] )
                     ( AppN Nothing
@@ -1672,7 +1672,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont228" )
+                                                                                                                                                                                                                                                                    ( Name "$kont1" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -1802,14 +1802,14 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont232", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x160$233" ) :| [] )
+            ( Nothing, Name "$kont3", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x160$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x160$233" ) ) :|
+                  ( Local ( Name "x160$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x161" ) :| [] )
                     ( AppN Nothing
@@ -2374,7 +2374,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont230" )
+                                                                                                                                                                                                                                                                    ( Name "$kont2" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -2504,14 +2504,14 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont234", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x120$235" ) :| [] )
+            ( Nothing, Name "$kont4", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x120$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x120$235" ) ) :|
+                  ( Local ( Name "x120$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x121" ) :| [] )
                     ( AppN Nothing
@@ -3076,7 +3076,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont232" )
+                                                                                                                                                                                                                                                                    ( Name "$kont3" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -3206,14 +3206,14 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont236", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x80$237" ) :| [] )
+            ( Nothing, Name "$kont5", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x80$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x80$237" ) ) :|
+                  ( Local ( Name "x80$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x81" ) :| [] )
                     ( AppN Nothing
@@ -3774,7 +3774,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont234" )
+                                                                                                                                                                                                                                                                    ( Name "$kont4" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -3904,14 +3904,14 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont238", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x40$239" ) :| [] )
+            ( Nothing, Name "$kont6", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x40$0" ) :| [] )
               ( AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Golden.LongCallbackChain.Test" ) ( Name "withInc$w" ) )
                 )
                 ( Ref Nothing
-                  ( Local ( Name "x40$239" ) ) :|
+                  ( Local ( Name "x40$0" ) ) :|
                   [ AbsN Nothing
                     ( ParamNamed Nothing ( Name "x41" ) :| [] )
                     ( AppN Nothing
@@ -4472,7 +4472,7 @@ UberModule
                                                                                                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                                                                                                   ( Local
-                                                                                                                                                                                                                                                                    ( Name "$kont236" )
+                                                                                                                                                                                                                                                                    ( Name "$kont5" )
                                                                                                                                                                                                                                                                   )
                                                                                                                                                                                                                                                                 )
                                                                                                                                                                                                                                                                 ( Ref Nothing
@@ -5162,7 +5162,7 @@ UberModule
                                                                                                                                                                                                                                                         ( AppN Nothing
                                                                                                                                                                                                                                                           ( Ref Nothing
                                                                                                                                                                                                                                                             ( Local
-                                                                                                                                                                                                                                                              ( Name "$kont238" )
+                                                                                                                                                                                                                                                              ( Name "$kont6" )
                                                                                                                                                                                                                                                             )
                                                                                                                                                                                                                                                           )
                                                                                                                                                                                                                                                           ( Ref Nothing

--- a/test/ps/output/Golden.LongEitherBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongEitherBind.Test/golden.ir
@@ -28,7 +28,7 @@ UberModule
       ),
       ( Name "main", Let Nothing
         ( Standalone
-          ( Nothing, Name "$cse2753", DataArgumentByIndex Nothing SumType 0
+          ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
             ( Ref Nothing
               ( Imported ( ModuleName "Golden.LongEitherBind.Test" ) ( Name "compute" ) )
             )
@@ -56,7 +56,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showStringImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse2753" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )
@@ -69,7 +69,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showIntImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse2753" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )

--- a/test/ps/output/Golden.LongExceptBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongExceptBind.Test/golden.ir
@@ -32,12 +32,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "map", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "f$529" ) :| [] )
+                  ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "m$530" ) :| [] )
+                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$529" ) ) )
-                      ( Ref Nothing ( Local ( Name "m$530" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "m$0" ) ) :| [] )
                     )
                   )
                 )
@@ -51,8 +51,8 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "pure", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$531" ) :| [] )
-            ( Ref Nothing ( Local ( Name "x$531" ) ) )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+            ( Ref Nothing ( Local ( Name "x$0" ) ) )
           ),
           ( PropName "Apply0", AbsN Nothing
             ( ParamUnused Nothing :| [] )
@@ -75,12 +75,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "bind", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "v$84" ) :| [] )
+                  ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$85" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$85" ) ) )
-                      ( Ref Nothing ( Local ( Name "v$84" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                     )
                   )
                 ),
@@ -154,17 +154,17 @@ UberModule
                         ( Ref Nothing ( Local ( Name "v" ) ) :| [] )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v2$534" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v2$0" ) :| [] )
                         ( Let Nothing
                           ( Standalone
-                            ( Nothing, Name "$cse1412", DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v2$534" ) ) )
+                            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
+                              ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                             ) :| []
                           )
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Either∷Either.Left" )
-                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$534" ) ) ) )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
                             )
                             ( AppN Nothing
                               ( ObjectProp Nothing
@@ -183,12 +183,12 @@ UberModule
                                 ( ModuleName "Data.Either" )
                                 ( TyName "Either" )
                                 ( CtorName "Left" )
-                                [ Ref Nothing ( Local ( Name "$cse1412" ) ) ] :| []
+                                [ Ref Nothing ( Local ( Name "$cse0" ) ) ] :| []
                               )
                             )
                             ( AppN Nothing
                               ( Ref Nothing ( Local ( Name "k" ) ) )
-                              ( Ref Nothing ( Local ( Name "$cse1412" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                             )
                           )
                         ) :| []
@@ -219,7 +219,7 @@ UberModule
               [
                 ( PropName "apply", Let Nothing
                   ( Standalone
-                    ( Nothing, Name "dictMonad$538", AppN Nothing
+                    ( Nothing, Name "dictMonad$0", AppN Nothing
                       ( Ref Nothing
                         ( Imported
                           ( ModuleName "Control.Monad.Except.Trans" )
@@ -231,10 +231,10 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$539", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
-                            ( Ref Nothing ( Local ( Name "dictMonad$538" ) ) )
+                            ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                             ( PropName "Bind1" )
                           )
                           ( Ref Nothing
@@ -245,28 +245,28 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$540" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$541" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$539" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$540" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$542" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$539" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$541" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$543" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
                                       ( ObjectProp Nothing
-                                        ( Ref Nothing ( Local ( Name "dictMonad$538" ) ) )
+                                        ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                                         ( PropName "Applicative0" )
                                       )
                                       ( Ref Nothing
@@ -279,8 +279,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$542" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$543" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -296,9 +296,9 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "map", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "f$526" ) :| [] )
+                        ( ParamNamed Nothing ( Name "f$1" ) :| [] )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$528" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                           ( AppN Nothing
                             ( AppN Nothing
                               ( ObjectProp Nothing
@@ -336,40 +336,40 @@ UberModule
                                 ( PropName "map" )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "m$536" ) :| [] )
+                                ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "$cse1413", DataArgumentByIndex Nothing SumType 0
-                                      ( Ref Nothing ( Local ( Name "m$536" ) ) )
+                                    ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
+                                      ( Ref Nothing ( Local ( Name "m$0" ) ) )
                                     ) :| []
                                   )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Either∷Either.Left" )
                                       ( ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "m$536" ) ) )
+                                        ( Ref Nothing ( Local ( Name "m$0" ) ) )
                                       )
                                     )
                                     ( Ctor Nothing SumType
                                       ( ModuleName "Data.Either" )
                                       ( TyName "Either" )
                                       ( CtorName "Left" )
-                                      [ Ref Nothing ( Local ( Name "$cse1413" ) ) ]
+                                      [ Ref Nothing ( Local ( Name "$cse0" ) ) ]
                                     )
                                     ( Ctor Nothing SumType
                                       ( ModuleName "Data.Either" )
                                       ( TyName "Either" )
                                       ( CtorName "Right" )
                                       [ AppN Nothing
-                                        ( Ref Nothing ( Local ( Name "f$526" ) ) )
-                                        ( Ref Nothing ( Local ( Name "$cse1413" ) ) :| [] )
+                                        ( Ref Nothing ( Local ( Name "f$1" ) ) )
+                                        ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                                       ]
                                     )
                                   )
                                 ) :| []
                               )
                             )
-                            ( Ref Nothing ( Local ( Name "v$528" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                           )
                         )
                       )
@@ -386,7 +386,7 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$1195" ) :| [] )
+                  ( ParamNamed Nothing ( Name "x$0" ) :| [] )
                   ( AppN Nothing
                     ( ObjectProp Nothing
                       ( AppN Nothing
@@ -404,7 +404,7 @@ UberModule
                       ( ModuleName "Data.Either" )
                       ( TyName "Either" )
                       ( CtorName "Right" )
-                      [ Ref Nothing ( Local ( Name "x$1195" ) ) ] :| []
+                      [ Ref Nothing ( Local ( Name "x$0" ) ) ] :| []
                     )
                   )
                 ),
@@ -440,11 +440,8 @@ UberModule
         { qnameModuleName = ModuleName "Golden.LongExceptBind.Test", qnameName = Name "go"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "$kont1415$w", AbsN Nothing
-            ( ParamNamed Nothing
-              ( Name "x1$1416" ) :|
-              [ ParamNamed Nothing ( Name "x160$1417" ) ]
-            )
+          ( Nothing, Name "$kont0$w", AbsN Nothing
+            ( ParamNamed Nothing ( Name "x1$0" ) :| [ ParamNamed Nothing ( Name "x160$0" ) ] )
             ( AppN Nothing
               ( AppN Nothing
                 ( Ref Nothing
@@ -455,7 +452,7 @@ UberModule
                   ( TyName "Either" )
                   ( CtorName "Right" )
                   [ PrimBinOp Nothing PrimAdd
-                    ( Ref Nothing ( Local ( Name "x160$1417" ) ) )
+                    ( Ref Nothing ( Local ( Name "x160$0" ) ) )
                     ( LiteralInt Nothing 1 )
                   ] :| []
                 )
@@ -1429,7 +1426,7 @@ UberModule
                                                                                                                                                                               ( PrimBinOp Nothing PrimAdd
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$1416" )
+                                                                                                                                                                                    ( Name "x1$0" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
@@ -1521,11 +1518,8 @@ UberModule
             )
           ) :|
           [ Standalone
-            ( Nothing, Name "$kont1418$w", AbsN Nothing
-              ( ParamNamed Nothing
-                ( Name "x1$1419" ) :|
-                [ ParamNamed Nothing ( Name "x120$1420" ) ]
-              )
+            ( Nothing, Name "$kont1$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$1" ) :| [ ParamNamed Nothing ( Name "x120$0" ) ] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing
@@ -1536,7 +1530,7 @@ UberModule
                     ( TyName "Either" )
                     ( CtorName "Right" )
                     [ PrimBinOp Nothing PrimAdd
-                      ( Ref Nothing ( Local ( Name "x120$1420" ) ) )
+                      ( Ref Nothing ( Local ( Name "x120$0" ) ) )
                       ( LiteralInt Nothing 1 )
                     ] :| []
                   )
@@ -2494,12 +2488,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont1415$w" )
+                                                                                                                                                                                    ( Name "$kont0$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$1419" )
+                                                                                                                                                                                    ( Name "x1$1" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
@@ -2589,11 +2583,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont1421$w", AbsN Nothing
-              ( ParamNamed Nothing
-                ( Name "x1$1422" ) :|
-                [ ParamNamed Nothing ( Name "x80$1423" ) ]
-              )
+            ( Nothing, Name "$kont2$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$2" ) :| [ ParamNamed Nothing ( Name "x80$0" ) ] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing
@@ -2604,7 +2595,7 @@ UberModule
                     ( TyName "Either" )
                     ( CtorName "Right" )
                     [ PrimBinOp Nothing PrimAdd
-                      ( Ref Nothing ( Local ( Name "x80$1423" ) ) )
+                      ( Ref Nothing ( Local ( Name "x80$0" ) ) )
                       ( LiteralInt Nothing 1 )
                     ] :| []
                   )
@@ -3560,12 +3551,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont1418$w" )
+                                                                                                                                                                                    ( Name "$kont1$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$1422" )
+                                                                                                                                                                                    ( Name "x1$2" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
@@ -3655,11 +3646,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont1424$w", AbsN Nothing
-              ( ParamNamed Nothing
-                ( Name "x1$1425" ) :|
-                [ ParamNamed Nothing ( Name "x40$1426" ) ]
-              )
+            ( Nothing, Name "$kont3$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$3" ) :| [ ParamNamed Nothing ( Name "x40$0" ) ] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing
@@ -3670,7 +3658,7 @@ UberModule
                     ( TyName "Either" )
                     ( CtorName "Right" )
                     [ PrimBinOp Nothing PrimAdd
-                      ( Ref Nothing ( Local ( Name "x40$1426" ) ) )
+                      ( Ref Nothing ( Local ( Name "x40$0" ) ) )
                       ( LiteralInt Nothing 1 )
                     ] :| []
                   )
@@ -4626,12 +4614,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont1421$w" )
+                                                                                                                                                                                    ( Name "$kont2$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$1425" )
+                                                                                                                                                                                    ( Name "x1$3" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
@@ -5675,7 +5663,7 @@ UberModule
                                                                                                                                                                         ( AppN Nothing
                                                                                                                                                                           ( Ref Nothing
                                                                                                                                                                             ( Local
-                                                                                                                                                                              ( Name "$kont1424$w" )
+                                                                                                                                                                              ( Name "$kont3$w" )
                                                                                                                                                                             )
                                                                                                                                                                           )
                                                                                                                                                                           ( Ref Nothing
@@ -5780,7 +5768,7 @@ UberModule
       ),
       ( Name "main", Let Nothing
         ( Standalone
-          ( Nothing, Name "$cse1414", DataArgumentByIndex Nothing SumType 0
+          ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
             ( Ref Nothing ( Imported ( ModuleName "Golden.LongExceptBind.Test" ) ( Name "go" ) ) )
           ) :| []
         )
@@ -5806,7 +5794,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showStringImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse1414" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )
@@ -5819,7 +5807,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showIntImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse1414" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )

--- a/test/ps/output/Golden.LongReaderBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongReaderBind.Test/golden.ir
@@ -16,13 +16,13 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongReaderBind.Test", qnameName = Name "go"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "r$995" ) :| [] )
+        ( ParamNamed Nothing ( Name "r$0" ) :| [] )
         ( PrimBinOp Nothing PrimAdd
           ( PrimBinOp Nothing PrimAdd
-            ( Ref Nothing ( Local ( Name "r$995" ) ) )
-            ( Ref Nothing ( Local ( Name "r$995" ) ) )
+            ( Ref Nothing ( Local ( Name "r$0" ) ) )
+            ( Ref Nothing ( Local ( Name "r$0" ) ) )
           )
-          ( Ref Nothing ( Local ( Name "r$995" ) ) )
+          ( Ref Nothing ( Local ( Name "r$0" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =

--- a/test/ps/output/Golden.LongStackBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongStackBind.Test/golden.ir
@@ -140,7 +140,7 @@ UberModule
             ( PropName "map", AbsN Nothing
               ( ParamNamed Nothing ( Name "f" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "v$567" ) :| [] )
+                ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                 ( AppN Nothing
                   ( AppN Nothing
                     ( ObjectProp Nothing
@@ -148,23 +148,23 @@ UberModule
                       ( PropName "map" )
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "m$577" ) :| [] )
+                      ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "$cse3017", DataArgumentByIndex Nothing SumType 0
-                            ( Ref Nothing ( Local ( Name "m$577" ) ) )
+                          ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
+                            ( Ref Nothing ( Local ( Name "m$0" ) ) )
                           ) :| []
                         )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Either∷Either.Left" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "m$577" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "m$0" ) ) ) )
                           )
                           ( Ctor Nothing SumType
                             ( ModuleName "Data.Either" )
                             ( TyName "Either" )
                             ( CtorName "Left" )
-                            [ Ref Nothing ( Local ( Name "$cse3017" ) ) ]
+                            [ Ref Nothing ( Local ( Name "$cse0" ) ) ]
                           )
                           ( Ctor Nothing SumType
                             ( ModuleName "Data.Either" )
@@ -172,14 +172,14 @@ UberModule
                             ( CtorName "Right" )
                             [ AppN Nothing
                               ( Ref Nothing ( Local ( Name "f" ) ) )
-                              ( Ref Nothing ( Local ( Name "$cse3017" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                             ]
                           )
                         )
                       ) :| []
                     )
                   )
-                  ( Ref Nothing ( Local ( Name "v$567" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                 )
               )
             )
@@ -245,17 +245,17 @@ UberModule
                         ( Ref Nothing ( Local ( Name "v" ) ) :| [] )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v2$575" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v2$0" ) :| [] )
                         ( Let Nothing
                           ( Standalone
-                            ( Nothing, Name "$cse3018", DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v2$575" ) ) )
+                            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
+                              ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                             ) :| []
                           )
                           ( IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Either∷Either.Left" )
-                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$575" ) ) ) )
+                              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
                             )
                             ( AppN Nothing
                               ( ObjectProp Nothing
@@ -274,12 +274,12 @@ UberModule
                                 ( ModuleName "Data.Either" )
                                 ( TyName "Either" )
                                 ( CtorName "Left" )
-                                [ Ref Nothing ( Local ( Name "$cse3018" ) ) ] :| []
+                                [ Ref Nothing ( Local ( Name "$cse0" ) ) ] :| []
                               )
                             )
                             ( AppN Nothing
                               ( Ref Nothing ( Local ( Name "k" ) ) )
-                              ( Ref Nothing ( Local ( Name "$cse3018" ) ) :| [] )
+                              ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                             )
                           )
                         ) :| []
@@ -366,7 +366,7 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$2815" ) :| [] )
+                  ( ParamNamed Nothing ( Name "x$0" ) :| [] )
                   ( AppN Nothing
                     ( ObjectProp Nothing
                       ( AppN Nothing
@@ -384,7 +384,7 @@ UberModule
                       ( ModuleName "Data.Either" )
                       ( TyName "Either" )
                       ( CtorName "Right" )
-                      [ Ref Nothing ( Local ( Name "x$2815" ) ) ] :| []
+                      [ Ref Nothing ( Local ( Name "x$0" ) ) ] :| []
                     )
                   )
                 ),
@@ -518,11 +518,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "map", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "f$562" ) :| [] )
+                        ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$563" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "s$564" ) :| [] )
+                            ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
                                 ( ObjectProp Nothing
@@ -560,26 +560,26 @@ UberModule
                                   ( PropName "map" )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "v1$565" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                                   ( AppN Nothing
                                     ( Ref Nothing
                                       ( Imported ( ModuleName "Data.Tuple" ) ( Name "Tuple$w" ) )
                                     )
                                     ( AppN Nothing
-                                      ( Ref Nothing ( Local ( Name "f$562" ) ) )
+                                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
                                       ( DataArgumentByIndex Nothing ProductType 0
-                                        ( Ref Nothing ( Local ( Name "v1$565" ) ) ) :| []
+                                        ( Ref Nothing ( Local ( Name "v1$0" ) ) ) :| []
                                       ) :|
                                       [ DataArgumentByIndex Nothing ProductType 1
-                                        ( Ref Nothing ( Local ( Name "v1$565" ) ) )
+                                        ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                                       ]
                                     )
                                   ) :| []
                                 )
                               )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "v$563" ) ) )
-                                ( Ref Nothing ( Local ( Name "s$564" ) ) :| [] ) :| []
+                                ( Ref Nothing ( Local ( Name "v$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] ) :| []
                               )
                             )
                           )
@@ -653,8 +653,8 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "pure", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "x$571" ) :| [] )
-                    ( Ref Nothing ( Local ( Name "x$571" ) ) )
+                    ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                    ( Ref Nothing ( Local ( Name "x$0" ) ) )
                   ),
                   ( PropName "Apply0", AbsN Nothing
                     ( ParamUnused Nothing :| [] )
@@ -670,12 +670,12 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "bind", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "v$569" ) :| [] )
+                    ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$570" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "f$570" ) ) )
-                        ( Ref Nothing ( Local ( Name "v$569" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                        ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                       )
                     )
                   ),
@@ -704,7 +704,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStackBind.Test", qnameName = Name "get"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$2732" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( AppN Nothing
@@ -722,10 +722,7 @@ UberModule
             ( ModuleName "Data.Tuple" )
             ( TyName "Tuple" )
             ( CtorName "Tuple" )
-            [ Ref Nothing
-              ( Local ( Name "x$2732" ) ), Ref Nothing
-              ( Local ( Name "x$2732" ) )
-            ] :| []
+            [ Ref Nothing ( Local ( Name "x$0" ) ), Ref Nothing ( Local ( Name "x$0" ) ) ] :| []
           )
         )
       ), Standalone
@@ -733,8 +730,8 @@ UberModule
         { qnameModuleName = ModuleName "Golden.LongStackBind.Test", qnameName = Name "go"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "$kont3020", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x1$3021" ) :| [] )
+          ( Nothing, Name "$kont0", AbsN Nothing
+            ( ParamNamed Nothing ( Name "x1$0" ) :| [] )
             ( AppN Nothing
               ( AppN Nothing
                 ( ObjectProp Nothing
@@ -1516,7 +1513,7 @@ UberModule
                                                                                                   ( PrimBinOp Nothing PrimAdd
                                                                                                     ( Ref Nothing
                                                                                                       ( Local
-                                                                                                        ( Name "x1$3021" )
+                                                                                                        ( Name "x1$0" )
                                                                                                       )
                                                                                                     )
                                                                                                     ( Ref Nothing
@@ -1570,8 +1567,8 @@ UberModule
             )
           ) :|
           [ Standalone
-            ( Nothing, Name "$kont3022", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3023" ) :| [] )
+            ( Nothing, Name "$kont1", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$1" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -3096,12 +3093,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3020" )
+                                                                                                                                                                                    ( Name "$kont0" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3023" )
+                                                                                                                                                                                    ( Name "x1$1" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -3186,8 +3183,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont3024", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3025" ) :| [] )
+            ( Nothing, Name "$kont2", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$2" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -4712,12 +4709,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3022" )
+                                                                                                                                                                                    ( Name "$kont1" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3025" )
+                                                                                                                                                                                    ( Name "x1$2" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -4802,8 +4799,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont3026", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3027" ) :| [] )
+            ( Nothing, Name "$kont3", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$3" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -6328,12 +6325,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3024" )
+                                                                                                                                                                                    ( Name "$kont2" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3027" )
+                                                                                                                                                                                    ( Name "x1$3" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -6418,8 +6415,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont3028", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3029" ) :| [] )
+            ( Nothing, Name "$kont4", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$4" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -7944,12 +7941,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3026" )
+                                                                                                                                                                                    ( Name "$kont3" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3029" )
+                                                                                                                                                                                    ( Name "x1$4" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -8034,8 +8031,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont3030", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3031" ) :| [] )
+            ( Nothing, Name "$kont5", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$5" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -9560,12 +9557,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3028" )
+                                                                                                                                                                                    ( Name "$kont4" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3031" )
+                                                                                                                                                                                    ( Name "x1$5" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -9650,8 +9647,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont3032", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$3033" ) :| [] )
+            ( Nothing, Name "$kont6", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$6" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -11176,12 +11173,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont3030" )
+                                                                                                                                                                                    ( Name "$kont5" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$3033" )
+                                                                                                                                                                                    ( Name "x1$6" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -12777,7 +12774,7 @@ UberModule
                                                                                                                                                                         ( AppN Nothing
                                                                                                                                                                           ( Ref Nothing
                                                                                                                                                                             ( Local
-                                                                                                                                                                              ( Name "$kont3032" )
+                                                                                                                                                                              ( Name "$kont6" )
                                                                                                                                                                             )
                                                                                                                                                                           )
                                                                                                                                                                           ( Ref Nothing
@@ -12871,7 +12868,7 @@ UberModule
         { qnameModuleName = ModuleName "Golden.LongStackBind.Test", qnameName = Name "compute"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "v$603", AppN Nothing
+          ( Nothing, Name "v$0", AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Golden.LongStackBind.Test" ) ( Name "go" ) ) )
             ( LiteralInt Nothing 0 :| [] )
           ) :| []
@@ -12879,20 +12876,20 @@ UberModule
         ( IfThenElse Nothing
           ( Eq Nothing
             ( LiteralString Nothing "Data.Either∷Either.Left" )
-            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$603" ) ) ) )
+            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
           )
           ( Ctor Nothing SumType
             ( ModuleName "Data.Either" )
             ( TyName "Either" )
             ( CtorName "Left" )
-            [ DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$603" ) ) ) ]
+            [ DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$0" ) ) ) ]
           )
           ( Ctor Nothing SumType
             ( ModuleName "Data.Either" )
             ( TyName "Either" )
             ( CtorName "Right" )
             [ DataArgumentByIndex Nothing ProductType 0
-              ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$603" ) ) ) )
+              ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
             ]
           )
         )
@@ -12907,7 +12904,7 @@ UberModule
       ),
       ( Name "main", Let Nothing
         ( Standalone
-          ( Nothing, Name "$cse3019", DataArgumentByIndex Nothing SumType 0
+          ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
             ( Ref Nothing
               ( Imported ( ModuleName "Golden.LongStackBind.Test" ) ( Name "compute" ) )
             )
@@ -12935,7 +12932,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showStringImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse3019" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )
@@ -12948,7 +12945,7 @@ UberModule
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
                     ( PropName "showIntImpl" )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse3019" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                 )
                 ( LiteralString Nothing ")" )
               )

--- a/test/ps/output/Golden.LongStateBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongStateBind.Test/golden.ir
@@ -44,12 +44,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "map", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "f$511" ) :| [] )
+                  ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "m$512" ) :| [] )
+                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$511" ) ) )
-                      ( Ref Nothing ( Local ( Name "m$512" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "m$0" ) ) :| [] )
                     )
                   )
                 )
@@ -67,8 +67,8 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "pure", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$513" ) :| [] )
-                  ( Ref Nothing ( Local ( Name "x$513" ) ) )
+                  ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                  ( Ref Nothing ( Local ( Name "x$0" ) ) )
                 ),
                 ( PropName "Apply0", AbsN Nothing
                   ( ParamUnused Nothing :| [] )
@@ -84,12 +84,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "bind", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "v$75" ) :| [] )
+                  ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$76" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$76" ) ) )
-                      ( Ref Nothing ( Local ( Name "v$75" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                     )
                   )
                 ),
@@ -205,7 +205,7 @@ UberModule
               [
                 ( PropName "apply", Let Nothing
                   ( Standalone
-                    ( Nothing, Name "dictMonad$514", AppN Nothing
+                    ( Nothing, Name "dictMonad$0", AppN Nothing
                       ( Ref Nothing
                         ( Imported
                           ( ModuleName "Control.Monad.State.Trans" )
@@ -217,10 +217,10 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$515", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
-                            ( Ref Nothing ( Local ( Name "dictMonad$514" ) ) )
+                            ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                             ( PropName "Bind1" )
                           )
                           ( Ref Nothing
@@ -231,28 +231,28 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$516" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$517" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$515" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$516" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$518" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$515" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$517" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$519" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
                                       ( ObjectProp Nothing
-                                        ( Ref Nothing ( Local ( Name "dictMonad$514" ) ) )
+                                        ( Ref Nothing ( Local ( Name "dictMonad$0" ) ) )
                                         ( PropName "Applicative0" )
                                       )
                                       ( Ref Nothing
@@ -265,8 +265,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$518" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$519" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -282,11 +282,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "map", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "f$507" ) :| [] )
+                        ( ParamNamed Nothing ( Name "f$1" ) :| [] )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v$508" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "s$509" ) :| [] )
+                            ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
                                 ( ObjectProp Nothing
@@ -324,24 +324,24 @@ UberModule
                                   ( PropName "map" )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "v1$510" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "v1$0" ) :| [] )
                                   ( Ctor Nothing ProductType
                                     ( ModuleName "Data.Tuple" )
                                     ( TyName "Tuple" )
                                     ( CtorName "Tuple" )
                                     [ AppN Nothing
-                                      ( Ref Nothing ( Local ( Name "f$507" ) ) )
+                                      ( Ref Nothing ( Local ( Name "f$1" ) ) )
                                       ( DataArgumentByIndex Nothing ProductType 0
-                                        ( Ref Nothing ( Local ( Name "v1$510" ) ) ) :| []
+                                        ( Ref Nothing ( Local ( Name "v1$0" ) ) ) :| []
                                       ), DataArgumentByIndex Nothing ProductType 1
-                                      ( Ref Nothing ( Local ( Name "v1$510" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                                     ]
                                   ) :| []
                                 )
                               )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "v$508" ) ) )
-                                ( Ref Nothing ( Local ( Name "s$509" ) ) :| [] ) :| []
+                                ( Ref Nothing ( Local ( Name "v$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] ) :| []
                               )
                             )
                           )
@@ -413,23 +413,20 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStateBind.Test", qnameName = Name "get"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$2801" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( Ctor Nothing ProductType
           ( ModuleName "Data.Tuple" )
           ( TyName "Tuple" )
           ( CtorName "Tuple" )
-          [ Ref Nothing ( Local ( Name "x$2801" ) ), Ref Nothing ( Local ( Name "x$2801" ) ) ]
+          [ Ref Nothing ( Local ( Name "x$0" ) ), Ref Nothing ( Local ( Name "x$0" ) ) ]
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.LongStateBind.Test", qnameName = Name "go"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "$kont2819$w", AbsN Nothing
-            ( ParamNamed Nothing
-              ( Name "x1$2820" ) :|
-              [ ParamNamed Nothing ( Name "x100$2821" ) ]
-            )
+          ( Nothing, Name "$kont0$w", AbsN Nothing
+            ( ParamNamed Nothing ( Name "x1$0" ) :| [ ParamNamed Nothing ( Name "x100$0" ) ] )
             ( AppN Nothing
               ( AppN Nothing
                 ( ObjectProp Nothing
@@ -996,12 +993,12 @@ UberModule
                                                                                                     ( PrimBinOp Nothing PrimAdd
                                                                                                       ( Ref Nothing
                                                                                                         ( Local
-                                                                                                          ( Name "x1$2820" )
+                                                                                                          ( Name "x1$0" )
                                                                                                         )
                                                                                                       )
                                                                                                       ( Ref Nothing
                                                                                                         ( Local
-                                                                                                          ( Name "x100$2821" )
+                                                                                                          ( Name "x100$0" )
                                                                                                         )
                                                                                                       )
                                                                                                     )
@@ -1056,11 +1053,8 @@ UberModule
             )
           ) :|
           [ Standalone
-            ( Nothing, Name "$kont2822$w", AbsN Nothing
-              ( ParamNamed Nothing
-                ( Name "x1$2823" ) :|
-                [ ParamNamed Nothing ( Name "x100$2824" ) ]
-              )
+            ( Nothing, Name "$kont1$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$1" ) :| [ ParamNamed Nothing ( Name "x100$1" ) ] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -2148,16 +2142,16 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2819$w" )
+                                                                                                                                                                                    ( Name "$kont0$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2823" )
+                                                                                                                                                                                    ( Name "x1$1" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
-                                                                                                                                                                                      ( Name "x100$2824" )
+                                                                                                                                                                                      ( Name "x100$1" )
                                                                                                                                                                                     )
                                                                                                                                                                                   ]
                                                                                                                                                                                 )
@@ -2243,11 +2237,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont2825$w", AbsN Nothing
-              ( ParamNamed Nothing
-                ( Name "x1$2826" ) :|
-                [ ParamNamed Nothing ( Name "x100$2827" ) ]
-              )
+            ( Nothing, Name "$kont2$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$2" ) :| [ ParamNamed Nothing ( Name "x100$2" ) ] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -3335,16 +3326,16 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2822$w" )
+                                                                                                                                                                                    ( Name "$kont1$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2826" )
+                                                                                                                                                                                    ( Name "x1$2" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
-                                                                                                                                                                                      ( Name "x100$2827" )
+                                                                                                                                                                                      ( Name "x100$2" )
                                                                                                                                                                                     )
                                                                                                                                                                                   ]
                                                                                                                                                                                 )
@@ -3430,8 +3421,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont2828", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$2829" ) :| [] )
+            ( Nothing, Name "$kont3", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$3" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -4519,12 +4510,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2825$w" )
+                                                                                                                                                                                    ( Name "$kont2$w" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2829" )
+                                                                                                                                                                                    ( Name "x1$3" )
                                                                                                                                                                                   ) :|
                                                                                                                                                                                   [ Ref Nothing
                                                                                                                                                                                     ( Local
@@ -4614,8 +4605,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont2830", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$2831" ) :| [] )
+            ( Nothing, Name "$kont4", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$4" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -5703,12 +5694,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2828" )
+                                                                                                                                                                                    ( Name "$kont3" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2831" )
+                                                                                                                                                                                    ( Name "x1$4" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -5793,8 +5784,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont2832", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$2833" ) :| [] )
+            ( Nothing, Name "$kont5", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$5" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -6882,12 +6873,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2830" )
+                                                                                                                                                                                    ( Name "$kont4" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2833" )
+                                                                                                                                                                                    ( Name "x1$5" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -6972,8 +6963,8 @@ UberModule
                 )
               )
             ), Standalone
-            ( Nothing, Name "$kont2834", AbsN Nothing
-              ( ParamNamed Nothing ( Name "x1$2835" ) :| [] )
+            ( Nothing, Name "$kont6", AbsN Nothing
+              ( ParamNamed Nothing ( Name "x1$6" ) :| [] )
               ( AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
@@ -8061,12 +8052,12 @@ UberModule
                                                                                                                                                                               ( AppN Nothing
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "$kont2832" )
+                                                                                                                                                                                    ( Name "$kont5" )
                                                                                                                                                                                   )
                                                                                                                                                                                 )
                                                                                                                                                                                 ( Ref Nothing
                                                                                                                                                                                   ( Local
-                                                                                                                                                                                    ( Name "x1$2835" )
+                                                                                                                                                                                    ( Name "x1$6" )
                                                                                                                                                                                   ) :| []
                                                                                                                                                                                 )
                                                                                                                                                                               ) :| []
@@ -9228,7 +9219,7 @@ UberModule
                                                                                                                                                                         ( AppN Nothing
                                                                                                                                                                           ( Ref Nothing
                                                                                                                                                                             ( Local
-                                                                                                                                                                              ( Name "$kont2834" )
+                                                                                                                                                                              ( Name "$kont6" )
                                                                                                                                                                             )
                                                                                                                                                                           )
                                                                                                                                                                           ( Ref Nothing

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.ir
@@ -50,12 +50,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "map", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "f$493" ) :| [] )
+                  ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "m$494" ) :| [] )
+                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
                     ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$493" ) ) )
-                      ( Ref Nothing ( Local ( Name "m$494" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "m$0" ) ) :| [] )
                     )
                   )
                 )
@@ -69,8 +69,8 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "pure", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$495" ) :| [] )
-            ( Ref Nothing ( Local ( Name "x$495" ) ) )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+            ( Ref Nothing ( Local ( Name "x$0" ) ) )
           ),
           ( PropName "Apply0", AbsN Nothing
             ( ParamUnused Nothing :| [] )
@@ -81,13 +81,13 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "discard$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$514" ) :| [ ParamNamed Nothing ( Name "k$515" ) ] )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [ ParamNamed Nothing ( Name "k$0" ) ] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "m$590", AppN Nothing
-              ( Ref Nothing ( Local ( Name "k$515" ) ) )
+            ( Nothing, Name "m$0", AppN Nothing
+              ( Ref Nothing ( Local ( Name "k$0" ) ) )
               ( DataArgumentByIndex Nothing ProductType 0
-                ( Ref Nothing ( Local ( Name "v$514" ) ) ) :| []
+                ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
               )
             ) :| []
           )
@@ -96,18 +96,18 @@ UberModule
             ( TyName "Tuple" )
             ( CtorName "Tuple" )
             [ DataArgumentByIndex Nothing ProductType 0
-              ( Ref Nothing ( Local ( Name "m$590" ) ) ), AppN Nothing
+              ( Ref Nothing ( Local ( Name "m$0" ) ) ), AppN Nothing
               ( AppN Nothing
                 ( ObjectProp Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Data.Semigroup" ) ( Name "foreign" ) ) )
                   ( PropName "concatArray" )
                 )
                 ( DataArgumentByIndex Nothing ProductType 1
-                  ( Ref Nothing ( Local ( Name "v$514" ) ) ) :| []
+                  ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                 )
               )
               ( DataArgumentByIndex Nothing ProductType 1
-                ( Ref Nothing ( Local ( Name "m$590" ) ) ) :| []
+                ( Ref Nothing ( Local ( Name "m$0" ) ) ) :| []
               )
             ]
           )
@@ -116,14 +116,14 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "tell"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$561" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( Ctor Nothing ProductType
           ( ModuleName "Data.Tuple" )
           ( TyName "Tuple" )
           ( CtorName "Tuple" )
           [ Ref Nothing
             ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ), Ref Nothing
-            ( Local ( Name "x$561" ) )
+            ( Local ( Name "x$0" ) )
           ]
         )
       ), Standalone
@@ -131,7 +131,7 @@ UberModule
         { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "go"
         }, Let Nothing
         ( Standalone
-          ( Nothing, Name "$kont15027", AppN Nothing
+          ( Nothing, Name "$kont0", AppN Nothing
             ( Ref Nothing
               ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
             )
@@ -1005,7 +1005,7 @@ UberModule
             )
           ) :|
           [ Standalone
-            ( Nothing, Name "$kont15028", AppN Nothing
+            ( Nothing, Name "$kont1", AppN Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
               )
@@ -1747,7 +1747,7 @@ UberModule
                                                                                                                                                                                                                                                             ( ParamUnused Nothing :| [] )
                                                                                                                                                                                                                                                             ( Ref Nothing
                                                                                                                                                                                                                                                               ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont15027" )
+                                                                                                                                                                                                                                                                ( Name "$kont0" )
                                                                                                                                                                                                                                                               )
                                                                                                                                                                                                                                                             )
                                                                                                                                                                                                                                                           ]
@@ -1870,7 +1870,7 @@ UberModule
                 ]
               )
             ), Standalone
-            ( Nothing, Name "$kont15029", AppN Nothing
+            ( Nothing, Name "$kont2", AppN Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
               )
@@ -2610,7 +2610,7 @@ UberModule
                                                                                                                                                                                                                                                             ( ParamUnused Nothing :| [] )
                                                                                                                                                                                                                                                             ( Ref Nothing
                                                                                                                                                                                                                                                               ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont15028" )
+                                                                                                                                                                                                                                                                ( Name "$kont1" )
                                                                                                                                                                                                                                                               )
                                                                                                                                                                                                                                                             )
                                                                                                                                                                                                                                                           ]
@@ -2733,7 +2733,7 @@ UberModule
                 ]
               )
             ), Standalone
-            ( Nothing, Name "$kont15030", AppN Nothing
+            ( Nothing, Name "$kont3", AppN Nothing
               ( Ref Nothing
                 ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
               )
@@ -3473,7 +3473,7 @@ UberModule
                                                                                                                                                                                                                                                             ( ParamUnused Nothing :| [] )
                                                                                                                                                                                                                                                             ( Ref Nothing
                                                                                                                                                                                                                                                               ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont15029" )
+                                                                                                                                                                                                                                                                ( Name "$kont2" )
                                                                                                                                                                                                                                                               )
                                                                                                                                                                                                                                                             )
                                                                                                                                                                                                                                                           ]
@@ -4335,7 +4335,7 @@ UberModule
                                                                                                                                                                                                                                                         ( ParamUnused Nothing :| [] )
                                                                                                                                                                                                                                                         ( Ref Nothing
                                                                                                                                                                                                                                                           ( Local
-                                                                                                                                                                                                                                                            ( Name "$kont15030" )
+                                                                                                                                                                                                                                                            ( Name "$kont3" )
                                                                                                                                                                                                                                                           )
                                                                                                                                                                                                                                                         )
                                                                                                                                                                                                                                                       ]

--- a/test/ps/output/Golden.Loopification.Test/golden.ir
+++ b/test/ps/output/Golden.Loopification.Test/golden.ir
@@ -16,7 +16,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Loopification.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
@@ -27,7 +27,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), RecursiveGroup
@@ -355,8 +355,8 @@ UberModule
                     )
                     ( LiteralInt Nothing 5 :|
                       [ AbsN Nothing
-                        ( ParamNamed Nothing ( Name "x$218" ) :| [] )
-                        ( Ref Nothing ( Local ( Name "x$218" ) ) )
+                        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+                        ( Ref Nothing ( Local ( Name "x$0" ) ) )
                       ]
                     ) :| []
                   )

--- a/test/ps/output/Golden.MaybeChain.Test/golden.ir
+++ b/test/ps/output/Golden.MaybeChain.Test/golden.ir
@@ -45,9 +45,9 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v2$331", Let Nothing
+                      ( Nothing, Name "v2$0", Let Nothing
                         ( Standalone
-                          ( Nothing, Name "v2$327", IfThenElse Nothing
+                          ( Nothing, Name "v2$1", IfThenElse Nothing
                             ( Eq Nothing
                               ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
                               ( ReflectCtor Nothing
@@ -74,7 +74,7 @@ UberModule
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$327" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1" ) ) ) )
                           )
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) )
@@ -84,7 +84,7 @@ UberModule
                             ( TyName "Maybe" )
                             ( CtorName "Just" )
                             [ DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v2$327" ) ) )
+                              ( Ref Nothing ( Local ( Name "v2$1" ) ) )
                             ]
                           )
                         )
@@ -93,11 +93,11 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$331" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
                       )
                       ( LiteralInt Nothing 0 )
                       ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "v2$331" ) ) )
+                        ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                       )
                     ) :| []
                   ) :| []

--- a/test/ps/output/Golden.MaybeChainModule.Test/golden.ir
+++ b/test/ps/output/Golden.MaybeChainModule.Test/golden.ir
@@ -12,9 +12,9 @@ UberModule
     [
       ( Name "chainedNothing", Let Nothing
         ( Standalone
-          ( Nothing, Name "v2$314", Let Nothing
+          ( Nothing, Name "v2$0", Let Nothing
             ( Standalone
-              ( Nothing, Name "v2$310", IfThenElse Nothing
+              ( Nothing, Name "v2$1", IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
                   ( ReflectCtor Nothing
@@ -35,16 +35,14 @@ UberModule
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$310" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1" ) ) ) )
               )
               ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
               ( Ctor Nothing SumType
                 ( ModuleName "Data.Maybe" )
                 ( TyName "Maybe" )
                 ( CtorName "Just" )
-                [ DataArgumentByIndex Nothing SumType 0
-                  ( Ref Nothing ( Local ( Name "v2$310" ) ) )
-                ]
+                [ DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v2$1" ) ) ) ]
               )
             )
           ) :| []
@@ -52,10 +50,10 @@ UberModule
         ( IfThenElse Nothing
           ( Eq Nothing
             ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$314" ) ) ) )
+            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
           )
           ( LiteralInt Nothing 0 )
-          ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v2$314" ) ) ) )
+          ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
         )
       ),
       ( Name "chainedJust", LiteralInt Nothing 42 )

--- a/test/ps/output/Golden.MixedEffectSTDo.Test/golden.ir
+++ b/test/ps/output/Golden.MixedEffectSTDo.Test/golden.ir
@@ -73,18 +73,18 @@ UberModule
                           ( PropName "modifyImpl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "s$446" ) :| [] )
+                          ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                           ( Let Nothing
                             ( Standalone
-                              ( Nothing, Name "s'$447", PrimBinOp Nothing PrimMul
-                                ( Ref Nothing ( Local ( Name "s$446" ) ) )
+                              ( Nothing, Name "s'$0", PrimBinOp Nothing PrimMul
+                                ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                 ( LiteralInt Nothing 2 )
                               ) :| []
                             )
                             ( LiteralObject Nothing
                               [
-                                ( PropName "state", Ref Nothing ( Local ( Name "s'$447" ) ) ),
-                                ( PropName "value", Ref Nothing ( Local ( Name "s'$447" ) ) )
+                                ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                                ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                               ]
                             )
                           ) :| []

--- a/test/ps/output/Golden.MutualLoopification.Test/golden.ir
+++ b/test/ps/output/Golden.MutualLoopification.Test/golden.ir
@@ -22,11 +22,11 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.MutualLoopification.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$289" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "a$289" ) ) )
+            ( Ref Nothing ( Local ( Name "a$0" ) ) )
             ( LiteralString Nothing "true" )
             ( LiteralString Nothing "false" ) :| []
           )
@@ -35,7 +35,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.MutualLoopification.Test", qnameName = Name "logShow1"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$287" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -43,7 +43,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$287" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), RecursiveGroup

--- a/test/ps/output/Golden.NameShadowing.Test/golden.ir
+++ b/test/ps/output/Golden.NameShadowing.Test/golden.ir
@@ -13,14 +13,14 @@ UberModule
         )
       ),
       ( Name "c", AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$3" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "x1$4" ) :| [] )
+          ( ParamNamed Nothing ( Name "x1$0" ) :| [] )
           ( IfThenElse Nothing
-            ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "x1$4" ) ) ) )
+            ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "x1$0" ) ) ) )
             ( LiteralInt Nothing 1 )
             ( IfThenElse Nothing
-              ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "x$3" ) ) ) )
+              ( Eq Nothing ( LiteralInt Nothing 1 ) ( Ref Nothing ( Local ( Name "x$0" ) ) ) )
               ( LiteralInt Nothing 2 )
               ( LiteralInt Nothing 3 )
             )

--- a/test/ps/output/Golden.NativeLoops.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoops.Test/golden.ir
@@ -143,9 +143,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$241" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$242" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -169,10 +169,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$241" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$242" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -193,7 +193,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$17", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -209,23 +209,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$19" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$20" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$17" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$19" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$21" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$17" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$20" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$22" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -248,8 +248,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$21" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$22" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -283,12 +283,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.NativeLoops.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$12" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "a$12" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       )
@@ -344,7 +344,7 @@ UberModule
                     )
                   )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "n$1" ) :| [] )
+                    ( ParamNamed Nothing ( Name "n$0" ) :| [] )
                     ( AppN Nothing
                       ( AppN Nothing
                         ( ObjectProp Nothing
@@ -366,18 +366,18 @@ UberModule
                             ( Imported ( ModuleName "Effect.Ref" ) ( Name "modifyImpl" ) )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "s$255" ) :| [] )
+                            ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                             ( Let Nothing
                               ( Standalone
-                                ( Nothing, Name "s'$256", PrimBinOp Nothing PrimAdd
-                                  ( Ref Nothing ( Local ( Name "s$255" ) ) )
-                                  ( Ref Nothing ( Local ( Name "n$1" ) ) )
+                                ( Nothing, Name "s'$0", PrimBinOp Nothing PrimAdd
+                                  ( Ref Nothing ( Local ( Name "s$0" ) ) )
+                                  ( Ref Nothing ( Local ( Name "n$0" ) ) )
                                 ) :| []
                               )
                               ( LiteralObject Nothing
                                 [
-                                  ( PropName "state", Ref Nothing ( Local ( Name "s'$256" ) ) ),
-                                  ( PropName "value", Ref Nothing ( Local ( Name "s'$256" ) ) )
+                                  ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                                  ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                                 ]
                               )
                             ) :| []
@@ -390,7 +390,7 @@ UberModule
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
-              ( Nothing, Name "total$3", AppN Nothing
+              ( Nothing, Name "total$0", AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) ) )
                   ( Ref Nothing ( Local ( Name "sum$0" ) ) :| [] )
@@ -402,7 +402,7 @@ UberModule
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-                    ( Ref Nothing ( Local ( Name "total$3" ) ) :| [] ) :| []
+                    ( Ref Nothing ( Local ( Name "total$0" ) ) :| [] ) :| []
                   )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
@@ -414,7 +414,7 @@ UberModule
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
-              ( Nothing, Name "counter$4", AppN Nothing
+              ( Nothing, Name "counter$0", AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "_new" ) ) )
                   ( LiteralInt Nothing 0 :| [] )
@@ -437,16 +437,16 @@ UberModule
                           ( PropName "map" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v0$5" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v0$0" ) :| [] )
                           ( PrimBinOp Nothing PrimLt
-                            ( Ref Nothing ( Local ( Name "v0$5" ) ) )
+                            ( Ref Nothing ( Local ( Name "v0$0" ) ) )
                             ( LiteralInt Nothing 3 )
                           ) :| []
                         )
                       )
                       ( AppN Nothing
                         ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) ) )
-                        ( Ref Nothing ( Local ( Name "counter$4" ) ) :| [] ) :| []
+                        ( Ref Nothing ( Local ( Name "counter$0" ) ) :| [] ) :| []
                       ) :| []
                     )
                   )
@@ -454,12 +454,12 @@ UberModule
                     ( ParamUnused Nothing :| [] )
                     ( Let Nothing
                       ( Standalone
-                        ( Nothing, Name "n0$6", AppN Nothing
+                        ( Nothing, Name "n0$0", AppN Nothing
                           ( AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) )
                             )
-                            ( Ref Nothing ( Local ( Name "counter$4" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "counter$0" ) ) :| [] )
                           )
                           ( Ref Nothing
                             ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| []
@@ -475,7 +475,7 @@ UberModule
                                 ( Ref Nothing
                                   ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                 )
-                                ( Ref Nothing ( Local ( Name "n0$6" ) ) :| [] ) :| []
+                                ( Ref Nothing ( Local ( Name "n0$0" ) ) :| [] ) :| []
                               )
                             )
                             ( Ref Nothing
@@ -506,26 +506,24 @@ UberModule
                                 ( Imported ( ModuleName "Effect.Ref" ) ( Name "modifyImpl" ) )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "s$268" ) :| [] )
+                                ( ParamNamed Nothing ( Name "s$1" ) :| [] )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "s'$269", PrimBinOp Nothing PrimAdd
-                                      ( Ref Nothing ( Local ( Name "s$268" ) ) )
+                                    ( Nothing, Name "s'$1", PrimBinOp Nothing PrimAdd
+                                      ( Ref Nothing ( Local ( Name "s$1" ) ) )
                                       ( LiteralInt Nothing 1 )
                                     ) :| []
                                   )
                                   ( LiteralObject Nothing
                                     [
-                                      ( PropName "state", Ref Nothing
-                                        ( Local ( Name "s'$269" ) )
-                                      ),
-                                      ( PropName "value", Ref Nothing ( Local ( Name "s'$269" ) ) )
+                                      ( PropName "state", Ref Nothing ( Local ( Name "s'$1" ) ) ),
+                                      ( PropName "value", Ref Nothing ( Local ( Name "s'$1" ) ) )
                                     ]
                                   )
                                 ) :| []
                               )
                             )
-                            ( Ref Nothing ( Local ( Name "counter$4" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "counter$0" ) ) :| [] ) :| []
                           )
                         )
                         ( Ref Nothing
@@ -556,7 +554,7 @@ UberModule
                 ( LiteralInt Nothing 2 :| [] )
               )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "i$8" ) :| [] )
+                ( ParamNamed Nothing ( Name "i$0" ) :| [] )
                 ( AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect" ) ( Name "foreachE" ) ) )
@@ -565,7 +563,7 @@ UberModule
                     )
                   )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "s$9" ) :| [] )
+                    ( ParamNamed Nothing ( Name "s$2" ) :| [] )
                     ( AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                       ( PrimBinOp Nothing PrimConcat
@@ -573,9 +571,9 @@ UberModule
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                           )
-                          ( Ref Nothing ( Local ( Name "i$8" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "i$0" ) ) :| [] )
                         )
-                        ( Ref Nothing ( Local ( Name "s$9" ) ) ) :| []
+                        ( Ref Nothing ( Local ( Name "s$2" ) ) ) :| []
                       )
                     ) :| []
                   )

--- a/test/ps/output/Golden.NativeLoopsAliasPin.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoopsAliasPin.Test/golden.ir
@@ -28,7 +28,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.NativeLoopsAliasPin.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -36,7 +36,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone

--- a/test/ps/output/Golden.NativeLoopsGuard.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoopsGuard.Test/golden.ir
@@ -126,9 +126,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$1466" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$1467" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -152,10 +152,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$1466" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$1467" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -176,7 +176,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$1420", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -192,23 +192,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$1421" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$1422" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$1420" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$1421" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$1423" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$1420" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$1422" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$1424" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -231,8 +231,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$1423" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$1424" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -266,12 +266,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.NativeLoopsGuard.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$6" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "a$6" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -316,18 +316,18 @@ UberModule
         ( ParamNamed Nothing ( Name "xs" ) :| [ ParamNamed Nothing ( Name "f" ) ] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "v2$1417", AppN Nothing
+            ( Nothing, Name "v2$0", AppN Nothing
               ( ObjectProp Nothing
                 ( Ref Nothing ( Imported ( ModuleName "Data.Array" ) ( Name "foreign" ) ) )
                 ( PropName "indexImpl" )
               )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "value0$1418" ) :| [] )
+                ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
                 ( Ctor Nothing SumType
                   ( ModuleName "Data.Maybe" )
                   ( TyName "Maybe" )
                   ( CtorName "Just" )
-                  [ Ref Nothing ( Local ( Name "value0$1418" ) ) ]
+                  [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
                 ) :|
                 [ Ctor Nothing SumType
                   ( ModuleName "Data.Maybe" )
@@ -341,7 +341,7 @@ UberModule
           ( IfThenElse Nothing
             ( Eq Nothing
               ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1417" ) ) ) )
+              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
             )
             ( AppN Nothing
               ( Ref Nothing ( Imported ( ModuleName "Effect" ) ( Name "pureE" ) ) )
@@ -350,7 +350,7 @@ UberModule
             ( AppN Nothing
               ( Ref Nothing ( Local ( Name "f" ) ) )
               ( DataArgumentByIndex Nothing SumType 0
-                ( Ref Nothing ( Local ( Name "v2$1417" ) ) ) :| []
+                ( Ref Nothing ( Local ( Name "v2$0" ) ) ) :| []
               )
             )
           )
@@ -384,19 +384,19 @@ UberModule
     ], uberModuleForeigns = [], uberModuleExports =
     [
       ( Name "forE", AbsN Nothing
-        ( ParamNamed Nothing ( Name "forE$p1$1443" ) :| [] )
+        ( ParamNamed Nothing ( Name "forE$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "forE$p2$1444" ) :| [] )
+          ( ParamNamed Nothing ( Name "forE$p2$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "forE$p3$1445" ) :| [] )
+            ( ParamNamed Nothing ( Name "forE$p3$0" ) :| [] )
             ( IfThenElse Nothing
               ( PrimBinOp Nothing PrimLt
-                ( Ref Nothing ( Local ( Name "forE$p1$1443" ) ) )
-                ( Ref Nothing ( Local ( Name "forE$p2$1444" ) ) )
+                ( Ref Nothing ( Local ( Name "forE$p1$0" ) ) )
+                ( Ref Nothing ( Local ( Name "forE$p2$0" ) ) )
               )
               ( AppN Nothing
-                ( Ref Nothing ( Local ( Name "forE$p3$1445" ) ) )
-                ( Ref Nothing ( Local ( Name "forE$p1$1443" ) ) :| [] )
+                ( Ref Nothing ( Local ( Name "forE$p3$0" ) ) )
+                ( Ref Nothing ( Local ( Name "forE$p1$0" ) ) :| [] )
               )
               ( AppN Nothing
                 ( ObjectProp Nothing
@@ -410,37 +410,37 @@ UberModule
         )
       ),
       ( Name "foreachE", AbsN Nothing
-        ( ParamNamed Nothing ( Name "foreachE$p1$1446" ) :| [] )
+        ( ParamNamed Nothing ( Name "foreachE$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "foreachE$p2$1447" ) :| [] )
+          ( ParamNamed Nothing ( Name "foreachE$p2$0" ) :| [] )
           ( AppN Nothing
             ( Ref Nothing
               ( Imported ( ModuleName "Golden.NativeLoopsGuard.Test" ) ( Name "foreachE$w" ) )
             )
             ( Ref Nothing
-              ( Local ( Name "foreachE$p1$1446" ) ) :|
-              [ Ref Nothing ( Local ( Name "foreachE$p2$1447" ) ) ]
+              ( Local ( Name "foreachE$p1$0" ) ) :|
+              [ Ref Nothing ( Local ( Name "foreachE$p2$0" ) ) ]
             )
           )
         )
       ),
       ( Name "whileE", AbsN Nothing
-        ( ParamNamed Nothing ( Name "whileE$p1$1448" ) :| [] )
+        ( ParamNamed Nothing ( Name "whileE$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "whileE$p2$1449" ) :| [] )
+          ( ParamNamed Nothing ( Name "whileE$p2$0" ) :| [] )
           ( AbsN Nothing
             ( ParamUnused Nothing :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "b$1491", AppN Nothing
-                  ( Ref Nothing ( Local ( Name "whileE$p1$1448" ) ) )
+                ( Nothing, Name "b$0", AppN Nothing
+                  ( Ref Nothing ( Local ( Name "whileE$p1$0" ) ) )
                   ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
                 ) :| []
               )
               ( IfThenElse Nothing
-                ( Ref Nothing ( Local ( Name "b$1491" ) ) )
+                ( Ref Nothing ( Local ( Name "b$0" ) ) )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "whileE$p2$1449" ) ) )
+                  ( Ref Nothing ( Local ( Name "whileE$p2$0" ) ) )
                   ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
                 )
                 ( AppN Nothing
@@ -514,15 +514,15 @@ UberModule
                         ( PropName "map" )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                         ( PrimBinOp Nothing PrimAnd
                           ( PrimBinOp Nothing PrimGe
-                            ( Ref Nothing ( Local ( Name "v$1" ) ) )
+                            ( Ref Nothing ( Local ( Name "v$0" ) ) )
                             ( LiteralInt Nothing 0 )
                           )
                           ( PrimNot Nothing
                             ( Eq Nothing
-                              ( Ref Nothing ( Local ( Name "v$1" ) ) )
+                              ( Ref Nothing ( Local ( Name "v$0" ) ) )
                               ( LiteralInt Nothing 0 )
                             )
                           )
@@ -537,7 +537,7 @@ UberModule
                       ( ParamUnused Nothing :| [] )
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "n$2", AppN Nothing
+                          ( Nothing, Name "n$0", AppN Nothing
                             ( AppN Nothing
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) )
@@ -558,7 +558,7 @@ UberModule
                                   ( Ref Nothing
                                     ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                                   )
-                                  ( Ref Nothing ( Local ( Name "n$2" ) ) :| [] ) :| []
+                                  ( Ref Nothing ( Local ( Name "n$0" ) ) :| [] ) :| []
                                 )
                               )
                               ( Ref Nothing
@@ -592,22 +592,20 @@ UberModule
                                   ( PropName "modifyImpl" )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "s$1538" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                                   ( Let Nothing
                                     ( Standalone
-                                      ( Nothing, Name "s'$1539", PrimBinOp Nothing PrimSub
-                                        ( Ref Nothing ( Local ( Name "s$1538" ) ) )
+                                      ( Nothing, Name "s'$0", PrimBinOp Nothing PrimSub
+                                        ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                         ( LiteralInt Nothing 1 )
                                       ) :| []
                                     )
                                     ( LiteralObject Nothing
                                       [
                                         ( PropName "state", Ref Nothing
-                                          ( Local ( Name "s'$1539" ) )
+                                          ( Local ( Name "s'$0" ) )
                                         ),
-                                        ( PropName "value", Ref Nothing
-                                          ( Local ( Name "s'$1539" ) )
-                                        )
+                                        ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                                       ]
                                     )
                                   ) :| []

--- a/test/ps/output/Golden.NativeLoopsST.Test/golden.ir
+++ b/test/ps/output/Golden.NativeLoopsST.Test/golden.ir
@@ -74,7 +74,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.NativeLoopsST.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
@@ -85,7 +85,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -140,18 +140,18 @@ UberModule
                               )
                             )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "s$483" ) :| [] )
+                              ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                               ( Let Nothing
                                 ( Standalone
-                                  ( Nothing, Name "s'$484", PrimBinOp Nothing PrimAdd
-                                    ( Ref Nothing ( Local ( Name "s$483" ) ) )
+                                  ( Nothing, Name "s'$0", PrimBinOp Nothing PrimAdd
+                                    ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                     ( Ref Nothing ( Local ( Name "i" ) ) )
                                   ) :| []
                                 )
                                 ( LiteralObject Nothing
                                   [
-                                    ( PropName "state", Ref Nothing ( Local ( Name "s'$484" ) ) ),
-                                    ( PropName "value", Ref Nothing ( Local ( Name "s'$484" ) ) )
+                                    ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                                    ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                                   ]
                                 )
                               ) :| []
@@ -238,20 +238,18 @@ UberModule
                                 )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "s$476" ) :| [] )
+                                ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                                 ( Let Nothing
                                   ( Standalone
-                                    ( Nothing, Name "s'$477", PrimBinOp Nothing PrimAdd
-                                      ( Ref Nothing ( Local ( Name "s$476" ) ) )
+                                    ( Nothing, Name "s'$0", PrimBinOp Nothing PrimAdd
+                                      ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                       ( Ref Nothing ( Local ( Name "x" ) ) )
                                     ) :| []
                                   )
                                   ( LiteralObject Nothing
                                     [
-                                      ( PropName "state", Ref Nothing
-                                        ( Local ( Name "s'$477" ) )
-                                      ),
-                                      ( PropName "value", Ref Nothing ( Local ( Name "s'$477" ) ) )
+                                      ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                                      ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                                     ]
                                   )
                                 ) :| []
@@ -369,21 +367,21 @@ UberModule
                                     )
                                   )
                                   ( AbsN Nothing
-                                    ( ParamNamed Nothing ( Name "s$465" ) :| [] )
+                                    ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                                     ( Let Nothing
                                       ( Standalone
-                                        ( Nothing, Name "s'$466", PrimBinOp Nothing PrimSub
-                                          ( Ref Nothing ( Local ( Name "s$465" ) ) )
+                                        ( Nothing, Name "s'$0", PrimBinOp Nothing PrimSub
+                                          ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                           ( LiteralInt Nothing 1 )
                                         ) :| []
                                       )
                                       ( LiteralObject Nothing
                                         [
                                           ( PropName "state", Ref Nothing
-                                            ( Local ( Name "s'$466" ) )
+                                            ( Local ( Name "s'$0" ) )
                                           ),
                                           ( PropName "value", Ref Nothing
-                                            ( Local ( Name "s'$466" ) )
+                                            ( Local ( Name "s'$0" ) )
                                           )
                                         ]
                                       )
@@ -407,22 +405,20 @@ UberModule
                                   )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "s$470" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "s$1" ) :| [] )
                                   ( Let Nothing
                                     ( Standalone
-                                      ( Nothing, Name "s'$471", PrimBinOp Nothing PrimAdd
-                                        ( Ref Nothing ( Local ( Name "s$470" ) ) )
+                                      ( Nothing, Name "s'$1", PrimBinOp Nothing PrimAdd
+                                        ( Ref Nothing ( Local ( Name "s$1" ) ) )
                                         ( LiteralInt Nothing 1 )
                                       ) :| []
                                     )
                                     ( LiteralObject Nothing
                                       [
                                         ( PropName "state", Ref Nothing
-                                          ( Local ( Name "s'$471" ) )
+                                          ( Local ( Name "s'$1" ) )
                                         ),
-                                        ( PropName "value", Ref Nothing
-                                          ( Local ( Name "s'$471" ) )
-                                        )
+                                        ( PropName "value", Ref Nothing ( Local ( Name "s'$1" ) ) )
                                       ]
                                     )
                                   ) :| []

--- a/test/ps/output/Golden.PatternMatching.Test1/golden.ir
+++ b/test/ps/output/Golden.PatternMatching.Test1/golden.ir
@@ -7,62 +7,62 @@ UberModule
         ( CtorName "Zero" ) []
       ),
       ( Name "Succ", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$7" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.PatternMatching.Test1" )
           ( TyName "N" )
           ( CtorName "Succ" )
-          [ Ref Nothing ( Local ( Name "value0$7" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "Num", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$6" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.PatternMatching.Test1" )
           ( TyName "E" )
           ( CtorName "Num" )
-          [ Ref Nothing ( Local ( Name "value0$6" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "Not", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$5" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.PatternMatching.Test1" )
           ( TyName "E" )
           ( CtorName "Not" )
-          [ Ref Nothing ( Local ( Name "value0$5" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "pat", AbsN Nothing
-        ( ParamNamed Nothing ( Name "e$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "e$0" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse11", DataArgumentByIndex Nothing SumType 0
-              ( Ref Nothing ( Local ( Name "e$2" ) ) )
+            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
+              ( Ref Nothing ( Local ( Name "e$0" ) ) )
             ) :| []
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse10", ReflectCtor Nothing
-                ( Ref Nothing ( Local ( Name "e$2" ) ) )
+              ( Nothing, Name "$cse1", ReflectCtor Nothing
+                ( Ref Nothing ( Local ( Name "e$0" ) ) )
               ) :| []
             )
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Golden.PatternMatching.Test1∷E.Not" )
-                ( Ref Nothing ( Local ( Name "$cse10" ) ) )
+                ( Ref Nothing ( Local ( Name "$cse1" ) ) )
               )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.PatternMatching.Test1∷E.Num" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse11" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.PatternMatching.Test1∷N.Succ" )
                     ( ReflectCtor Nothing
                       ( DataArgumentByIndex Nothing SumType 0
-                        ( Ref Nothing ( Local ( Name "$cse11" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                       )
                     )
                   )
@@ -72,7 +72,7 @@ UberModule
                       ( LiteralString Nothing "Golden.PatternMatching.Test1∷N.Zero" )
                       ( ReflectCtor Nothing
                         ( DataArgumentByIndex Nothing SumType 0
-                          ( Ref Nothing ( Local ( Name "$cse11" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         )
                       )
                     )
@@ -83,14 +83,14 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.PatternMatching.Test1∷E.Not" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse11" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                   )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.PatternMatching.Test1∷E.Num" )
                       ( ReflectCtor Nothing
                         ( DataArgumentByIndex Nothing SumType 0
-                          ( Ref Nothing ( Local ( Name "$cse11" ) ) )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         )
                       )
                     )
@@ -100,7 +100,7 @@ UberModule
                         ( ReflectCtor Nothing
                           ( DataArgumentByIndex Nothing SumType 0
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "$cse11" ) ) )
+                              ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                             )
                           )
                         )
@@ -116,12 +116,12 @@ UberModule
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.PatternMatching.Test1∷E.Num" )
-                  ( Ref Nothing ( Local ( Name "$cse10" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.PatternMatching.Test1∷N.Succ" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse11" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                   )
                   ( LiteralInt Nothing 4 )
                   ( LiteralInt Nothing 5 )
@@ -133,14 +133,14 @@ UberModule
         )
       ),
       ( Name "T", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$8" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "value1$9" ) :| [] )
+          ( ParamNamed Nothing ( Name "value1$0" ) :| [] )
           ( Ctor Nothing ProductType
             ( ModuleName "Golden.PatternMatching.Test1" )
             ( TyName "Tuple" )
             ( CtorName "T" )
-            [ Ref Nothing ( Local ( Name "value0$8" ) ), Ref Nothing ( Local ( Name "value1$9" ) ) ]
+            [ Ref Nothing ( Local ( Name "value0$0" ) ), Ref Nothing ( Local ( Name "value1$0" ) ) ]
           )
         )
       ),
@@ -149,8 +149,8 @@ UberModule
         ( DataArgumentByIndex Nothing ProductType 0 ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
       ),
       ( Name "snd", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$3" ) :| [] )
-        ( DataArgumentByIndex Nothing ProductType 1 ( Ref Nothing ( Local ( Name "v$3" ) ) ) )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
+        ( DataArgumentByIndex Nothing ProductType 1 ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
       )
     ]
   }

--- a/test/ps/output/Golden.PatternMatching.Test2/golden.ir
+++ b/test/ps/output/Golden.PatternMatching.Test2/golden.ir
@@ -29,35 +29,35 @@ UberModule
         ( CtorName "Zero" ) []
       ),
       ( Name "Succ", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$5" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( Ctor Nothing SumType
           ( ModuleName "Golden.PatternMatching.Test2" )
           ( TyName "N" )
           ( CtorName "Succ" )
-          [ Ref Nothing ( Local ( Name "value0$5" ) ) ]
+          [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
         )
       ),
       ( Name "Add", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$3" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "value1$4" ) :| [] )
+          ( ParamNamed Nothing ( Name "value1$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.PatternMatching.Test2" )
             ( TyName "N" )
             ( CtorName "Add" )
-            [ Ref Nothing ( Local ( Name "value0$3" ) ), Ref Nothing ( Local ( Name "value1$4" ) ) ]
+            [ Ref Nothing ( Local ( Name "value0$0" ) ), Ref Nothing ( Local ( Name "value1$0" ) ) ]
           )
         )
       ),
       ( Name "Mul", AbsN Nothing
-        ( ParamNamed Nothing ( Name "value0$1" ) :| [] )
+        ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "value1$2" ) :| [] )
+          ( ParamNamed Nothing ( Name "value1$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.PatternMatching.Test2" )
             ( TyName "N" )
             ( CtorName "Mul" )
-            [ Ref Nothing ( Local ( Name "value0$1" ) ), Ref Nothing ( Local ( Name "value1$2" ) ) ]
+            [ Ref Nothing ( Local ( Name "value0$0" ) ), Ref Nothing ( Local ( Name "value1$0" ) ) ]
           )
         )
       ),
@@ -65,13 +65,13 @@ UberModule
         ( ParamNamed Nothing ( Name "e$0" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse7", DataArgumentByIndex Nothing SumType 0
+            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
               ( Ref Nothing ( Local ( Name "e$0" ) ) )
             ) :| []
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse6", DataArgumentByIndex Nothing SumType 1
+              ( Nothing, Name "$cse1", DataArgumentByIndex Nothing SumType 1
                 ( Ref Nothing ( Local ( Name "e$0" ) ) )
               ) :| []
             )
@@ -83,18 +83,18 @@ UberModule
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.PatternMatching.Test2∷N.Zero" )
-                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse6" ) ) ) )
+                  ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse1" ) ) ) )
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.PatternMatching.Test2∷N.Add" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse7" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                   )
                   ( LiteralInt Nothing 1 )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.PatternMatching.Test2∷N.Mul" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse7" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse0" ) ) ) )
                     )
                     ( LiteralInt Nothing 2 )
                     ( LiteralInt Nothing 5 )
@@ -103,13 +103,13 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Golden.PatternMatching.Test2∷N.Mul" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse6" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse1" ) ) ) )
                   )
                   ( LiteralInt Nothing 3 )
                   ( IfThenElse Nothing
                     ( Eq Nothing
                       ( LiteralString Nothing "Golden.PatternMatching.Test2∷N.Add" )
-                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse6" ) ) ) )
+                      ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "$cse1" ) ) ) )
                     )
                     ( LiteralInt Nothing 4 )
                     ( LiteralInt Nothing 6 )

--- a/test/ps/output/Golden.Primops.Test/golden.ir
+++ b/test/ps/output/Golden.Primops.Test/golden.ir
@@ -59,28 +59,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$205" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$206" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$0" ) :| [] )
                 ( PrimBinOp Nothing PrimAnd
-                  ( Ref Nothing ( Local ( Name "b1$205" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$206" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$0" ) ) )
                 )
               )
             ),
             ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$203" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$1" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$204" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$1" ) :| [] )
                 ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$203" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$204" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1" ) ) )
                 )
               )
             ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$202" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$202" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$0" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$0" ) ) ) )
             )
           ]
         ) :| []

--- a/test/ps/output/Golden.ProfunctorDictLens.Test/golden.ir
+++ b/test/ps/output/Golden.ProfunctorDictLens.Test/golden.ir
@@ -27,8 +27,8 @@ UberModule
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.Newtype", qnameName = Name "coerce" }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$253" ) :| [] )
-        ( Ref Nothing ( Local ( Name "x$253" ) ) )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+        ( Ref Nothing ( Local ( Name "x$0" ) ) )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.ProfunctorDictLens.Test", qnameName = Name "unwrap"

--- a/test/ps/output/Golden.RecGroupOrder.Test/golden.ir
+++ b/test/ps/output/Golden.RecGroupOrder.Test/golden.ir
@@ -63,7 +63,7 @@ UberModule
               )
             ) :|
             [
-              ( Nothing, Name "record$1", AppN Nothing
+              ( Nothing, Name "record$0", AppN Nothing
                 ( Ref Nothing ( Local ( Name "Lazy_record$0" ) ) )
                 ( LiteralInt Nothing 0 :| [] )
               )
@@ -76,7 +76,7 @@ UberModule
             ( PropName "log" )
           )
           ( AppN Nothing
-            ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "record$1" ) ) ) ( PropName "run" ) )
+            ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "record$0" ) ) ) ( PropName "run" ) )
             ( Ref Nothing ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ) :| [] ) :| []
           )
         )

--- a/test/ps/output/Golden.RecordSurgery.Test/golden.ir
+++ b/test/ps/output/Golden.RecordSurgery.Test/golden.ir
@@ -38,7 +38,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.RecordSurgery.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$216" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -46,18 +46,18 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$216" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.RecordSurgery.Test", qnameName = Name "logShow1"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$214" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( IfThenElse Nothing
-            ( Ref Nothing ( Local ( Name "a$214" ) ) )
+            ( Ref Nothing ( Local ( Name "a$0" ) ) )
             ( LiteralString Nothing "true" )
             ( LiteralString Nothing "false" ) :| []
           )
@@ -113,7 +113,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
             ) :|
             [ Standalone
-              ( Nothing, Name "dyn$1", AppN Nothing
+              ( Nothing, Name "dyn$0", AppN Nothing
                 ( AppN Nothing
                   ( ObjectProp Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "foreign" ) ) )
@@ -196,13 +196,13 @@ UberModule
                         )
                         ( PrimBinOp Nothing PrimAdd
                           ( ObjectProp Nothing
-                            ( Ref Nothing ( Local ( Name "dyn$1" ) ) )
+                            ( Ref Nothing ( Local ( Name "dyn$0" ) ) )
                             ( PropName "k" )
                           )
                           ( LiteralInt Nothing 1 ) :| []
                         )
                       )
-                      ( Ref Nothing ( Local ( Name "dyn$1" ) ) :| [] )
+                      ( Ref Nothing ( Local ( Name "dyn$0" ) ) :| [] )
                     )
                     ( PropName "k" ) :| []
                   )
@@ -234,7 +234,7 @@ UberModule
                         )
                         ( LiteralString Nothing "k" :| [] )
                       )
-                      ( Ref Nothing ( Local ( Name "dyn$1" ) ) :| [] ) :| []
+                      ( Ref Nothing ( Local ( Name "dyn$0" ) ) :| [] ) :| []
                     ) :| []
                   )
                 )

--- a/test/ps/output/Golden.RecordsAccess.Test/golden.ir
+++ b/test/ps/output/Golden.RecordsAccess.Test/golden.ir
@@ -17,12 +17,12 @@ UberModule
         ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) ( PropName "x" ) )
       ),
       ( Name "test3", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$1" ) :| [] )
-        ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$1" ) ) ) ( PropName "x" ) )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
+        ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) ( PropName "x" ) )
       ),
       ( Name "test4", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$3" ) :| [] )
-        ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$3" ) ) ) ( PropName "x" ) )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
+        ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) ( PropName "x" ) )
       )
     ]
   }

--- a/test/ps/output/Golden.RecordsUpdate.Test/golden.ir
+++ b/test/ps/output/Golden.RecordsUpdate.Test/golden.ir
@@ -25,28 +25,28 @@ UberModule
         ( ( PropName "x", LiteralInt Nothing 2 ) :| [] )
       ),
       ( Name "test2", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$1" ) :| [] )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
         ( ObjectUpdate Nothing
-          ( Ref Nothing ( Local ( Name "v$1" ) ) )
+          ( Ref Nothing ( Local ( Name "v$0" ) ) )
           ( ( PropName "y", LiteralBool Nothing False ) :| [] )
         )
       ),
       ( Name "test3", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
         ( ObjectUpdate Nothing
-          ( Ref Nothing ( Local ( Name "v$2" ) ) )
+          ( Ref Nothing ( Local ( Name "v$0" ) ) )
           (
             ( PropName "z", ObjectUpdate Nothing
-              ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$2" ) ) ) ( PropName "z" ) )
+              ( ObjectProp Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) ( PropName "z" ) )
               ( ( PropName "p", LiteralChar Nothing 'b' ) :| [] )
             ) :| []
           )
         )
       ),
       ( Name "test4", AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$3" ) :| [] )
+        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
         ( ObjectUpdate Nothing
-          ( Ref Nothing ( Local ( Name "v$3" ) ) )
+          ( Ref Nothing ( Local ( Name "v$0" ) ) )
           ( ( PropName "x", LiteralInt Nothing 1 ) :| [] )
         )
       )

--- a/test/ps/output/Golden.RecursiveBindings.Test/golden.ir
+++ b/test/ps/output/Golden.RecursiveBindings.Test/golden.ir
@@ -5,24 +5,24 @@ UberModule
         ( RecursiveGroup
           (
             ( Nothing, Name "yes$0", AbsN Nothing
-              ( ParamNamed Nothing ( Name "v$2" ) :| [] )
+              ( ParamNamed Nothing ( Name "v$0" ) :| [] )
               ( IfThenElse Nothing
-                ( Ref Nothing ( Local ( Name "v$2" ) ) )
+                ( Ref Nothing ( Local ( Name "v$0" ) ) )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "no$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "no$0" ) ) )
                   ( LiteralBool Nothing False :| [] )
                 )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "no$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "no$0" ) ) )
                   ( LiteralBool Nothing True :| [] )
                 )
               )
             ) :|
             [
-              ( Nothing, Name "no$1", AbsN Nothing
-                ( ParamNamed Nothing ( Name "v0$3" ) :| [] )
+              ( Nothing, Name "no$0", AbsN Nothing
+                ( ParamNamed Nothing ( Name "v0$0" ) :| [] )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "v0$3" ) ) )
+                  ( Ref Nothing ( Local ( Name "v0$0" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing ( Local ( Name "yes$0" ) ) )
                     ( LiteralBool Nothing False :| [] )
@@ -37,38 +37,38 @@ UberModule
           ) :| []
         )
         ( AppN Nothing
-          ( Ref Nothing ( Local ( Name "no$1" ) ) )
+          ( Ref Nothing ( Local ( Name "no$0" ) ) )
           ( LiteralBool Nothing False :| [] )
         )
       ),
       ( Name "whereRec", Let Nothing
         ( RecursiveGroup
           (
-            ( Nothing, Name "yes$14", AbsN Nothing
-              ( ParamNamed Nothing ( Name "v$16" ) :| [] )
+            ( Nothing, Name "yes$0", AbsN Nothing
+              ( ParamNamed Nothing ( Name "v$0" ) :| [] )
               ( IfThenElse Nothing
-                ( Ref Nothing ( Local ( Name "v$16" ) ) )
+                ( Ref Nothing ( Local ( Name "v$0" ) ) )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "no$15" ) ) )
+                  ( Ref Nothing ( Local ( Name "no$0" ) ) )
                   ( LiteralBool Nothing False :| [] )
                 )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "no$15" ) ) )
+                  ( Ref Nothing ( Local ( Name "no$0" ) ) )
                   ( LiteralBool Nothing True :| [] )
                 )
               )
             ) :|
             [
-              ( Nothing, Name "no$15", AbsN Nothing
-                ( ParamNamed Nothing ( Name "v0$17" ) :| [] )
+              ( Nothing, Name "no$0", AbsN Nothing
+                ( ParamNamed Nothing ( Name "v0$0" ) :| [] )
                 ( IfThenElse Nothing
-                  ( Ref Nothing ( Local ( Name "v0$17" ) ) )
+                  ( Ref Nothing ( Local ( Name "v0$0" ) ) )
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "yes$14" ) ) )
+                    ( Ref Nothing ( Local ( Name "yes$0" ) ) )
                     ( LiteralBool Nothing False :| [] )
                   )
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "yes$14" ) ) )
+                    ( Ref Nothing ( Local ( Name "yes$0" ) ) )
                     ( LiteralBool Nothing True :| [] )
                   )
                 )
@@ -77,53 +77,53 @@ UberModule
           ) :| []
         )
         ( AppN Nothing
-          ( Ref Nothing ( Local ( Name "no$15" ) ) )
+          ( Ref Nothing ( Local ( Name "no$0" ) ) )
           ( LiteralBool Nothing False :| [] )
         )
       ),
       ( Name "letRecMixed", Let Nothing
         ( Standalone
-          ( Nothing, Name "z$4", LiteralInt Nothing 1 ) :|
+          ( Nothing, Name "z$0", LiteralInt Nothing 1 ) :|
           [ RecursiveGroup
             (
-              ( Nothing, Name "b$5", AbsN Nothing
+              ( Nothing, Name "b$0", AbsN Nothing
                 ( ParamUnused Nothing :| [] )
                 ( AppN Nothing
-                  ( Ref Nothing ( Local ( Name "a$6" ) ) )
-                  ( Ref Nothing ( Local ( Name "z$4" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "a$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "z$0" ) ) :| [] )
                 )
               ) :|
               [
-                ( Nothing, Name "a$6", AbsN Nothing
+                ( Nothing, Name "a$0", AbsN Nothing
                   ( ParamUnused Nothing :| [] )
                   ( AppN Nothing
-                    ( Ref Nothing ( Local ( Name "b$5" ) ) )
-                    ( Ref Nothing ( Local ( Name "z$4" ) ) :| [] )
+                    ( Ref Nothing ( Local ( Name "b$0" ) ) )
+                    ( Ref Nothing ( Local ( Name "z$0" ) ) :| [] )
                   )
                 )
               ]
             ), Standalone
-            ( Nothing, Name "f$7$w", AbsN Nothing
-              ( ParamNamed Nothing ( Name "f$7$u1" ) :| [ ParamNamed Nothing ( Name "k$13" ) ] )
+            ( Nothing, Name "f$0$w", AbsN Nothing
+              ( ParamNamed Nothing ( Name "f$0$u1" ) :| [ ParamNamed Nothing ( Name "k$0" ) ] )
               ( AppN Nothing
-                ( Ref Nothing ( Local ( Name "a$6" ) ) )
-                ( Ref Nothing ( Local ( Name "k$13" ) ) :| [] )
+                ( Ref Nothing ( Local ( Name "a$0" ) ) )
+                ( Ref Nothing ( Local ( Name "k$0" ) ) :| [] )
               )
             ), Standalone
-            ( Nothing, Name "y$8", AppN Nothing
-              ( Ref Nothing ( Local ( Name "f$7$w" ) ) )
-              ( Ref Nothing ( Local ( Name "z$4" ) ) :| [ Ref Nothing ( Local ( Name "z$4" ) ) ] )
+            ( Nothing, Name "y$0", AppN Nothing
+              ( Ref Nothing ( Local ( Name "f$0$w" ) ) )
+              ( Ref Nothing ( Local ( Name "z$0" ) ) :| [ Ref Nothing ( Local ( Name "z$0" ) ) ] )
             )
           ]
         )
         ( AppN Nothing
-          ( Ref Nothing ( Local ( Name "f$7$w" ) ) )
+          ( Ref Nothing ( Local ( Name "f$0$w" ) ) )
           ( AppN Nothing
-            ( Ref Nothing ( Local ( Name "f$7$w" ) ) )
-            ( Ref Nothing ( Local ( Name "y$8" ) ) :| [ Ref Nothing ( Local ( Name "y$8" ) ) ] ) :|
+            ( Ref Nothing ( Local ( Name "f$0$w" ) ) )
+            ( Ref Nothing ( Local ( Name "y$0" ) ) :| [ Ref Nothing ( Local ( Name "y$0" ) ) ] ) :|
             [ AppN Nothing
-              ( Ref Nothing ( Local ( Name "f$7$w" ) ) )
-              ( Ref Nothing ( Local ( Name "y$8" ) ) :| [ LiteralInt Nothing 0 ] )
+              ( Ref Nothing ( Local ( Name "f$0$w" ) ) )
+              ( Ref Nothing ( Local ( Name "y$0" ) ) :| [ LiteralInt Nothing 0 ] )
             ]
           )
         )

--- a/test/ps/output/Golden.RefUnbox.Test/golden.ir
+++ b/test/ps/output/Golden.RefUnbox.Test/golden.ir
@@ -68,23 +68,23 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "add", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$426" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "y$427" ) :| [] )
+              ( ParamNamed Nothing ( Name "y$0" ) :| [] )
               ( PrimBinOp Nothing PrimAdd
-                ( Ref Nothing ( Local ( Name "x$426" ) ) )
-                ( Ref Nothing ( Local ( Name "y$427" ) ) )
+                ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                ( Ref Nothing ( Local ( Name "y$0" ) ) )
               )
             )
           ),
           ( PropName "zero", LiteralInt Nothing 0 ),
           ( PropName "mul", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$424" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$1" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "y$425" ) :| [] )
+              ( ParamNamed Nothing ( Name "y$1" ) :| [] )
               ( PrimBinOp Nothing PrimMul
-                ( Ref Nothing ( Local ( Name "x$424" ) ) )
-                ( Ref Nothing ( Local ( Name "y$425" ) ) )
+                ( Ref Nothing ( Local ( Name "x$1" ) ) )
+                ( Ref Nothing ( Local ( Name "y$1" ) ) )
               )
             )
           ),
@@ -94,7 +94,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.RefUnbox.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$5" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "foreign" ) ) )
@@ -105,7 +105,7 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$5" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -211,18 +211,18 @@ UberModule
                               )
                             )
                             ( AbsN Nothing
-                              ( ParamNamed Nothing ( Name "s$464" ) :| [] )
+                              ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                               ( Let Nothing
                                 ( Standalone
-                                  ( Nothing, Name "s'$465", PrimBinOp Nothing PrimAdd
-                                    ( Ref Nothing ( Local ( Name "s$464" ) ) )
+                                  ( Nothing, Name "s'$0", PrimBinOp Nothing PrimAdd
+                                    ( Ref Nothing ( Local ( Name "s$0" ) ) )
                                     ( Ref Nothing ( Local ( Name "i" ) ) )
                                   ) :| []
                                 )
                                 ( LiteralObject Nothing
                                   [
-                                    ( PropName "state", Ref Nothing ( Local ( Name "s'$465" ) ) ),
-                                    ( PropName "value", Ref Nothing ( Local ( Name "s'$465" ) ) )
+                                    ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                                    ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                                   ]
                                 )
                               ) :| []
@@ -363,18 +363,18 @@ UberModule
                         )
                       )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "s$451" ) :| [] )
+                        ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                         ( Let Nothing
                           ( Standalone
-                            ( Nothing, Name "s'$452", PrimBinOp Nothing PrimMul
-                              ( Ref Nothing ( Local ( Name "s$451" ) ) )
+                            ( Nothing, Name "s'$0", PrimBinOp Nothing PrimMul
+                              ( Ref Nothing ( Local ( Name "s$0" ) ) )
                               ( LiteralInt Nothing 2 )
                             ) :| []
                           )
                           ( LiteralObject Nothing
                             [
-                              ( PropName "state", Ref Nothing ( Local ( Name "s'$452" ) ) ),
-                              ( PropName "value", Ref Nothing ( Local ( Name "s'$452" ) ) )
+                              ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                              ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                             ]
                           )
                         ) :| []
@@ -477,7 +477,7 @@ UberModule
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
-              ( Nothing, Name "v$1", AppN Nothing
+              ( Nothing, Name "v$0", AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) ) )
                   ( Ref Nothing ( Local ( Name "counter$0" ) ) :| [] )
@@ -499,7 +499,7 @@ UberModule
                           )
                           ( PropName "add" )
                         )
-                        ( Ref Nothing ( Local ( Name "v$1" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "v$0" ) ) :| [] )
                       )
                       ( LiteralInt Nothing 1 :| [] ) :| []
                     )
@@ -508,7 +508,7 @@ UberModule
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               ), Standalone
-              ( Nothing, Name "w$2", AppN Nothing
+              ( Nothing, Name "w$0", AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) ) )
                   ( Ref Nothing ( Local ( Name "counter$0" ) ) :| [] )
@@ -520,7 +520,7 @@ UberModule
           ( AppN Nothing
             ( AppN Nothing
               ( Ref Nothing ( Imported ( ModuleName "Golden.RefUnbox.Test" ) ( Name "logShow" ) ) )
-              ( Ref Nothing ( Local ( Name "w$2" ) ) :| [] )
+              ( Ref Nothing ( Local ( Name "w$0" ) ) :| [] )
             )
             ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
           )

--- a/test/ps/output/Golden.STDoBlock.Test/golden.ir
+++ b/test/ps/output/Golden.STDoBlock.Test/golden.ir
@@ -47,19 +47,19 @@ UberModule
             ( ParamUnused Nothing :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse513", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "s$448" ) :| [] )
+                ( Nothing, Name "$cse0", AbsN Nothing
+                  ( ParamNamed Nothing ( Name "s$0" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "s'$449", PrimBinOp Nothing PrimAdd
-                        ( Ref Nothing ( Local ( Name "s$448" ) ) )
+                      ( Nothing, Name "s'$0", PrimBinOp Nothing PrimAdd
+                        ( Ref Nothing ( Local ( Name "s$0" ) ) )
                         ( Ref Nothing ( Local ( Name "n" ) ) )
                       ) :| []
                     )
                     ( LiteralObject Nothing
                       [
-                        ( PropName "state", Ref Nothing ( Local ( Name "s'$449" ) ) ),
-                        ( PropName "value", Ref Nothing ( Local ( Name "s'$449" ) ) )
+                        ( PropName "state", Ref Nothing ( Local ( Name "s'$0" ) ) ),
+                        ( PropName "value", Ref Nothing ( Local ( Name "s'$0" ) ) )
                       ]
                     )
                   )
@@ -89,7 +89,7 @@ UberModule
                               ( Name "modifyImpl" )
                             )
                           )
-                          ( Ref Nothing ( Local ( Name "$cse513" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                         )
                         ( Ref Nothing ( Local ( Name "ref" ) ) :| [] )
                       )
@@ -106,7 +106,7 @@ UberModule
                               ( Name "modifyImpl" )
                             )
                           )
-                          ( Ref Nothing ( Local ( Name "$cse513" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "$cse0" ) ) :| [] )
                         )
                         ( Ref Nothing ( Local ( Name "ref" ) ) :| [] )
                       )

--- a/test/ps/output/Golden.ScalarReplacement.Test/golden.ir
+++ b/test/ps/output/Golden.ScalarReplacement.Test/golden.ir
@@ -112,17 +112,17 @@ UberModule
         ( Imported ( ModuleName "Golden.ScalarReplacement.Test" ) ( Name "defaults" ) )
       ),
       ( Name "chained", AbsN Nothing
-        ( ParamNamed Nothing ( Name "chained$p1$227" ) :| [] )
+        ( ParamNamed Nothing ( Name "chained$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "chained$p2$228" ) :| [] )
+          ( ParamNamed Nothing ( Name "chained$p2$0" ) :| [] )
           ( PrimBinOp Nothing PrimAdd
             ( PrimBinOp Nothing PrimAdd
-              ( Ref Nothing ( Local ( Name "chained$p1$227" ) ) )
-              ( Ref Nothing ( Local ( Name "chained$p2$228" ) ) )
+              ( Ref Nothing ( Local ( Name "chained$p1$0" ) ) )
+              ( Ref Nothing ( Local ( Name "chained$p2$0" ) ) )
             )
             ( PrimBinOp Nothing PrimAdd
-              ( Ref Nothing ( Local ( Name "chained$p1$227" ) ) )
-              ( Ref Nothing ( Local ( Name "chained$p2$228" ) ) )
+              ( Ref Nothing ( Local ( Name "chained$p1$0" ) ) )
+              ( Ref Nothing ( Local ( Name "chained$p2$0" ) ) )
             )
           )
         )

--- a/test/ps/output/Golden.SpecConstr.Test/golden.ir
+++ b/test/ps/output/Golden.SpecConstr.Test/golden.ir
@@ -101,7 +101,7 @@ UberModule
             ( ParamNamed Nothing ( Name "m" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse499", DataArgumentByIndex Nothing SumType 0
+                ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
                   ( Ref Nothing ( Local ( Name "m" ) ) )
                 ) :| []
               )
@@ -113,7 +113,7 @@ UberModule
                 ( LiteralInt Nothing 0 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "$cse499" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                     ( LiteralInt Nothing 0 )
                   )
                   ( LiteralInt Nothing 42 )
@@ -125,7 +125,7 @@ UberModule
                       )
                     )
                     ( PrimBinOp Nothing PrimSub
-                      ( Ref Nothing ( Local ( Name "$cse499" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                       ( LiteralInt Nothing 1 ) :| []
                     )
                   )
@@ -171,31 +171,31 @@ UberModule
             ( ParamNamed Nothing ( Name "t" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse501", DataArgumentByIndex Nothing ProductType 1
+                ( Nothing, Name "$cse0", DataArgumentByIndex Nothing ProductType 1
                   ( Ref Nothing ( Local ( Name "t" ) ) )
                 ) :| []
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "$cse500", DataArgumentByIndex Nothing ProductType 0
+                  ( Nothing, Name "$cse1", DataArgumentByIndex Nothing ProductType 0
                     ( Ref Nothing ( Local ( Name "t" ) ) )
                   ) :| []
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "$cse500" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                     ( LiteralInt Nothing 0 )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse501" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Golden.SpecConstr.Test" ) ( Name "ping$sc1Tuple" ) )
                     )
                     ( PrimBinOp Nothing PrimSub
-                      ( Ref Nothing ( Local ( Name "$cse500" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                       ( LiteralInt Nothing 1 ) :|
                       [ PrimBinOp Nothing PrimAdd
-                        ( Ref Nothing ( Local ( Name "$cse501" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( LiteralInt Nothing 2 )
                       ]
                     )
@@ -238,31 +238,31 @@ UberModule
             ( ParamNamed Nothing ( Name "t" ) :| [] )
             ( Let Nothing
               ( Standalone
-                ( Nothing, Name "$cse503", DataArgumentByIndex Nothing ProductType 1
+                ( Nothing, Name "$cse0", DataArgumentByIndex Nothing ProductType 1
                   ( Ref Nothing ( Local ( Name "t" ) ) )
                 ) :| []
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "$cse502", DataArgumentByIndex Nothing ProductType 0
+                  ( Nothing, Name "$cse1", DataArgumentByIndex Nothing ProductType 0
                     ( Ref Nothing ( Local ( Name "t" ) ) )
                   ) :| []
                 )
                 ( IfThenElse Nothing
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "$cse502" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                     ( LiteralInt Nothing 0 )
                   )
-                  ( Ref Nothing ( Local ( Name "$cse503" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                   ( AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Golden.SpecConstr.Test" ) ( Name "pong$sc1Tuple" ) )
                     )
                     ( PrimBinOp Nothing PrimSub
-                      ( Ref Nothing ( Local ( Name "$cse502" ) ) )
+                      ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                       ( LiteralInt Nothing 1 ) :|
                       [ PrimBinOp Nothing PrimAdd
-                        ( Ref Nothing ( Local ( Name "$cse503" ) ) )
+                        ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                         ( LiteralInt Nothing 1 )
                       ]
                     )
@@ -344,26 +344,26 @@ UberModule
                 ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
                 ( Let Nothing
                   ( Standalone
-                    ( Nothing, Name "v$86", Let Nothing
+                    ( Nothing, Name "v$0", Let Nothing
                       ( RecursiveGroup
                         (
-                          ( Nothing, Name "go$460$sc1Tuple", AbsN Nothing
+                          ( Nothing, Name "go$0$sc1Tuple", AbsN Nothing
                             ( ParamNamed Nothing
-                              ( Name "go$460$sc1Tuple$f1" ) :|
-                              [ ParamNamed Nothing ( Name "go$460$sc1Tuple$f2" ) ]
+                              ( Name "go$0$sc1Tuple$f1" ) :|
+                              [ ParamNamed Nothing ( Name "go$0$sc1Tuple$f2" ) ]
                             )
                             ( IfThenElse Nothing
                               ( PrimBinOp Nothing PrimLt
-                                ( Ref Nothing ( Local ( Name "go$460$sc1Tuple$f2" ) ) )
+                                ( Ref Nothing ( Local ( Name "go$0$sc1Tuple$f2" ) ) )
                                 ( LiteralInt Nothing 5 )
                               )
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "go$460$sc1Tuple" ) ) )
+                                ( Ref Nothing ( Local ( Name "go$0$sc1Tuple" ) ) )
                                 ( PrimBinOp Nothing PrimAdd
-                                  ( Ref Nothing ( Local ( Name "go$460$sc1Tuple$f1" ) ) )
-                                  ( Ref Nothing ( Local ( Name "go$460$sc1Tuple$f2" ) ) ) :|
+                                  ( Ref Nothing ( Local ( Name "go$0$sc1Tuple$f1" ) ) )
+                                  ( Ref Nothing ( Local ( Name "go$0$sc1Tuple$f2" ) ) ) :|
                                   [ PrimBinOp Nothing PrimAdd
-                                    ( Ref Nothing ( Local ( Name "go$460$sc1Tuple$f2" ) ) )
+                                    ( Ref Nothing ( Local ( Name "go$0$sc1Tuple$f2" ) ) )
                                     ( LiteralInt Nothing 1 )
                                   ]
                                 )
@@ -373,8 +373,8 @@ UberModule
                                 ( TyName "Tuple" )
                                 ( CtorName "Tuple" )
                                 [ Ref Nothing
-                                  ( Local ( Name "go$460$sc1Tuple$f1" ) ), Ref Nothing
-                                  ( Local ( Name "go$460$sc1Tuple$f2" ) )
+                                  ( Local ( Name "go$0$sc1Tuple$f1" ) ), Ref Nothing
+                                  ( Local ( Name "go$0$sc1Tuple$f2" ) )
                                 ]
                               )
                             )
@@ -382,7 +382,7 @@ UberModule
                         ) :| []
                       )
                       ( AppN Nothing
-                        ( Ref Nothing ( Local ( Name "go$460$sc1Tuple" ) ) )
+                        ( Ref Nothing ( Local ( Name "go$0$sc1Tuple" ) ) )
                         ( LiteralInt Nothing 0 :| [ LiteralInt Nothing 0 ] )
                       )
                     ) :| []
@@ -395,7 +395,7 @@ UberModule
                           ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                         )
                         ( DataArgumentByIndex Nothing ProductType 0
-                          ( Ref Nothing ( Local ( Name "v$86" ) ) ) :| []
+                          ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                         )
                       )
                       ( PrimBinOp Nothing PrimConcat
@@ -406,7 +406,7 @@ UberModule
                               ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) )
                             )
                             ( DataArgumentByIndex Nothing ProductType 1
-                              ( Ref Nothing ( Local ( Name "v$86" ) ) ) :| []
+                              ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                             )
                           )
                           ( LiteralString Nothing ")" )

--- a/test/ps/output/Golden.StringCodePoints.Test/golden.ir
+++ b/test/ps/output/Golden.StringCodePoints.Test/golden.ir
@@ -174,28 +174,28 @@ UberModule
               )
             ),
             ( PropName "conj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$1492" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$0" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$1493" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$0" ) :| [] )
                 ( PrimBinOp Nothing PrimAnd
-                  ( Ref Nothing ( Local ( Name "b1$1492" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$1493" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$0" ) ) )
                 )
               )
             ),
             ( PropName "disj", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b1$1490" ) :| [] )
+              ( ParamNamed Nothing ( Name "b1$1" ) :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "b2$1491" ) :| [] )
+                ( ParamNamed Nothing ( Name "b2$1" ) :| [] )
                 ( PrimBinOp Nothing PrimOr
-                  ( Ref Nothing ( Local ( Name "b1$1490" ) ) )
-                  ( Ref Nothing ( Local ( Name "b2$1491" ) ) )
+                  ( Ref Nothing ( Local ( Name "b1$1" ) ) )
+                  ( Ref Nothing ( Local ( Name "b2$1" ) ) )
                 )
               )
             ),
             ( PropName "not", AbsN Nothing
-              ( ParamNamed Nothing ( Name "b$1489" ) :| [] )
-              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$1489" ) ) ) )
+              ( ParamNamed Nothing ( Name "b$0" ) :| [] )
+              ( PrimNot Nothing ( Ref Nothing ( Local ( Name "b$0" ) ) ) )
             )
           ]
         ) :| []
@@ -204,12 +204,12 @@ UberModule
         { qnameModuleName = ModuleName "Data.Eq", qnameName = Name "eqInt" }, LiteralObject Nothing
         [
           ( PropName "eq", AbsN Nothing
-            ( ParamNamed Nothing ( Name "r1$1485" ) :| [] )
+            ( ParamNamed Nothing ( Name "r1$0" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "r2$1486" ) :| [] )
+              ( ParamNamed Nothing ( Name "r2$0" ) :| [] )
               ( Eq Nothing
-                ( Ref Nothing ( Local ( Name "r1$1485" ) ) )
-                ( Ref Nothing ( Local ( Name "r2$1486" ) ) )
+                ( Ref Nothing ( Local ( Name "r1$0" ) ) )
+                ( Ref Nothing ( Local ( Name "r2$0" ) ) )
               )
             )
           )
@@ -241,19 +241,19 @@ UberModule
         }, LiteralObject Nothing
         [
           ( PropName "compare", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$1469" ) :| [] )
+            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
             ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "y$1470" ) :| [] )
+              ( ParamNamed Nothing ( Name "y$0" ) :| [] )
               ( IfThenElse Nothing
                 ( PrimBinOp Nothing PrimLt
-                  ( Ref Nothing ( Local ( Name "x$1469" ) ) )
-                  ( Ref Nothing ( Local ( Name "y$1470" ) ) )
+                  ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                  ( Ref Nothing ( Local ( Name "y$0" ) ) )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "LT" ) ) )
                 ( IfThenElse Nothing
                   ( Eq Nothing
-                    ( Ref Nothing ( Local ( Name "x$1469" ) ) )
-                    ( Ref Nothing ( Local ( Name "y$1470" ) ) )
+                    ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                    ( Ref Nothing ( Local ( Name "y$0" ) ) )
                   )
                   ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "EQ" ) ) )
                   ( Ref Nothing ( Imported ( ModuleName "Data.Ordering" ) ( Name "GT" ) ) )
@@ -367,19 +367,19 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Data.String.CodePoints", qnameName = Name "add$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1752" ) :| [ ParamNamed Nothing ( Name "y$1753" ) ] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [ ParamNamed Nothing ( Name "y$0" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "x$1752" ) ) )
-          ( Ref Nothing ( Local ( Name "y$1753" ) ) )
+          ( Ref Nothing ( Local ( Name "x$0" ) ) )
+          ( Ref Nothing ( Local ( Name "y$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Data.String.CodePoints", qnameName = Name "sub$w"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1749" ) :| [ ParamNamed Nothing ( Name "y$1750" ) ] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [ ParamNamed Nothing ( Name "y$0" ) ] )
         ( PrimBinOp Nothing PrimSub
-          ( Ref Nothing ( Local ( Name "x$1749" ) ) )
-          ( Ref Nothing ( Local ( Name "y$1750" ) ) )
+          ( Ref Nothing ( Local ( Name "x$0" ) ) )
+          ( Ref Nothing ( Local ( Name "y$0" ) ) )
         )
       ), Standalone
       ( QName
@@ -403,10 +403,10 @@ UberModule
           ( PropName "_unsafeCodePointAt0" )
         )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "s$24" ) :| [] )
+          ( ParamNamed Nothing ( Name "s$0" ) :| [] )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "cu0$25", AppN Nothing
+              ( Nothing, Name "cu0$0", AppN Nothing
                 ( Ref Nothing
                   ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "fromEnum" ) )
                 )
@@ -417,7 +417,7 @@ UberModule
                     )
                     ( LiteralInt Nothing 0 :| [] )
                   )
-                  ( Ref Nothing ( Local ( Name "s$24" ) ) :| [] ) :| []
+                  ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] ) :| []
                 )
               ) :| []
             )
@@ -438,7 +438,7 @@ UberModule
                         )
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                          [ LiteralInt Nothing 55296, Ref Nothing ( Local ( Name "cu0$25" ) ) ]
+                          [ LiteralInt Nothing 55296, Ref Nothing ( Local ( Name "cu0$0" ) ) ]
                         ) :| []
                       )
                     )
@@ -448,7 +448,7 @@ UberModule
                       )
                       ( Ref Nothing
                         ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                        [ Ref Nothing ( Local ( Name "cu0$25" ) ), LiteralInt Nothing 56319 ]
+                        [ Ref Nothing ( Local ( Name "cu0$0" ) ), LiteralInt Nothing 56319 ]
                       ) :| []
                     ) :| []
                   )
@@ -459,27 +459,27 @@ UberModule
                     ( AppN Nothing
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "x$1723", AppN Nothing
+                          ( Nothing, Name "x$0", AppN Nothing
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "length" ) )
                             )
-                            ( Ref Nothing ( Local ( Name "s$24" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] )
                           ) :| []
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "y$1724" ) :| [] )
+                          ( ParamNamed Nothing ( Name "y$0" ) :| [] )
                           ( IfThenElse Nothing
                             ( PrimBinOp Nothing PrimLt
-                              ( Ref Nothing ( Local ( Name "x$1723" ) ) )
-                              ( Ref Nothing ( Local ( Name "y$1724" ) ) )
+                              ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                              ( Ref Nothing ( Local ( Name "y$0" ) ) )
                             )
                             ( Ref Nothing
                               ( Imported ( ModuleName "Data.Ordering" ) ( Name "LT" ) )
                             )
                             ( IfThenElse Nothing
                               ( Eq Nothing
-                                ( Ref Nothing ( Local ( Name "x$1723" ) ) )
-                                ( Ref Nothing ( Local ( Name "y$1724" ) ) )
+                                ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "y$0" ) ) )
                               )
                               ( Ref Nothing
                                 ( Imported ( ModuleName "Data.Ordering" ) ( Name "EQ" ) )
@@ -498,7 +498,7 @@ UberModule
               )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "cu1$27", AppN Nothing
+                  ( Nothing, Name "cu1$0", AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "fromEnum" ) )
                     )
@@ -509,7 +509,7 @@ UberModule
                         )
                         ( LiteralInt Nothing 1 :| [] )
                       )
-                      ( Ref Nothing ( Local ( Name "s$24" ) ) :| [] ) :| []
+                      ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] ) :| []
                     )
                   ) :| []
                 )
@@ -525,7 +525,7 @@ UberModule
                         )
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                          [ LiteralInt Nothing 56320, Ref Nothing ( Local ( Name "cu1$27" ) ) ]
+                          [ LiteralInt Nothing 56320, Ref Nothing ( Local ( Name "cu1$0" ) ) ]
                         ) :| []
                       )
                     )
@@ -535,7 +535,7 @@ UberModule
                       )
                       ( Ref Nothing
                         ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
-                        [ Ref Nothing ( Local ( Name "cu1$27" ) ), LiteralInt Nothing 57343 ]
+                        [ Ref Nothing ( Local ( Name "cu1$0" ) ), LiteralInt Nothing 57343 ]
                       ) :| []
                     )
                   )
@@ -543,22 +543,22 @@ UberModule
                     ( PrimBinOp Nothing PrimAdd
                       ( PrimBinOp Nothing PrimMul
                         ( PrimBinOp Nothing PrimSub
-                          ( Ref Nothing ( Local ( Name "cu0$25" ) ) )
+                          ( Ref Nothing ( Local ( Name "cu0$0" ) ) )
                           ( LiteralInt Nothing 55296 )
                         )
                         ( LiteralInt Nothing 1024 )
                       )
                       ( PrimBinOp Nothing PrimSub
-                        ( Ref Nothing ( Local ( Name "cu1$27" ) ) )
+                        ( Ref Nothing ( Local ( Name "cu1$0" ) ) )
                         ( LiteralInt Nothing 56320 )
                       )
                     )
                     ( LiteralInt Nothing 65536 )
                   )
-                  ( Ref Nothing ( Local ( Name "cu0$25" ) ) )
+                  ( Ref Nothing ( Local ( Name "cu0$0" ) ) )
                 )
               )
-              ( Ref Nothing ( Local ( Name "cu0$25" ) ) )
+              ( Ref Nothing ( Local ( Name "cu0$0" ) ) )
             )
           ) :| []
         )
@@ -566,7 +566,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Data.String.CodePoints", qnameName = Name "fromCharCode"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1680" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AppN Nothing
           ( ObjectProp Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.String.CodeUnits" ) ( Name "foreign" ) ) )
@@ -574,7 +574,7 @@ UberModule
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "v$60", IfThenElse Nothing
+              ( Nothing, Name "v$0", IfThenElse Nothing
                 ( AppN Nothing
                   ( AppN Nothing
                     ( ObjectProp Nothing
@@ -593,7 +593,7 @@ UberModule
                       ( Ref Nothing
                         ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                         [ Ref Nothing
-                          ( Local ( Name "x$1680" ) ), AppN Nothing
+                          ( Local ( Name "x$0" ) ), AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                           )
@@ -611,7 +611,7 @@ UberModule
                     ( Ref Nothing
                       ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                       [ Ref Nothing
-                        ( Local ( Name "x$1680" ) ), AppN Nothing
+                        ( Local ( Name "x$0" ) ), AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) )
                         )
@@ -631,7 +631,7 @@ UberModule
                       ( Ref Nothing ( Imported ( ModuleName "Data.Enum" ) ( Name "foreign" ) ) )
                       ( PropName "fromCharCode" )
                     )
-                    ( Ref Nothing ( Local ( Name "x$1680" ) ) :| [] )
+                    ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] )
                   ]
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Data.Maybe" ) ( Name "Nothing" ) ) )
@@ -640,16 +640,16 @@ UberModule
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$60" ) ) ) )
+                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
               )
-              ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$60" ) ) ) )
+              ( DataArgumentByIndex Nothing SumType 0 ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
               ( IfThenElse Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Data.Ord" ) ( Name "lessThan$w" ) ) )
                   ( Ref Nothing
                     ( Imported ( ModuleName "Data.Ord" ) ( Name "ordInt" ) ) :|
                     [ Ref Nothing
-                      ( Local ( Name "x$1680" ) ), AppN Nothing
+                      ( Local ( Name "x$0" ) ), AppN Nothing
                       ( Ref Nothing ( Imported ( ModuleName "Data.Enum" ) ( Name "toCharCode" ) ) )
                       ( Ref Nothing
                         ( Imported ( ModuleName "Data.Bounded" ) ( Name "bottomChar" ) ) :| []
@@ -797,12 +797,12 @@ UberModule
             ( LiteralObject Nothing
               [
                 ( PropName "eq", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "x$17" ) :| [] )
+                  ( ParamNamed Nothing ( Name "x$0" ) :| [] )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "y$18" ) :| [] )
+                    ( ParamNamed Nothing ( Name "y$0" ) :| [] )
                     ( Eq Nothing
-                      ( Ref Nothing ( Local ( Name "x$17" ) ) )
-                      ( Ref Nothing ( Local ( Name "y$18" ) ) )
+                      ( Ref Nothing ( Local ( Name "x$0" ) ) )
+                      ( Ref Nothing ( Local ( Name "y$0" ) ) )
                     )
                   )
                 )
@@ -883,7 +883,7 @@ UberModule
               ( LiteralString Nothing "" )
               ( Let Nothing
                 ( Standalone
-                  ( Nothing, Name "v2$14", AppN Nothing
+                  ( Nothing, Name "v2$0", AppN Nothing
                     ( Ref Nothing
                       ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                     )
@@ -893,7 +893,7 @@ UberModule
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$14" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
                   )
                   ( PrimBinOp Nothing PrimConcat
                     ( AppN Nothing
@@ -902,7 +902,7 @@ UberModule
                       )
                       ( ObjectProp Nothing
                         ( DataArgumentByIndex Nothing SumType 0
-                          ( Ref Nothing ( Local ( Name "v2$14" ) ) )
+                          ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                         )
                         ( PropName "head" ) :| []
                       )
@@ -919,7 +919,7 @@ UberModule
                         ( LiteralInt Nothing 1 ) :|
                         [ ObjectProp Nothing
                           ( DataArgumentByIndex Nothing SumType 0
-                            ( Ref Nothing ( Local ( Name "v2$14" ) ) )
+                            ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                           )
                           ( PropName "tail" )
                         ]
@@ -1014,7 +1014,7 @@ UberModule
             ( PropName "_toCodePointArray" )
           )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "s$7" ) :| [] )
+            ( ParamNamed Nothing ( Name "s$0" ) :| [] )
             ( AppN Nothing
               ( AppN Nothing
                 ( AppN Nothing
@@ -1028,10 +1028,10 @@ UberModule
                           ( PropName "unfoldrArrayImpl" )
                         )
                         ( AbsN Nothing
-                          ( ParamNamed Nothing ( Name "v2$1518" ) :| [] )
+                          ( ParamNamed Nothing ( Name "v2$0" ) :| [] )
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$1518" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v2$0" ) ) ) )
                           ) :| []
                         )
                       )
@@ -1042,14 +1042,14 @@ UberModule
                         ( AbsN Nothing
                           ( ParamUnused Nothing :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "v$1608" ) :| [] )
+                            ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                             ( IfThenElse Nothing
                               ( Eq Nothing
                                 ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1608" ) ) ) )
+                                ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
                               )
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v$1608" ) ) )
+                                ( Ref Nothing ( Local ( Name "v$0" ) ) )
                               )
                               ( Exception Nothing "No patterns matched" )
                             )
@@ -1058,34 +1058,34 @@ UberModule
                       )
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "v$1516" ) :| [] )
+                      ( ParamNamed Nothing ( Name "v$1" ) :| [] )
                       ( DataArgumentByIndex Nothing ProductType 0
-                        ( Ref Nothing ( Local ( Name "v$1516" ) ) )
+                        ( Ref Nothing ( Local ( Name "v$1" ) ) )
                       ) :| []
                     )
                   )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "v$1517" ) :| [] )
+                    ( ParamNamed Nothing ( Name "v$2" ) :| [] )
                     ( DataArgumentByIndex Nothing ProductType 1
-                      ( Ref Nothing ( Local ( Name "v$1517" ) ) )
+                      ( Ref Nothing ( Local ( Name "v$2" ) ) )
                     ) :| []
                   )
                 )
                 ( AbsN Nothing
-                  ( ParamNamed Nothing ( Name "s$8" ) :| [] )
+                  ( ParamNamed Nothing ( Name "s$1" ) :| [] )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$1611", AppN Nothing
+                      ( Nothing, Name "v1$0", AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                         )
-                        ( Ref Nothing ( Local ( Name "s$8" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "s$1" ) ) :| [] )
                       ) :| []
                     )
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1611" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$0" ) ) ) )
                       )
                       ( Ctor Nothing SumType
                         ( ModuleName "Data.Maybe" )
@@ -1097,11 +1097,11 @@ UberModule
                           ( CtorName "Tuple" )
                           [ ObjectProp Nothing
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1611" ) ) )
+                              ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                             )
                             ( PropName "head" ), ObjectProp Nothing
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$1611" ) ) )
+                              ( Ref Nothing ( Local ( Name "v1$0" ) ) )
                             )
                             ( PropName "tail" )
                           ]
@@ -1112,7 +1112,7 @@ UberModule
                   ) :| []
                 )
               )
-              ( Ref Nothing ( Local ( Name "s$7" ) ) :| [] )
+              ( Ref Nothing ( Local ( Name "s$0" ) ) :| [] )
             ) :| []
           )
         )
@@ -1370,7 +1370,7 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "succ", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "a$1588" ) :| [] )
+                    ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                     ( AppN Nothing
                       ( ObjectProp Nothing
                         ( Ref Nothing
@@ -1392,14 +1392,14 @@ UberModule
                             )
                             ( PropName "fromEnum" )
                           )
-                          ( Ref Nothing ( Local ( Name "a$1588" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                         )
                         ( LiteralInt Nothing 1 ) :| []
                       )
                     )
                   ),
                   ( PropName "pred", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "a$1596" ) :| [] )
+                    ( ParamNamed Nothing ( Name "a$1" ) :| [] )
                     ( AppN Nothing
                       ( ObjectProp Nothing
                         ( Ref Nothing
@@ -1421,7 +1421,7 @@ UberModule
                             )
                             ( PropName "fromEnum" )
                           )
-                          ( Ref Nothing ( Local ( Name "a$1596" ) ) :| [] )
+                          ( Ref Nothing ( Local ( Name "a$1" ) ) :| [] )
                         )
                         ( LiteralInt Nothing 1 ) :| []
                       )
@@ -1465,7 +1465,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "logShow$p2$1556" ) :| [] )
+        ( ParamNamed Nothing ( Name "logShow$p2$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -1473,32 +1473,32 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showArrayImpl" ) ) )
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) :| [] )
             )
-            ( Ref Nothing ( Local ( Name "logShow$p2$1556" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "logShow1"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "logShow$p2$1551" ) :| [] )
+        ( ParamNamed Nothing ( Name "logShow$p2$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "logShow$p2$1551" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "logShow2"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "logShow$p2$1546" ) :| [] )
+        ( ParamNamed Nothing ( Name "logShow$p2$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( IfThenElse Nothing
             ( Eq Nothing
               ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "logShow$p2$1546" ) ) ) )
+              ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) ) )
             )
             ( PrimBinOp Nothing PrimConcat
               ( LiteralString Nothing "(Just " )
@@ -1506,7 +1506,7 @@ UberModule
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "logShow$p2$1546" ) ) ) :| []
+                    ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) ) :| []
                   )
                 )
                 ( LiteralString Nothing ")" )
@@ -1519,21 +1519,21 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "cp"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1535" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Partial.Unsafe" ) ( Name "_unsafePartial" ) ) )
             ( AbsN Nothing
               ( ParamUnused Nothing :| [] )
               ( AbsN Nothing
-                ( ParamNamed Nothing ( Name "v$1531" ) :| [] )
+                ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                 ( IfThenElse Nothing
                   ( Eq Nothing
                     ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$1531" ) ) ) )
+                    ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 0
-                    ( Ref Nothing ( Local ( Name "v$1531" ) ) )
+                    ( Ref Nothing ( Local ( Name "v$0" ) ) )
                   )
                   ( Exception Nothing "No patterns matched" )
                 )
@@ -1547,14 +1547,14 @@ UberModule
               )
               ( PropName "toEnum" )
             )
-            ( Ref Nothing ( Local ( Name "x$1535" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.StringCodePoints.Test", qnameName = Name "codes"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1529" ) :| [] )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
         ( AppN Nothing
           ( AppN Nothing
             ( ObjectProp Nothing
@@ -1569,7 +1569,7 @@ UberModule
             ( Ref Nothing
               ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "toCodePointArray" ) )
             )
-            ( Ref Nothing ( Local ( Name "x$1529" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "x$0" ) ) :| [] ) :| []
           )
         )
       )
@@ -1680,7 +1680,7 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$2051", AppN Nothing
+                      ( Nothing, Name "v1$0", AppN Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Data.String.CodePoints" )
@@ -1693,7 +1693,7 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2051" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$0" ) ) ) )
                       )
                       ( Ctor Nothing SumType
                         ( ModuleName "Data.Maybe" )
@@ -1707,7 +1707,7 @@ UberModule
                             )
                           )
                           ( DataArgumentByIndex Nothing SumType 0
-                            ( Ref Nothing ( Local ( Name "v1$2051" ) ) ) :| []
+                            ( Ref Nothing ( Local ( Name "v1$0" ) ) ) :| []
                           )
                         ]
                       )
@@ -1724,7 +1724,7 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$2055", AppN Nothing
+                      ( Nothing, Name "v1$1", AppN Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Data.String.CodePoints" )
@@ -1737,7 +1737,7 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2055" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$1" ) ) ) )
                       )
                       ( Ctor Nothing SumType
                         ( ModuleName "Data.Maybe" )
@@ -1751,7 +1751,7 @@ UberModule
                             )
                           )
                           ( DataArgumentByIndex Nothing SumType 0
-                            ( Ref Nothing ( Local ( Name "v1$2055" ) ) ) :| []
+                            ( Ref Nothing ( Local ( Name "v1$1" ) ) ) :| []
                           )
                         ]
                       )
@@ -1768,7 +1768,7 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$2059", AppN Nothing
+                      ( Nothing, Name "v1$2", AppN Nothing
                         ( Ref Nothing
                           ( Imported
                             ( ModuleName "Data.String.CodePoints" )
@@ -1781,7 +1781,7 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2059" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2" ) ) ) )
                       )
                       ( Ctor Nothing SumType
                         ( ModuleName "Data.Maybe" )
@@ -1795,7 +1795,7 @@ UberModule
                             )
                           )
                           ( DataArgumentByIndex Nothing SumType 0
-                            ( Ref Nothing ( Local ( Name "v1$2059" ) ) ) :| []
+                            ( Ref Nothing ( Local ( Name "v1$2" ) ) ) :| []
                           )
                         ]
                       )
@@ -1812,7 +1812,7 @@ UberModule
                   )
                   ( Let Nothing
                     ( Standalone
-                      ( Nothing, Name "v1$2063", AppN Nothing
+                      ( Nothing, Name "v1$3", AppN Nothing
                         ( Ref Nothing
                           ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                         )
@@ -1822,7 +1822,7 @@ UberModule
                     ( IfThenElse Nothing
                       ( Eq Nothing
                         ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2063" ) ) ) )
+                        ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$3" ) ) ) )
                       )
                       ( Ctor Nothing SumType
                         ( ModuleName "Data.Maybe" )
@@ -1837,7 +1837,7 @@ UberModule
                           )
                           ( ObjectProp Nothing
                             ( DataArgumentByIndex Nothing SumType 0
-                              ( Ref Nothing ( Local ( Name "v1$2063" ) ) )
+                              ( Ref Nothing ( Local ( Name "v1$3" ) ) )
                             )
                             ( PropName "head" ) :| []
                           )
@@ -1855,11 +1855,11 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$2070" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                         ( IfThenElse Nothing
                           ( Eq Nothing
                             ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$2070" ) ) ) )
+                            ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v$0" ) ) ) )
                           )
                           ( PrimBinOp Nothing PrimConcat
                             ( LiteralString Nothing "(Just " )
@@ -1877,7 +1877,7 @@ UberModule
                                   )
                                 )
                                 ( DataArgumentByIndex Nothing SumType 0
-                                  ( Ref Nothing ( Local ( Name "v$2070" ) ) ) :| []
+                                  ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
                                 )
                               )
                               ( LiteralString Nothing ")" )
@@ -1889,7 +1889,7 @@ UberModule
                     ] :|
                     [ Let Nothing
                       ( Standalone
-                        ( Nothing, Name "v1$2081", AppN Nothing
+                        ( Nothing, Name "v1$4", AppN Nothing
                           ( Ref Nothing
                             ( Imported ( ModuleName "Data.String.CodePoints" ) ( Name "uncons" ) )
                           )
@@ -1899,7 +1899,7 @@ UberModule
                       ( IfThenElse Nothing
                         ( Eq Nothing
                           ( LiteralString Nothing "Data.Maybe∷Maybe.Just" )
-                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$2081" ) ) ) )
+                          ( ReflectCtor Nothing ( Ref Nothing ( Local ( Name "v1$4" ) ) ) )
                         )
                         ( Ctor Nothing SumType
                           ( ModuleName "Data.Maybe" )
@@ -1914,7 +1914,7 @@ UberModule
                             )
                             ( ObjectProp Nothing
                               ( DataArgumentByIndex Nothing SumType 0
-                                ( Ref Nothing ( Local ( Name "v1$2081" ) ) )
+                                ( Ref Nothing ( Local ( Name "v1$4" ) ) )
                               )
                               ( PropName "tail" ) :| []
                             )
@@ -1933,9 +1933,9 @@ UberModule
                   ( LiteralObject Nothing
                     [
                       ( PropName "show", AbsN Nothing
-                        ( ParamNamed Nothing ( Name "v$1225" ) :| [] )
+                        ( ParamNamed Nothing ( Name "v$1" ) :| [] )
                         ( IfThenElse Nothing
-                          ( Ref Nothing ( Local ( Name "v$1225" ) ) )
+                          ( Ref Nothing ( Local ( Name "v$1" ) ) )
                           ( LiteralString Nothing "true" )
                           ( LiteralString Nothing "false" )
                         )

--- a/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
+++ b/test/ps/output/Golden.TailRecM2Shadow.Test/golden.ir
@@ -102,9 +102,9 @@ UberModule
               ( LiteralObject Nothing
                 [
                   ( PropName "map", AbsN Nothing
-                    ( ParamNamed Nothing ( Name "f$498" ) :| [] )
+                    ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "a$499" ) :| [] )
+                      ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                       ( AppN Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
@@ -128,10 +128,10 @@ UberModule
                               )
                               ( PropName "pure" )
                             )
-                            ( Ref Nothing ( Local ( Name "f$498" ) ) :| [] ) :| []
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] ) :| []
                           )
                         )
-                        ( Ref Nothing ( Local ( Name "a$499" ) ) :| [] )
+                        ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                       )
                     )
                   )
@@ -152,7 +152,7 @@ UberModule
                 [
                   ( PropName "apply", Let Nothing
                     ( Standalone
-                      ( Nothing, Name "bind$218", ObjectProp Nothing
+                      ( Nothing, Name "bind$0", ObjectProp Nothing
                         ( AppN Nothing
                           ( ObjectProp Nothing
                             ( Ref Nothing
@@ -168,23 +168,23 @@ UberModule
                       ) :| []
                     )
                     ( AbsN Nothing
-                      ( ParamNamed Nothing ( Name "f$220" ) :| [] )
+                      ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                       ( AbsN Nothing
-                        ( ParamNamed Nothing ( Name "a$221" ) :| [] )
+                        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                         ( AppN Nothing
                           ( AppN Nothing
-                            ( Ref Nothing ( Local ( Name "bind$218" ) ) )
-                            ( Ref Nothing ( Local ( Name "f$220" ) ) :| [] )
+                            ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                            ( Ref Nothing ( Local ( Name "f$0" ) ) :| [] )
                           )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "f'$222" ) :| [] )
+                            ( ParamNamed Nothing ( Name "f'$0" ) :| [] )
                             ( AppN Nothing
                               ( AppN Nothing
-                                ( Ref Nothing ( Local ( Name "bind$218" ) ) )
-                                ( Ref Nothing ( Local ( Name "a$221" ) ) :| [] )
+                                ( Ref Nothing ( Local ( Name "bind$0" ) ) )
+                                ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                               )
                               ( AbsN Nothing
-                                ( ParamNamed Nothing ( Name "a'$223" ) :| [] )
+                                ( ParamNamed Nothing ( Name "a'$0" ) :| [] )
                                 ( AppN Nothing
                                   ( ObjectProp Nothing
                                     ( AppN Nothing
@@ -207,8 +207,8 @@ UberModule
                                     ( PropName "pure" )
                                   )
                                   ( AppN Nothing
-                                    ( Ref Nothing ( Local ( Name "f'$222" ) ) )
-                                    ( Ref Nothing ( Local ( Name "a'$223" ) ) :| [] ) :| []
+                                    ( Ref Nothing ( Local ( Name "f'$0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "a'$0" ) ) :| [] ) :| []
                                   )
                                 ) :| []
                               )
@@ -273,24 +273,24 @@ UberModule
                     ( PropName "tailRecM" )
                   )
                   ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "o$475" ) :| [] )
+                    ( ParamNamed Nothing ( Name "o$0" ) :| [] )
                     ( Let Nothing
                       ( Standalone
-                        ( Nothing, Name "$cse607", ObjectProp Nothing
-                          ( Ref Nothing ( Local ( Name "o$475" ) ) )
+                        ( Nothing, Name "$cse0", ObjectProp Nothing
+                          ( Ref Nothing ( Local ( Name "o$0" ) ) )
                           ( PropName "a" )
                         ) :| []
                       )
                       ( Let Nothing
                         ( Standalone
-                          ( Nothing, Name "$cse606", ObjectProp Nothing
-                            ( Ref Nothing ( Local ( Name "o$475" ) ) )
+                          ( Nothing, Name "$cse1", ObjectProp Nothing
+                            ( Ref Nothing ( Local ( Name "o$0" ) ) )
                             ( PropName "b" )
                           ) :| []
                         )
                         ( IfThenElse Nothing
                           ( PrimBinOp Nothing PrimLt
-                            ( Ref Nothing ( Local ( Name "$cse606" ) ) )
+                            ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                             ( Ref Nothing ( Local ( Name "n" ) ) )
                           )
                           ( AppN Nothing
@@ -302,11 +302,11 @@ UberModule
                               [ LiteralObject Nothing
                                 [
                                   ( PropName "a", PrimBinOp Nothing PrimAdd
-                                    ( Ref Nothing ( Local ( Name "$cse607" ) ) )
-                                    ( Ref Nothing ( Local ( Name "$cse606" ) ) )
+                                    ( Ref Nothing ( Local ( Name "$cse0" ) ) )
+                                    ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                                   ),
                                   ( PropName "b", PrimBinOp Nothing PrimAdd
-                                    ( Ref Nothing ( Local ( Name "$cse606" ) ) )
+                                    ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                                     ( LiteralInt Nothing 1 )
                                   )
                                 ]
@@ -319,7 +319,7 @@ UberModule
                               ( ModuleName "Control.Monad.Rec.Class" )
                               ( TyName "Step" )
                               ( CtorName "Done" )
-                              [ Ref Nothing ( Local ( Name "$cse607" ) ) ] :| []
+                              [ Ref Nothing ( Local ( Name "$cse0" ) ) ] :| []
                             )
                           )
                         )
@@ -357,14 +357,14 @@ UberModule
                     ( LiteralObject Nothing
                       [
                         ( PropName "tailRecM", AbsN Nothing
-                          ( ParamNamed Nothing ( Name "f$11" ) :| [] )
+                          ( ParamNamed Nothing ( Name "f$0" ) :| [] )
                           ( AbsN Nothing
-                            ( ParamNamed Nothing ( Name "a$12" ) :| [] )
+                            ( ParamNamed Nothing ( Name "a$0" ) :| [] )
                             ( AbsN Nothing
                               ( ParamUnused Nothing :| [] )
                               ( Let Nothing
                                 ( Standalone
-                                  ( Nothing, Name "r$16", AppN Nothing
+                                  ( Nothing, Name "r$1", AppN Nothing
                                     ( AppN Nothing
                                       ( AppN Nothing
                                         ( ObjectProp Nothing
@@ -377,8 +377,8 @@ UberModule
                                           ( PropName "bind" )
                                         )
                                         ( AppN Nothing
-                                          ( Ref Nothing ( Local ( Name "f$11" ) ) )
-                                          ( Ref Nothing ( Local ( Name "a$12" ) ) :| [] ) :| []
+                                          ( Ref Nothing ( Local ( Name "f$0" ) ) )
+                                          ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
                                         )
                                       )
                                       ( ObjectProp Nothing
@@ -411,7 +411,7 @@ UberModule
                                           ( ParamUnused Nothing :| [] )
                                           ( Let Nothing
                                             ( Standalone
-                                              ( Nothing, Name "v0$17", AppN Nothing
+                                              ( Nothing, Name "v0$0", AppN Nothing
                                                 ( AppN Nothing
                                                   ( Ref Nothing
                                                     ( Imported
@@ -419,7 +419,7 @@ UberModule
                                                       ( Name "read" )
                                                     )
                                                   )
-                                                  ( Ref Nothing ( Local ( Name "r$16" ) ) :| [] )
+                                                  ( Ref Nothing ( Local ( Name "r$1" ) ) :| [] )
                                                 )
                                                 ( Ref Nothing
                                                   ( Imported
@@ -433,7 +433,7 @@ UberModule
                                               ( Eq Nothing
                                                 ( LiteralString Nothing "Control.Monad.Rec.Class∷Step.Loop" )
                                                 ( ReflectCtor Nothing
-                                                  ( Ref Nothing ( Local ( Name "v0$17" ) ) )
+                                                  ( Ref Nothing ( Local ( Name "v0$0" ) ) )
                                                 )
                                               )
                                               ( AppN Nothing
@@ -441,12 +441,12 @@ UberModule
                                                   ( ParamUnused Nothing :| [] )
                                                   ( Let Nothing
                                                     ( Standalone
-                                                      ( Nothing, Name "e$19", AppN Nothing
+                                                      ( Nothing, Name "e$0", AppN Nothing
                                                         ( AppN Nothing
-                                                          ( Ref Nothing ( Local ( Name "f$11" ) ) )
+                                                          ( Ref Nothing ( Local ( Name "f$0" ) ) )
                                                           ( DataArgumentByIndex Nothing SumType 0
                                                             ( Ref Nothing
-                                                              ( Local ( Name "v0$17" ) )
+                                                              ( Local ( Name "v0$0" ) )
                                                             ) :| []
                                                           )
                                                         )
@@ -471,11 +471,11 @@ UberModule
                                                                 ( PropName "write" )
                                                               )
                                                               ( Ref Nothing
-                                                                ( Local ( Name "e$19" ) ) :| []
+                                                                ( Local ( Name "e$0" ) ) :| []
                                                               )
                                                             )
                                                             ( Ref Nothing
-                                                              ( Local ( Name "r$16" ) ) :| []
+                                                              ( Local ( Name "r$1" ) ) :| []
                                                             )
                                                           )
                                                           ( Ref Nothing
@@ -551,16 +551,16 @@ UberModule
                                         ( AbsN Nothing
                                           ( ParamUnused Nothing :| [] )
                                           ( AbsN Nothing
-                                            ( ParamNamed Nothing ( Name "v$20" ) :| [] )
+                                            ( ParamNamed Nothing ( Name "v$0" ) :| [] )
                                             ( IfThenElse Nothing
                                               ( Eq Nothing
                                                 ( LiteralString Nothing "Control.Monad.Rec.Class∷Step.Done" )
                                                 ( ReflectCtor Nothing
-                                                  ( Ref Nothing ( Local ( Name "v$20" ) ) )
+                                                  ( Ref Nothing ( Local ( Name "v$0" ) ) )
                                                 )
                                               )
                                               ( DataArgumentByIndex Nothing SumType 0
-                                                ( Ref Nothing ( Local ( Name "v$20" ) ) )
+                                                ( Ref Nothing ( Local ( Name "v$0" ) ) )
                                               )
                                               ( Exception Nothing "No patterns matched" )
                                             )
@@ -572,7 +572,7 @@ UberModule
                                       ( Ref Nothing
                                         ( Imported ( ModuleName "Effect.Ref" ) ( Name "read" ) )
                                       )
-                                      ( Ref Nothing ( Local ( Name "r$16" ) ) :| [] ) :| []
+                                      ( Ref Nothing ( Local ( Name "r$1" ) ) :| [] ) :| []
                                     )
                                   )
                                   ( Ref Nothing

--- a/test/ps/output/Golden.UncurriedLift.Test/golden.ir
+++ b/test/ps/output/Golden.UncurriedLift.Test/golden.ir
@@ -28,7 +28,7 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$2" ) :| [] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
@@ -36,41 +36,41 @@ UberModule
               ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "foreign" ) ) )
               ( PropName "showIntImpl" )
             )
-            ( Ref Nothing ( Local ( Name "a$2" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "sumST"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$699" ) :| [ ParamNamed Nothing ( Name "b$700" ) ] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [ ParamNamed Nothing ( Name "b$0" ) ] )
         ( PrimBinOp Nothing PrimAdd
-          ( Ref Nothing ( Local ( Name "a$699" ) ) )
-          ( Ref Nothing ( Local ( Name "b$700" ) ) )
+          ( Ref Nothing ( Local ( Name "a$0" ) ) )
+          ( Ref Nothing ( Local ( Name "b$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "mulByFn"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$690" ) :| [ ParamNamed Nothing ( Name "b$691" ) ] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [ ParamNamed Nothing ( Name "b$0" ) ] )
         ( PrimBinOp Nothing PrimMul
-          ( Ref Nothing ( Local ( Name "a$690" ) ) )
-          ( Ref Nothing ( Local ( Name "b$691" ) ) )
+          ( Ref Nothing ( Local ( Name "a$0" ) ) )
+          ( Ref Nothing ( Local ( Name "b$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "mul2"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$693" ) :| [ ParamNamed Nothing ( Name "b$694" ) ] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [ ParamNamed Nothing ( Name "b$0" ) ] )
         ( PrimBinOp Nothing PrimMul
-          ( Ref Nothing ( Local ( Name "a$693" ) ) )
-          ( Ref Nothing ( Local ( Name "b$694" ) ) )
+          ( Ref Nothing ( Local ( Name "a$0" ) ) )
+          ( Ref Nothing ( Local ( Name "b$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "logTwice"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "a$665" ) :| [ ParamNamed Nothing ( Name "b$666" ) ] )
+        ( ParamNamed Nothing ( Name "a$0" ) :| [ ParamNamed Nothing ( Name "b$0" ) ] )
         ( AppN Nothing
           ( AbsN Nothing
             ( ParamUnused Nothing :| [] )
@@ -79,7 +79,7 @@ UberModule
                 ( Nothing, Name "_", AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
-                    ( Ref Nothing ( Local ( Name "a$665" ) ) :| [] )
+                    ( Ref Nothing ( Local ( Name "a$0" ) ) :| [] )
                   )
                   ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
                 ) :| []
@@ -87,7 +87,7 @@ UberModule
               ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
-                  ( Ref Nothing ( Local ( Name "b$666" ) ) :| [] )
+                  ( Ref Nothing ( Local ( Name "b$0" ) ) :| [] )
                 )
                 ( Ref Nothing ( Imported ( ModuleName "Prim" ) ( Name "$magicDoRun" ) ) :| [] )
               )
@@ -100,24 +100,24 @@ UberModule
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "add3"
         }, AbsN Nothing
         ( ParamNamed Nothing
-          ( Name "a$686" ) :|
-          [ ParamNamed Nothing ( Name "b$687" ), ParamNamed Nothing ( Name "c$688" ) ]
+          ( Name "a$0" ) :|
+          [ ParamNamed Nothing ( Name "b$0" ), ParamNamed Nothing ( Name "c$0" ) ]
         )
         ( PrimBinOp Nothing PrimAdd
           ( PrimBinOp Nothing PrimAdd
-            ( Ref Nothing ( Local ( Name "a$686" ) ) )
-            ( Ref Nothing ( Local ( Name "b$687" ) ) )
+            ( Ref Nothing ( Local ( Name "a$0" ) ) )
+            ( Ref Nothing ( Local ( Name "b$0" ) ) )
           )
-          ( Ref Nothing ( Local ( Name "c$688" ) ) )
+          ( Ref Nothing ( Local ( Name "c$0" ) ) )
         )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurriedLift.Test", qnameName = Name "addOnePlusTwoTo"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "c$674" ) :| [] )
+        ( ParamNamed Nothing ( Name "c$0" ) :| [] )
         ( PrimBinOp Nothing PrimAdd
           ( LiteralInt Nothing 3 )
-          ( Ref Nothing ( Local ( Name "c$674" ) ) )
+          ( Ref Nothing ( Local ( Name "c$0" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =

--- a/test/ps/output/Golden.Uncurry.Test/golden.ir
+++ b/test/ps/output/Golden.Uncurry.Test/golden.ir
@@ -63,12 +63,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "logShow$p2$214" ) :| [] )
+        ( ParamNamed Nothing ( Name "logShow$p2$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "logShow$p2$214" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -198,13 +198,13 @@ UberModule
         }, AbsN Nothing
         ( ParamNamed Nothing ( Name "x" ) :| [ ParamNamed Nothing ( Name "y" ) ] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "y$237" ) :| [] )
+          ( ParamNamed Nothing ( Name "y$0" ) :| [] )
           ( PrimBinOp Nothing PrimAdd
             ( PrimBinOp Nothing PrimAdd
               ( Ref Nothing ( Local ( Name "x" ) ) )
               ( Ref Nothing ( Local ( Name "y" ) ) )
             )
-            ( Ref Nothing ( Local ( Name "y$237" ) ) )
+            ( Ref Nothing ( Local ( Name "y$0" ) ) )
           )
         )
       ), Standalone
@@ -244,10 +244,10 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.Uncurry.Test", qnameName = Name "inc"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "add3$p3$217" ) :| [] )
+        ( ParamNamed Nothing ( Name "add3$p3$0" ) :| [] )
         ( PrimBinOp Nothing PrimAdd
           ( LiteralInt Nothing 1 )
-          ( Ref Nothing ( Local ( Name "add3$p3$217" ) ) )
+          ( Ref Nothing ( Local ( Name "add3$p3$0" ) ) )
         )
       )
     ], uberModuleForeigns = [], uberModuleExports =
@@ -266,26 +266,26 @@ UberModule
         ( Imported ( ModuleName "Golden.Uncurry.Test" ) ( Name "sumTo" ) )
       ),
       ( Name "adderOf", AbsN Nothing
-        ( ParamNamed Nothing ( Name "adderOf$p1$209" ) :| [] )
+        ( ParamNamed Nothing ( Name "adderOf$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "adderOf$p2$210" ) :| [] )
+          ( ParamNamed Nothing ( Name "adderOf$p2$0" ) :| [] )
           ( AbsN Nothing
-            ( ParamNamed Nothing ( Name "y$265" ) :| [] )
+            ( ParamNamed Nothing ( Name "y$0" ) :| [] )
             ( PrimBinOp Nothing PrimAdd
               ( PrimBinOp Nothing PrimAdd
-                ( Ref Nothing ( Local ( Name "adderOf$p1$209" ) ) )
-                ( Ref Nothing ( Local ( Name "adderOf$p2$210" ) ) )
+                ( Ref Nothing ( Local ( Name "adderOf$p1$0" ) ) )
+                ( Ref Nothing ( Local ( Name "adderOf$p2$0" ) ) )
               )
-              ( Ref Nothing ( Local ( Name "y$265" ) ) )
+              ( Ref Nothing ( Local ( Name "y$0" ) ) )
             )
           )
         )
       ),
       ( Name "alwaysFirst", AbsN Nothing
-        ( ParamNamed Nothing ( Name "alwaysFirst$p1$211" ) :| [] )
+        ( ParamNamed Nothing ( Name "alwaysFirst$p1$0" ) :| [] )
         ( AbsN Nothing
           ( ParamUnused Nothing :| [] )
-          ( Ref Nothing ( Local ( Name "alwaysFirst$p1$211" ) ) )
+          ( Ref Nothing ( Local ( Name "alwaysFirst$p1$0" ) ) )
         )
       ),
       ( Name "main", AbsN Nothing

--- a/test/ps/output/Golden.UncurryCtor.Test/golden.ir
+++ b/test/ps/output/Golden.UncurryCtor.Test/golden.ir
@@ -63,12 +63,12 @@ UberModule
       ( QName
         { qnameModuleName = ModuleName "Golden.UncurryCtor.Test", qnameName = Name "logShow"
         }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "logShow$p2$319" ) :| [] )
+        ( ParamNamed Nothing ( Name "logShow$p2$0" ) :| [] )
         ( AppN Nothing
           ( Ref Nothing ( Imported ( ModuleName "Effect.Console" ) ( Name "log" ) ) )
           ( AppN Nothing
             ( Ref Nothing ( Imported ( ModuleName "Data.Show" ) ( Name "showIntImpl" ) ) )
-            ( Ref Nothing ( Local ( Name "logShow$p2$319" ) ) :| [] ) :| []
+            ( Ref Nothing ( Local ( Name "logShow$p2$0" ) ) :| [] ) :| []
           )
         )
       ), Standalone
@@ -254,31 +254,31 @@ UberModule
         ( ParamNamed Nothing ( Name "v" ) :| [] )
         ( Let Nothing
           ( Standalone
-            ( Nothing, Name "$cse585", DataArgumentByIndex Nothing SumType 0
+            ( Nothing, Name "$cse0", DataArgumentByIndex Nothing SumType 0
               ( Ref Nothing ( Local ( Name "v" ) ) )
             ) :| []
           )
           ( Let Nothing
             ( Standalone
-              ( Nothing, Name "$cse584", ReflectCtor Nothing
+              ( Nothing, Name "$cse1", ReflectCtor Nothing
                 ( Ref Nothing ( Local ( Name "v" ) ) )
               ) :| []
             )
             ( IfThenElse Nothing
               ( Eq Nothing
                 ( LiteralString Nothing "Golden.UncurryCtor.Test∷Shape.Origin" )
-                ( Ref Nothing ( Local ( Name "$cse584" ) ) )
+                ( Ref Nothing ( Local ( Name "$cse1" ) ) )
               )
               ( LiteralInt Nothing 0 )
               ( IfThenElse Nothing
                 ( Eq Nothing
                   ( LiteralString Nothing "Golden.UncurryCtor.Test∷Shape.Dot" )
-                  ( Ref Nothing ( Local ( Name "$cse584" ) ) )
+                  ( Ref Nothing ( Local ( Name "$cse1" ) ) )
                 )
-                ( Ref Nothing ( Local ( Name "$cse585" ) ) )
+                ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                 ( PrimBinOp Nothing PrimAdd
                   ( PrimBinOp Nothing PrimAdd
-                    ( Ref Nothing ( Local ( Name "$cse585" ) ) )
+                    ( Ref Nothing ( Local ( Name "$cse0" ) ) )
                     ( DataArgumentByIndex Nothing SumType 1 ( Ref Nothing ( Local ( Name "v" ) ) ) )
                   )
                   ( DataArgumentByIndex Nothing SumType 2 ( Ref Nothing ( Local ( Name "v" ) ) ) )
@@ -300,38 +300,38 @@ UberModule
         ( Imported ( ModuleName "Golden.UncurryCtor.Test" ) ( Name "Tri" ) )
       ),
       ( Name "Pair", AbsN Nothing
-        ( ParamNamed Nothing ( Name "Pair$p1$316" ) :| [] )
+        ( ParamNamed Nothing ( Name "Pair$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "Pair$p2$317" ) :| [] )
+          ( ParamNamed Nothing ( Name "Pair$p2$0" ) :| [] )
           ( Ctor Nothing ProductType
             ( ModuleName "Golden.UncurryCtor.Test" )
             ( TyName "Pair" )
             ( CtorName "Pair" )
             [ Ref Nothing
-              ( Local ( Name "Pair$p1$316" ) ), Ref Nothing
-              ( Local ( Name "Pair$p2$317" ) )
+              ( Local ( Name "Pair$p1$0" ) ), Ref Nothing
+              ( Local ( Name "Pair$p2$0" ) )
             ]
           )
         )
       ),
       ( Name "Boxed", AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$1" ) :| [] )
-        ( Ref Nothing ( Local ( Name "x$1" ) ) )
+        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
+        ( Ref Nothing ( Local ( Name "x$0" ) ) )
       ),
       ( Name "Nil", Ref Nothing
         ( Imported ( ModuleName "Golden.UncurryCtor.Test" ) ( Name "Nil" ) )
       ),
       ( Name "Cons", AbsN Nothing
-        ( ParamNamed Nothing ( Name "Cons$p1$314" ) :| [] )
+        ( ParamNamed Nothing ( Name "Cons$p1$0" ) :| [] )
         ( AbsN Nothing
-          ( ParamNamed Nothing ( Name "Cons$p2$315" ) :| [] )
+          ( ParamNamed Nothing ( Name "Cons$p2$0" ) :| [] )
           ( Ctor Nothing SumType
             ( ModuleName "Golden.UncurryCtor.Test" )
             ( TyName "IntList" )
             ( CtorName "Cons" )
             [ Ref Nothing
-              ( Local ( Name "Cons$p1$314" ) ), Ref Nothing
-              ( Local ( Name "Cons$p2$315" ) )
+              ( Local ( Name "Cons$p1$0" ) ), Ref Nothing
+              ( Local ( Name "Cons$p2$0" ) )
             ]
           )
         )
@@ -534,17 +534,17 @@ UberModule
                                   )
                                 )
                                 ( AbsN Nothing
-                                  ( ParamNamed Nothing ( Name "v2$303" ) :| [] )
+                                  ( ParamNamed Nothing ( Name "v2$0" ) :| [] )
                                   ( IfThenElse Nothing
                                     ( Eq Nothing
                                       ( LiteralString Nothing "Data.Maybe∷Maybe.Nothing" )
                                       ( ReflectCtor Nothing
-                                        ( Ref Nothing ( Local ( Name "v2$303" ) ) )
+                                        ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                                       )
                                     )
                                     ( LiteralInt Nothing 0 )
                                     ( DataArgumentByIndex Nothing SumType 0
-                                      ( Ref Nothing ( Local ( Name "v2$303" ) ) )
+                                      ( Ref Nothing ( Local ( Name "v2$0" ) ) )
                                     )
                                   ) :| []
                                 )
@@ -558,12 +558,12 @@ UberModule
                                     )
                                   )
                                   ( AbsN Nothing
-                                    ( ParamNamed Nothing ( Name "value0$304" ) :| [] )
+                                    ( ParamNamed Nothing ( Name "value0$0" ) :| [] )
                                     ( Ctor Nothing SumType
                                       ( ModuleName "Data.Maybe" )
                                       ( TyName "Maybe" )
                                       ( CtorName "Just" )
-                                      [ Ref Nothing ( Local ( Name "value0$304" ) ) ]
+                                      [ Ref Nothing ( Local ( Name "value0$0" ) ) ]
                                     ) :| []
                                   )
                                 )


### PR DESCRIPTION
Closes #338.

## The churn

Every pass of the IR pipeline mints fresh binder names by drawing an index from one counter shared across the whole pipeline (`SupplyM`, in `Language.PureScript.Backend.IR.Supply`). The index a name ends up carrying is therefore not a property of the code it binds — it records how many names the passes that happened to run earlier consumed. Insert one extra mint anywhere and every name minted after it shifts by one.

The structural golden files (`golden.ir`, a pretty-printed dump of the linked, optimized IR module used to pin what the optimizer produces) render those names verbatim, so they diff on lines whose only change is the counter. From PR #337, whose only semantic effect on `Golden.LongWriterBind.Test` was one constructor worker dissolving, the `.ir` diff carried 94 changed lines, many of them purely this:

```
-            ( Nothing, Name "m$548", AppN Nothing
+            ( Nothing, Name "m$590", AppN Nothing
```

Every optimizer PR pays that tax: the reviewer has to sort real rewrites from shifted counters, and modules whose IR did not meaningfully change churn anyway.

## The fix

The golden harness now renumbers a module's minted binders before rendering it, so the printed indices are assigned in first-occurrence order and each name becomes a function of its own site's structure. The same line now reads:

```
-                    ( ParamNamed Nothing ( Name "m$494" ) :| [] )
+                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
```

Across the golden corpus this collapses 413 distinct minted spellings to 136, and the largest index from 3033 to 6 — a name's index is now the count of same-prefixed binders that precede it in its own site, not a pipeline high-water mark.

## Why the harness rather than the pipeline

Issue #338 offered two shapes: stabilize the names where they are minted, or normalize them where the artifact is rendered. The first one's extra payoff — a stable *shipped* artifact — is already delivered: `renumberChunk` (`Language.PureScript.Backend.Lua.Renumber`, landed in 83c083a) does exactly this renumbering on the final Lua chunk immediately before printing, and the emitted `.lua` goldens are consequently already history-free, with indices topping out at 7. What is left churning is only the IR dump, which nothing but the goldens renders. Normalizing at that render point keeps the compiler's own passes untouched, which is what makes "generated Lua is unchanged" a fact about the diff rather than a claim: of 336 golden examples, the 55 that moved are all `golden.ir`, and no `golden.lua` or `eval/golden.txt` moved at all.

## Mechanism

`renumberUberModule` (new, `Language.PureScript.Backend.IR.Renumber`) walks each top-level site of an `UberModule` — the linker's flattening of every reachable binding, foreign binding and export into one module — and renumbers that site from its own fresh allocation. Per-site rather than module-wide is the whole point: a site that mints one more name cannot shift the site printed after it.

```haskell
renumberUberModule uberModule =
  uberModule
    { uberModuleBindings =
        fmap renumberSite <<$>> uberModuleBindings uberModule
    , uberModuleForeigns = renumberSite <<$>> uberModuleForeigns uberModule
    , uberModuleExports = renumberSite <<$>> uberModuleExports uberModule
    }
```

Within a site the renaming is a plain name-to-name map applied to every occurrence, with no scope threading. What licenses that is the pipeline's global-uniqueness condition (`UniqueBinders`, established by the entry pass `uniquifyNames`): at most one binder in a site carries any given name, so a local reference belongs to the binder whose name it matches — the same reasoning `substituteCopyM` already relies on.

```haskell
renumberSite ∷ RawExp ann → RawExp ann
renumberSite e = rename (siteRenaming (binders e)) e
```

Per-site allocation is safe against cross-site capture because no name reachable from another site is ever renumbered. Top-level names come from source identifiers plus structural suffixes, and the corpus bears this out: no `QName` in any `.ir` golden carries a supply-drawn index. The one local reference a site may leave free is the runtime lazy factory, whose name holds no digit run and so is never an image of the renumbering.

## Which digit runs are history

Deciding that is the delicate part, and it was already solved once for the Lua side, where the mangling of `$` to `_S_` is the only difference. Rather than copy a subtle heuristic and its rationale, the classifier moved to `Language.PureScript.Backend.Renumber`, parameterized by the delimiter, and both renumberers now call it — one `Note [Supply-drawn digit runs]` instead of two. Each keeps its own scope discipline, which is where they genuinely differ: the Lua pass threads real Lua scopes and withholds spellings that occur free in the chunk, the IR one needs neither.

A digit run is supply-drawn when it forms a whole delimited segment (`m$590`, and the same run embedded in a derived name, `$kont7$w`) or terminates the tag of a prefix-minted name (`$cse1413`). Everything else is spelling and passes through, which is what keeps the structural suffixes readable: uncurrying's worker and parameter marks (`f$w`, `f$p1`), call-pattern specialization's shape mark (`pong$sc1Tuple`), uniquification's shadowing suffix (`x0`), and a source name that merely ends in a digit (`add3`).

## Verification

The acceptance criterion #338 names is that offsetting the supply start must leave the goldens byte-identical. Starting the pipeline's counter at 1000 instead of 0 does exactly that: all 336 golden examples pass with nothing rewritten. The offset provably took effect, because the unit tests that pin exact minted names see the shift and 25 of them fail on it:

```
Name "a$1000"
Name "x$1000"
Name "x$1001"
```

`Language.PureScript.Backend.IR.Renumber.Spec` pins the behaviour, each guard aimed at one property. Three tests fix the invariance directly, comparing a fixture built at supply offset 0 against the same fixture at offset 100, for suffix-minted binders, prefix-minted ones, and — over 300 generated expressions freshened at an arbitrary offset — any site at all:

```haskell
prop 300 "any freshened site, at any supply offset" do
  e ← forAll Gen.scopedExp
  let atOffset k =
        renumbered
          (runSupply (burn k *> freshenBinders (uniquifyNamesInExpr e)))
  atOffset 1000 === atOffset 0
```

Two more pin per-site isolation, which no supply-history test can catch: they fail only if the allocation is shared across sites. Replacing the per-site allocation with a module-wide one to check they have teeth turns the second site's `v$0`/`f$0`/`x$0` into `v$1`/`f$1`/`x$1` and both go red.

The remaining guards are example-based: the two minting grammars, first-occurrence order within one prefix (`v$1437`, `v$921` → `v$0`, `v$1`), a derived name landing on the index of the binder it embeds (`$kont7` and `$kont7$w` → `$kont0` and `$kont0$w`), the structural suffixes above left alone, and a foreign import's name list left alone since it holds the foreign file's export keys rather than binders. Three properties over 300 generated inputs each close it off: the renumbering is the identity on sites with no minted names, it is idempotent, and — the safety net that matters for a renaming — its output still satisfies `lintWellScoped` and `lintUniqueBinders`.

`cabal test all` is green at 1215 examples.
