### PR TITLE
fix(ir): rename a Let's binders in scope order in freshenBinders

### DIFF
--- a/changelog.d/20260729_120000_unisay_freshen_binders_scope_order.md
+++ b/changelog.d/20260729_120000_unisay_freshen_binders_scope_order.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- `freshenBinders` — the traversal that alpha-renames an expression's binders
+  before a copy of it is pasted somewhere else — no longer renames a free
+  reference that happens to share the name of a `Let` binder it does not sit
+  under (#345). It collected every binder name of a `Let` into one rename map
+  up front and walked all the right-hand sides under that map, so freshening
+  `let x = x in y` renamed both the binder and the free `x` beside it, even
+  though a `Standalone` binding is non-recursive and its right-hand side
+  therefore resolves `x` to an outer binder
+  (Note [Sequential scoping of Let bindings]):
+
+  ```
+  Let (Standalone (Name "x$0", Ref (Local (Name "x$0")))) (Ref (Local (Name "y")))
+  ```
+
+  The map is now threaded through the groupings in scope order — a
+  `Standalone` right-hand side is renamed before its own binder enters, a
+  `RecursiveGroup`'s members all enter before any of theirs is walked — which
+  is what `alphaEq` and `countFreeRefs` already implement, and what the
+  `LetValues` case of this same traversal already did:
+
+  ```
+  Let (Standalone (Name "x$0", Ref (Local (Name "x")))) (Ref (Local (Name "y")))
+  ```
+
+  Emitted code is unchanged, and the whole golden corpus stays byte-identical:
+  `uniquifyNames` is the pipeline's entry pass and every later pass requires
+  the global-uniqueness condition it establishes, so real compilation never
+  presents a shadowed shape to `freshenBinders`. What the bug did cost was a
+  test suite that reddened intermittently, because the property
+  `IR Optimizer / inlines expressions referenced once` feeds the optimizer
+  deliberately non-uniquified generated terms and occasionally drew the
+  degenerate shape.

--- a/lib/Language/PureScript/Backend/IR/CSE.hs
+++ b/lib/Language/PureScript/Backend/IR/CSE.hs
@@ -424,10 +424,10 @@ annotations (the 'Language.PureScript.Backend.IR.Types.alphaEq' relation
 weakened by ignoring the annotations optimization sheds unevenly).
 
 Binders are resolved to their references by name, so the key is correct
-under the GUC discipline the pass runs under (the blind descent of
-'Language.PureScript.Backend.IR.Types.freshenBinders'; the discard
-binder @_@ is exempt from uniqueness and referenced by nothing, so it
-stays unrenamed). Free references keep their names; a positional
+under the GUC discipline the pass runs under: binders are unique, so a
+reference belongs to a binder iff the names match (the discard binder
+@_@ is exempt from uniqueness and referenced by nothing, so it stays
+unrenamed). Free references keep their names; a positional
 @$key\<n\>@ name cannot collide with one, because @$@ never occurs in a
 source identifier and every supply-minted name uses another prefix.
 -}
@@ -449,8 +449,7 @@ alphaKey = canonicalize . void
       AbsN ann params' <$> go renames' body
     Let ann binds body → do
       -- Under unique binders no Let name can be referenced before it is
-      -- bound, so all the groupings can enter the rename map up front
-      -- (as in 'freshenBinders').
+      -- bound, so all the groupings can enter the rename map up front.
       renames' ←
         foldlM
           ( \rs name → do

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -1255,12 +1255,11 @@ alphaEq = go 0 Map.empty Map.empty
 supply-minted name (@\<original\>$\<n\>@ — the @$@ cannot occur in a
 source identifier, so a mint can never collide with one), rewriting the
 references each binder binds. Free references — bound outside the
-expression — are untouched.
+expression — are untouched, one that happens to share a binder's name
+included: the rename map is threaded in scope order, so a reference is
+renamed only by a binder that encloses it, and the innermost such one
+(Note [Sequential scoping of Let bindings]).
 
-Correct only under the GUC discipline (@UniqueBinders@): binders
-within the expression are unique, so a reference belongs to a binder
-iff the names match, and the sequential scoping subtleties of
-Note [Sequential scoping of Let bindings] cannot be observed.
 'ParamUnused' binds nothing, and the name list of a 'ForeignImport'
 holds the export keys of the foreign source file, not binders —
 neither is renamed.
@@ -1284,30 +1283,40 @@ freshenBinders = go Map.empty
       rhs' ← go renames rhs
       (renames', params') ← mapAccumM freshenParam renames params
       LetValues ann params' rhs' <$> go renames' body
+    -- The groupings bind sequentially, so the map grows left to right.
     Let ann binds body → do
-      -- Under unique binders no Let name can be referenced before it is
-      -- bound, so all the groupings can enter the rename map up front.
-      -- The discard binder `_` stays out of the map: it is exempt from
-      -- the uniqueness invariant, so one Let can bind it several times
-      -- (magic-do's discard statements), and a single name-keyed entry
-      -- would rename every one of them to the same fresh name — a
-      -- genuine duplicate the exemption no longer covers. Nothing may
-      -- reference it, so it needs no rename at all.
-      renames' ←
-        foldlM
-          ( \rs name → do
-              name' ← freshNameFor name
-              pure (Map.insert name name' rs)
-          )
-          renames
-          (filter (/= discardName) (bindingNames =<< toList binds))
-      let renameBound (bindAnn, name, expr) =
-            (bindAnn,Map.findWithDefault name name renames',)
-              <$> go renames' expr
-      Let ann <$> traverse (traverse renameBound) binds <*> go renames' body
+      (renames', binds') ← mapAccumM freshenGrouping renames binds
+      Let ann binds' <$> go renames' body
     -- No other constructor binds or references names ('ForeignImport'
     -- included: its name list holds export keys, not binders):
     other → traverseOf subexpressions (go renames) other
+
+  freshenGrouping
+    ∷ Map Name Name
+    → Grouping (ann, Name, RawExp ann)
+    → SupplyM (Map Name Name, Grouping (ann, Name, RawExp ann))
+  freshenGrouping renames = \case
+    -- A Standalone binding is non-recursive: its RHS does not see its
+    -- own binder, so the RHS is renamed under the incoming map and the
+    -- binder enters only afterwards.
+    Standalone (bindAnn, name, expr) → do
+      expr' ← go renames expr
+      (renames', name') ← bindFresh renames name
+      pure (renames', Standalone (bindAnn, name', expr'))
+    -- Every member of a recursive group is in scope in every member's
+    -- RHS, so the whole group enters the map before any RHS is walked.
+    RecursiveGroup members → do
+      (renames', rebound) ←
+        mapAccumM
+          ( \rs (bindAnn, name, expr) → do
+              (rs', name') ← bindFresh rs name
+              pure (rs', (bindAnn, name', expr))
+          )
+          renames
+          members
+      members' ← forM rebound \(bindAnn, name, expr) →
+        (bindAnn,name,) <$> go renames' expr
+      pure (renames', RecursiveGroup members')
 
   freshenParam
     ∷ Map Name Name
@@ -1318,6 +1327,19 @@ freshenBinders = go Map.empty
     ParamNamed paramAnn name → do
       name' ← freshNameFor name
       pure (Map.insert name name' rs, ParamNamed paramAnn name')
+
+  -- The discard binder @_@ stays out of the rename map: it is exempt
+  -- from the uniqueness invariant, so one Let can bind it several times
+  -- (magic-do's discard statements), and a single name-keyed entry
+  -- would rename every one of them to the same fresh name — a genuine
+  -- duplicate the exemption no longer covers. Nothing may reference it,
+  -- so it needs no rename at all.
+  bindFresh ∷ Map Name Name → Name → SupplyM (Map Name Name, Name)
+  bindFresh rs name
+    | name == discardName = pure (rs, name)
+    | otherwise = do
+        name' ← freshNameFor name
+        pure (Map.insert name name' rs, name')
 
   freshNameFor ∷ Name → SupplyM Name
   freshNameFor name = freshName (stripFreshSuffix (nameToText name) <> "$")

--- a/test/Language/PureScript/Backend/IR/Types/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Types/Spec.hs
@@ -354,6 +354,37 @@ spec = describe "Types" do
       annotateShow freshened
       alphaEq guc freshened === True
 
+    it "leaves a free reference alone in the RHS of its own binder" do
+      -- let x = x in y: a Standalone binding is non-recursive, so the
+      -- RHS x is a free occurrence of an outer x (Note [Sequential
+      -- scoping of Let bindings]); only the binder is freshened.
+      runSupply
+        ( freshenBinders
+            (lets (Standalone (noAnn, x, refLocal x) :| []) (refLocal y))
+        )
+        `shouldBe` lets
+          (Standalone (noAnn, Name "x$0", refLocal x) :| [])
+          (refLocal y)
+
+    it "brings a Let's binders into scope left to right" do
+      -- let x = y; y = x in y: the RHS of the first binding predates the
+      -- y binder, so its y is free, while the RHS of the second sees the
+      -- freshened x and the body sees the freshened y.
+      runSupply
+        ( freshenBinders
+            ( lets
+                ( Standalone (noAnn, x, refLocal y)
+                    :| [Standalone (noAnn, y, refLocal x)]
+                )
+                (refLocal y)
+            )
+        )
+        `shouldBe` lets
+          ( Standalone (noAnn, Name "x$0", refLocal y)
+              :| [Standalone (noAnn, Name "y$1", refLocal (Name "x$0"))]
+          )
+          (refLocal (Name "y$1"))
+
     it "keeps the discard binders of a Let apart" do
       -- A magic-do-lowered thunk binds several Let statements to the
       -- GUC-exempt discard binder `_`. One name-keyed rename entry


### PR DESCRIPTION
Closes #345.

`freshenBinders` alpha-renames every binder bound inside an IR expression to a fresh, supply-minted name. The optimizer calls it whenever it pastes a *copy* of an expression somewhere else — the call-site inliners, the call-pattern specializer, and the `substituteCopyM`/`substituteMoveM` substitution pair all go through it — so that the copy's binders cannot collide with anything at the destination. Renaming a binder means rewriting the references that binder binds; references that are *free* in the expression belong to the enclosing scope and must survive untouched.

The `Let` case did not honour that. It collected every binder name of the `Let` into one rename map up front and then walked all the right-hand sides under that single map:

```haskell
    Let ann binds body → do
      -- Under unique binders no Let name can be referenced before it is
      -- bound, so all the groupings can enter the rename map up front.
      -- …
      renames' ←
        foldlM
          ( \rs name → do
              name' ← freshNameFor name
              pure (Map.insert name name' rs)
          )
          renames
          (filter (/= discardName) (bindingNames =<< toList binds))
      let renameBound (bindAnn, name, expr) =
            (bindAnn,Map.findWithDefault name name renames',)
              <$> go renames' expr
      Let ann <$> traverse (traverse renameBound) binds <*> go renames' body
```

The comment states the precondition the shortcut needs, and it is exactly the one that fails here. The IR's scoping rule is sequential, like Scheme's `let*` — `Note [Sequential scoping of Let bindings]` in `IR/Types.hs` — and its first clause says a `Standalone` binding is non-recursive: its own name is **not** in scope in its right-hand side, so a reference to that name from its own right-hand side resolves to an *outer* binder. Because the binder's rename entry was already in the map when its own right-hand side was walked, such a free reference was renamed along with the binder and silently repointed at it.

The minimal shape is `let x = x in y`, where the right-hand-side `x` is free. Freshening it should rename the binder alone; instead it renamed both (verbatim from the guard added below, `expected` being the correct result and `but got` the pre-fix one):

```
       expected: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "x"))) :| []) (Ref Nothing (Local (Name "y")))
        but got: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "x$0"))) :| []) (Ref Nothing (Local (Name "y")))
```

`freshenBinders` was the odd one out. `alphaEq` (structural equality modulo binder names) implements the sequential rule explicitly — it compares a `Standalone` right-hand side *before* binding the name, under the comment `-- The RHS of a Standalone binding does not see its own binder:` — and both free-reference counters, `countFreeRefs` and `countFreeRefUsage`, thread their bound-name set through the groupings the same way. Even `freshenBinders`' own `LetValues` case already got it right, for the same reason: `-- The RHS is renamed under the incoming map — the binders scope over the body only`. Only the `Let` case hoisted.

## The fix

The rename map is threaded through the groupings in scope order instead of being hoisted:

```haskell
    -- The groupings bind sequentially, so the map grows left to right.
    Let ann binds body → do
      (renames', binds') ← mapAccumM freshenGrouping renames binds
      Let ann binds' <$> go renames' body
```

```haskell
  freshenGrouping renames = \case
    -- A Standalone binding is non-recursive: its RHS does not see its
    -- own binder, so the RHS is renamed under the incoming map and the
    -- binder enters only afterwards.
    Standalone (bindAnn, name, expr) → do
      expr' ← go renames expr
      (renames', name') ← bindFresh renames name
      pure (renames', Standalone (bindAnn, name', expr'))
    -- Every member of a recursive group is in scope in every member's
    -- RHS, so the whole group enters the map before any RHS is walked.
    RecursiveGroup members → do
      (renames', rebound) ← mapAccumM (\rs (bindAnn, name, expr) → do
          (rs', name') ← bindFresh rs name
          pure (rs', (bindAnn, name', expr))) renames members
      members' ← forM rebound \(bindAnn, name, expr) →
        (bindAnn,name,) <$> go renames' expr
      pure (renames', RecursiveGroup members')
```

The discard binder `_` keeps its exemption, now expressed in `bindFresh`: it is exempt from the uniqueness invariant, so one `Let` can bind it several times (a magic-do-lowered thunk binds a run of statements to `_`), and a single name-keyed map entry would rename every one of them to the *same* fresh name — a genuine duplicate the exemption no longer covers. Nothing may reference it, so it takes no rename at all.

```haskell
  bindFresh rs name
    | name == discardName = pure (rs, name)
    | otherwise = do
        name' ← freshNameFor name
        pure (Map.insert name name' rs, name')
```

## How it showed up

As an intermittent red in the property `IR Optimizer / inlines expressions referenced once`. That test hands `optimizedExpression`, the optimizer's single-expression entry point, a generated and deliberately **non**-uniquified inlinee, lets it inline the used-once binding, and compares the pasted copy against the original up to alpha-equivalence. It fails exactly when the generator happens to draw the self-shadowing shape, which is why it is rare.

Fixing hspec's global seed makes it deterministic. `--seed 328` on the pre-fix build draws `let j = j in []` as the inlinee and fails verbatim:

```
           2154 ┃       inlinee ← forAll $ fmap optimizedExpression do
                ┃       │ Let
                ┃       │   Nothing
                ┃       │   (Standalone
                ┃       │      ( Nothing , Name "j" , Ref Nothing (Local (Name "j")) ) :|
                ┃       │      [])
                ┃       │   (LiteralArray Nothing [])
...
           2169 ┃       diff (optimizedExpression original) alphaEq expected
                ┃       │ ━━━ Failed (- lhs) (+ rhs) ━━━
                ┃       │ -     Standalone
                ┃       │ -       ( Nothing , Name "j$0" , Ref Nothing (Local (Name "j$0")) ) :|
                ┃       │ -       []
                ┃       │ +     Standalone
                ┃       │ +       ( Nothing , Name "j" , Ref Nothing (Local (Name "j")) ) :|
                ┃       │ +       []
```

## Impact on emitted code: none

`uniquifyNames` is the pipeline's entry pass and the only one whose stated precondition is merely `wellScoped`; all nine passes behind it declare `passRequires = guc`, the global-uniqueness condition under which every binder in the program has a distinct name. Real compilation therefore never presents a shadowed shape to `freshenBinders`. The whole golden corpus — `.ir`, `.lua` and the hand-verified `eval/golden.txt` oracles alike — is byte-identical; the branch touches no generated file:

```
$ git diff --stat origin/main...HEAD
 ...29_120000_unisay_freshen_binders_scope_order.md | 34 ++++++++++
 lib/Language/PureScript/Backend/IR/CSE.hs          | 11 ++--
 lib/Language/PureScript/Backend/IR/Types.hs        | 72 ++++++++++++++--------
 test/Language/PureScript/Backend/IR/Types/Spec.hs  | 31 ++++++++++
 4 files changed, 117 insertions(+), 31 deletions(-)
```

(`CSE.hs` is comment-only: two remarks in the common-subexpression-elimination pass cited `freshenBinders`' hoisted map as precedent for its own, so they now state the assumption directly instead of pointing at code that no longer works that way.)

## Verification

Two example-based guards were added first and confirmed red on the unmodified traversal. The first pins the acceptance criterion; the second pins the left-to-right ordering, which a "hoist everything except the current binder" implementation would still get wrong:

```
    leaves a free reference alone in the RHS of its own binder [✘]
    brings a Let's binders into scope left to right [✘]

  1) Types.freshenBinders leaves a free reference alone in the RHS of its own binder
       expected: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "x"))) :| []) (Ref Nothing (Local (Name "y")))
        but got: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "x$0"))) :| []) (Ref Nothing (Local (Name "y")))

  2) Types.freshenBinders brings a Let's binders into scope left to right
       expected: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "y"))) :| [Standalone (Nothing, Name "y$1", Ref Nothing (Local (Name "x$0")))]) (Ref Nothing (Local (Name "y$1")))
        but got: Let Nothing (Standalone (Nothing, Name "x$0", Ref Nothing (Local (Name "y$1"))) :| [Standalone (Nothing, Name "y$1", Ref Nothing (Local (Name "x$0")))]) (Ref Nothing (Local (Name "y$1")))
```

Both pass after the change, alongside the existing discard-binder and GUC-alpha-renaming guards:

```
  freshenBinders
    renames binders and their references, not free references [✔]
    freshens a previously-freshened binder without compounding the suffix [✔]
    is an alpha-renaming of GUC-shaped input [✔]
        ✓ property passed 100 tests.
    leaves a free reference alone in the RHS of its own binder [✔]
    brings a Let's binders into scope left to right [✔]
    keeps the discard binders of a Let apart [✔]
```

The flake itself was measured as a differential: the `IR Optimizer` group was run over hspec seeds 1–500 with the pre-fix and post-fix binaries, on the same seeds.

```
unfixed (this branch with the fix commit reverted): seeds 1..500 -> ok=495 assertion-failures=2 timeouts=3
fixed:                                              seeds 1..500 -> ok=497 assertion-failures=0 timeouts=3
```

The two assertion failures are seeds 328 and 379, both the self-shadowing shape quoted above; 379 buries it one `Let` deeper, inside `let z = 0 (pink.y) in let x = x in '…'`, and repoints that inner `x` the same way:

```
                ┃       │ -       Standalone
                ┃       │ -         ( Nothing , Name "x$1" , Ref Nothing (Local (Name "x$1")) ) :|
                ┃       │ -         []
                ┃       │ +       Standalone
                ┃       │ +         ( Nothing , Name "x" , Ref Nothing (Local (Name "x")) ) :|
                ┃       │ +         []
```

(The surrounding `z$0`-vs-`z` lines in that rendering are a plain binder rename, which `alphaEq` tolerates; hedgehog's structural diff shows them regardless.) Neither seed reproduces after the change.

`cabal test all` is green — 1232 examples, 0 failures — from a `cabal clean` rebuild that emits no compiler warnings, and `hlint lib/ exe/ test/` reports no hints.

## One unrelated observation

The three timeouts are the *same* seeds on both binaries — 109, 152 and 478 — so they are not this bug. Each stalls in the property `optimization keeps expressions well-scoped`, immediately after `blanking an unused shadowing binder keeps outer references bound`, where a normal run of the whole group takes 0.35 s. That property runs the full `optimizedUberModule` pipeline, whose entry pass is `uniquifyNames`, so it never sees a shadowed shape and cannot be reached by this fix. It is a second, independent source of intermittent redness in the same group and gets its own issue.
