### PR TITLE
fix(ir): bound the bottom-up rewrite driver's re-application loop (#348)

### DIFF
--- a/changelog.d/20260729_150000_unisay_bound_nested_rewrites.md
+++ b/changelog.d/20260729_150000_unisay_bound_nested_rewrites.md
@@ -1,0 +1,34 @@
+### Fixed
+
+- The bottom-up IR rewrite driver — the traversal that rewrites a node's
+  children before the node and then re-applies the rules to their own result
+  until none fires — no longer loops forever on an expression that has no
+  normal form (#348). The re-application loop was unbounded, so beta reduction
+  spun on the self-application `Ω = (λx. x x) (λy. y y)`, whose every reduction
+  step reproduces it modulo binder names:
+
+  ```
+  AppN (AbsN [x$400] (AppN x$400 [x$400])) [AbsN [x$401] (AppN x$401 [x$401])]
+  AppN (AbsN [x$401] (AppN x$401 [x$401])) [AbsN [x$402] (AppN x$402 [x$402])]
+  AppN (AbsN [x$402] (AppN x$402 [x$402])) [AbsN [x$403] (AppN x$403 [x$403])]
+  ```
+
+  The loop now stops after `maxNestedRewrites` (100) nested rewrites along one
+  path and returns the term it has reached, the same treatment the pass-level
+  fixpoint already gave its own iteration cap: every rewrite preserves
+  semantics and the IR invariants on its own, so abandoning a redex
+  mid-reduction costs optimization and nothing else, and the driver's
+  `Rewritten` flag stays precise. With the pipeline's invariant checking on
+  (`--lint-ir`, and the test suite) the residual redex surfaces as
+  `FixpointDivergence "optimize+dce"` rather than as silence.
+
+  Emitted code is unchanged and the whole golden corpus stays byte-identical:
+  PureScript's type system rejects every term without a normal form, so no
+  compiled program contains one, and a converging rule chain needs a handful of
+  nested rewrites — the whole test suite, the ~300-deep golden constant chains
+  included, peaks at five, twenty times clear of the bound. What the bug did
+  cost was a test suite that hung rather than reddened, because the property
+  `IR Optimizer / optimization keeps expressions well-scoped` feeds the
+  optimizer generated untyped terms and drew `Ω` at 3 of the first 500 hspec
+  seeds (109, 152 and 478), each of which now finishes the group in about five
+  seconds.

--- a/lib/Language/PureScript/Backend/IR/Types.hs
+++ b/lib/Language/PureScript/Backend/IR/Types.hs
@@ -8,8 +8,8 @@ import Control.Lens
   , foldMapOf
   , makePrisms
   , prism'
-  , rewriteMOf
   , toListOf
+  , transformMOf
   , traverseOf
   )
 import Control.Monad.Writer.CPS (runWriterT, tell)
@@ -850,20 +850,49 @@ thenRewrite rewrite1 rewrite2 e =
     Just e' → Just . fromMaybe e' <$> rewrite2 e'
     Nothing → rewrite2 e
 
+{- | Backstop for the re-application loop of 'rewriteExpBottomUpM': how
+many nested rewrites one path down the expression may take before the
+driver stops re-applying the rule and returns the term it has reached.
+
+The bound is what makes the driver total, because beta reduction has no
+terminating strategy on an arbitrary untyped term: Ω = @(λx. x x) (λy. y
+y)@ reduces to itself modulo binder names, so the loop would re-apply
+forever. The IR is assumed well-typed (Note [IR is assumed well-typed])
+and PureScript's type system rejects every such term, so only the
+untyped terms the property-test generators draw reach the bound.
+
+Stopping early costs optimization and nothing else: each rewrite
+preserves semantics and the IR invariants on its own, so a term the
+driver abandons mid-reduction is as valid as a fully reduced one, and
+'WasRewritten' stays precise (it reports 'Rewritten' iff a rule fired,
+whether or not the loop ran to exhaustion). A converging rule chain
+needs a handful of nested rewrites — the whole test suite, the ~300-deep
+golden constant chains included, peaks at five — so the bound sits two
+orders of magnitude clear of legitimate work.
+-}
+maxNestedRewrites ∷ Natural
+maxNestedRewrites = 100
+
 {- | Rewrite bottom-up: every node's children are fully rewritten before
 the rule sees the node, and the rule is re-applied to its own result
-until it no longer fires ('rewriteMOf' semantics). One pass is
-therefore complete and idempotent — the result contains no node the
-rule still fires on — which is what makes the returned 'WasRewritten'
-precise, and what closes the Recurse-escape bug class (issue #149)
-structurally: a node exposed by a collapsing parent has already been
-fully rewritten.
+until it no longer fires, bounded by 'maxNestedRewrites'. Short of that
+bound one pass is complete and idempotent — the result contains no node
+the rule still fires on — which closes the Recurse-escape bug class
+(issue #149) structurally: a node exposed by a collapsing parent has
+already been fully rewritten.
 -}
 rewriteExpBottomUpM
   ∷ Monad m ⇒ RewriteRuleM m ann → RawExp ann → m (RawExp ann, WasRewritten)
-rewriteExpBottomUpM rule expr =
-  runWriterT $ flip (rewriteMOf subexpressions) expr \e →
-    lift (rule e) >>= traverse \e' → e' <$ tell Rewritten
+rewriteExpBottomUpM rule = runWriterT . reapply maxNestedRewrites
+ where
+  reapply budget = transformMOf subexpressions \e →
+    lift (rule e) >>= \case
+      Nothing → pure e
+      Just e' → do
+        tell Rewritten
+        case budget of
+          0 → pure e'
+          _ → reapply (budget - 1) e'
 
 -- | Pure 'rewriteExpBottomUpM'.
 rewriteExpBottomUp ∷ RewriteRule ann → RawExp ann → (RawExp ann, WasRewritten)

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -43,6 +43,10 @@ import Language.PureScript.Backend.IR.Optimizer
   , shareForeignAccessors
   , sinkProjectionIntoLet
   )
+import Language.PureScript.Backend.IR.Pass
+  ( PassCheckFailure (FixpointDivergence)
+  , maxFixpointIterations
+  )
 import Language.PureScript.Backend.IR.Supply (runSupply)
 import Language.PureScript.Backend.IR.Types
   ( AlgebraicType (ProductType, SumType)
@@ -4014,6 +4018,41 @@ spec = describe "IR Optimizer" do
               }
       annotateShow original
       optimizedUberModule mempty original === expected
+
+  -- Issue #348: Ω = (λx. x x) (λy. y y) is the smallest untyped term with
+  -- no normal form — every beta step reproduces it modulo binder names —
+  -- so the bottom-up driver's "re-apply the rule at this node until it
+  -- stops firing" loop must be bounded ('maxNestedRewrites'). PureScript's
+  -- type system rejects Ω, so no compiled program contains one; the
+  -- generator behind the properties below draws untyped terms and does.
+  describe "terminates on a term with no normal form (#348)" do
+    let selfApplication name =
+          abstraction (paramNamed name) $
+            application (refLocal name) (refLocal name)
+        omega =
+          application
+            (selfApplication (Name "x"))
+            (selfApplication (Name "y"))
+        original =
+          Linker.UberModule
+            { uberModuleForeigns = []
+            , uberModuleBindings = []
+            , uberModuleExports = [(Name "omega", omega)]
+            }
+
+    test "the pipeline gives up on a diverging redex" do
+      let optimized = optimizedUberModule mempty original
+      annotateShow optimized
+      -- Reaching an assertion at all is what this pins: the pipeline
+      -- returned rather than spinning. Abandoning a redex mid-reduction
+      -- leaves the term un-normalized but breaks no invariant, because
+      -- every step taken so far was semantics- and invariant-preserving.
+      lintWellScoped optimized === []
+      lintUniqueBinders optimized === []
+
+    test "the checked pipeline names the fixpoint that keeps firing" do
+      optimizedUberModuleChecked mempty original
+        === Left (FixpointDivergence "optimize+dce" maxFixpointIterations)
 
   describe "scoping invariants" do
     -- Mimics issue #37: an inlined binding contains a let with a


### PR DESCRIPTION
Closes #348.

## The symptom

`pslua` optimizes its intermediate representation (IR) by rewriting expression trees, and the rewrite rules are exercised by Hedgehog properties that generate random IR terms. Three of the first 500 hspec seeds — 109, 152 and 478 — made the `IR Optimizer` spec group stop emitting output and pin one core indefinitely. A complete run of that group costs 0.35 s; these were still spinning when killed at 120 s, with a flat 50 MiB resident set, so nothing was growing — the optimizer was looping.

```
$ timeout 120 $(cabal list-bin spec) --match "IR Optimizer" --seed 109
    blanking an unused shadowing binder keeps outer references bound [✔]
        ✓ property passed 1 test.
timeout 120 $SPEC --match "IR Optimizer" --seed 109  119.58s user 0.21s system 99% cpu 2:00.00 total
```

The last line printed is the test declared immediately before `optimization keeps expressions well-scoped`, the property that feeds generated terms through the whole optimizer pipeline — so the loop was inside that property, and it hung rather than reddening, which is the easiest kind of failure to misread as flakiness.

## What was looping

The IR rewrite driver `rewriteExpBottomUpM` walks an expression bottom-up: it rewrites a node's children first, then applies the rule set to the node, and re-applies it to its own result until the rule set stops firing. That re-application loop had no bound.

```haskell
rewriteExpBottomUpM rule expr =
  runWriterT $ flip (rewriteMOf subexpressions) expr \e →
    lift (rule e) >>= traverse \e' → e' <$ tell Rewritten
```

Among the rules that loop drives is `betaReduce`, which reduces a redex `(λx. M) N` to `M[x := N]`. Beta reduction has no terminating strategy on an arbitrary untyped term, and the generator draws untyped terms: it drew Ω = `(λx. x x) (λy. y y)`, the smallest term with no normal form, whose every reduction step reproduces it modulo binder names. Instrumenting the loop to abort after 400 nested rewrites and print the node it was chewing on shows the cycle exactly — the two abstractions swap places and every binder index advances by one, because pasting a copy of the argument freshens its binders:

```
BEFORE:
AppN () (AbsN () (ParamNamed () (Name "x$400") :| []) (AppN () (Ref () (Local (Name "x$400"))) (Ref () (Local (Name "x$400")) :| []))) (AbsN () (ParamNamed () (Name "x$401") :| []) (AppN () (Ref () (Local (Name "x$401"))) (Ref () (Local (Name "x$401")) :| [])) :| [])
AFTER:
AppN () (AbsN () (ParamNamed () (Name "x$401") :| []) (AppN () (Ref () (Local (Name "x$401"))) (Ref () (Local (Name "x$401")) :| []))) (AbsN () (ParamNamed () (Name "x$402") :| []) (AppN () (Ref () (Local (Name "x$402"))) (Ref () (Local (Name "x$402")) :| [])) :| [])
```

All three seeds hit the same term. So this is not the non-converging rule *pair* the issue guessed at, and it is not a guard that `betaReduce` is missing: no local test on a redex can decide whether reducing it terminates. The pass-level pipeline was never the problem either — its fixpoint combinator has carried a 1000-iteration backstop for a while. The unbounded loop was one level below it, inside a single pass, at a single node.

## The fix

The loop now carries a budget, spelled `maxNestedRewrites`, and returns the term it has reached when the budget runs out:

```haskell
rewriteExpBottomUpM rule = runWriterT . reapply maxNestedRewrites
 where
  reapply budget = transformMOf subexpressions \e →
    lift (rule e) >>= \case
      Nothing → pure e
      Just e' → do
        tell Rewritten
        case budget of
          0 → pure e'
          _ → reapply (budget - 1) e'
```

This is the treatment the pass-level fixpoint already gives its own iteration cap: stopping early costs optimization and nothing else, because each rewrite preserves semantics and the IR invariants on its own, so a term the driver abandons mid-reduction is exactly as valid as a fully reduced one. The driver's `WasRewritten` flag — which the enclosing fixpoint trusts to decide whether to iterate again — also stays precise: it reports `Rewritten` iff some rule fired, whether or not the loop ran to exhaustion.

The budget is 100, and it cannot reach legitimate work. Instrumenting the driver to record the deepest nesting it ever reaches and running the whole suite gives 5 — 1232 examples, 344 of them golden compilations of real PureScript including the ~300-deep constant chains that stress the pipeline hardest. That is the population that matters, since the IR is assumed well-typed (`Note [IR is assumed well-typed]`) and PureScript's type system rejects every term without a normal form; only the untyped terms the generators draw reach the bound at all.

## Diagnosability

Nothing is silent about a term that exhausts the budget. `optimizedUberModule` (the production pipeline) returns a correct, under-optimized module, while `optimizedUberModuleChecked` (the same pipeline with every pass's contract linted, used by the test suite always and by the CLI behind `--lint-ir`) reports which fixpoint kept firing:

```haskell
optimizedUberModuleChecked mempty original
  === Left (FixpointDivergence "optimize+dce" maxFixpointIterations)
```

Each round of that fixpoint genuinely changes the module — it advances Ω by another 100 beta steps — so the fixpoint runs its full cap and then names itself, which is the third acceptance criterion of the issue.

## Tests

Two example-based tests replace the generator draw, so the fix is pinned by something that does not depend on a seed. Both hang on the parent commit; the test commit is deliberately red.

```haskell
    let selfApplication name =
          abstraction (paramNamed name) $
            application (refLocal name) (refLocal name)
        omega =
          application
            (selfApplication (Name "x"))
            (selfApplication (Name "y"))
```

The first asserts the pipeline returns at all and that the abandoned term still satisfies the two IR invariants — `lintWellScoped` (every local reference resolves to an enclosing binder) and `lintUniqueBinders` (no local binder name bound twice within a top-level site). The second pins the `FixpointDivergence` report above.

## Verification

`cabal test all` is green (1234 examples), `fourmolu` and `hlint` are clean, and the golden corpus is byte-identical — no `golden.ir` or `golden.lua` moved, which follows from the bound being 20× clear of the deepest chain any real compilation produces.

The check the issue asks for is the sweep that found the stall, so here it is over the same range, with a timeout generous against the group's cost:

```
$ for s in $(seq 1 500); do timeout 60 $SPEC --match "IR Optimizer" --seed $s; done
worst_elapsed=6s
failures:
```

Every seed passes; the worst is seed 109 at 6 s. Two costs are worth naming rather than hiding. The group now takes about 3 s at *every* seed, up from 0.35 s, because the new example-based test deliberately drives the budget to exhaustion twice — the enclosing `optimize+dce` fixpoint keeps spending its 1000 rounds advancing a term that will never converge, since each round does change the module. On top of that, the three seeds that draw Ω themselves add ~2 s (109 → 6 s, 152 and 478 → 5 s). Full-suite wall clock is unchanged within noise at 88 s. Making an exhausted budget stop the enclosing fixpoint at once would remove both, but it means widening `Pass.passRun`'s result and its three runners, so it belongs in its own change.
