### PR TITLE
fix(bench): re-measure a trace report that differs only in the measured sets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,13 @@ jobs:
       - name: "🔨 Build & test"
         run: >-
           nix develop --accept-flake-config --allow-import-from-derivation --command cabal test all --test-show-details=direct
+      # Which counter mismatch is re-measured as trace-formation noise and
+      # which fails outright is a judgement the oracle makes on every run, so
+      # it is pinned against synthetic reports first: a broken verdict then
+      # reads as itself instead of as a mystery counter diff. Milliseconds.
+      - name: "🧪 Bench oracle self-test"
+        run: >-
+          nix develop --accept-flake-config --allow-import-from-derivation --command ./bench/tools/counters_selftest
       # Deterministic LuaJIT counters over freshly linked bench artifacts
       # (FNEW census, trace abort/blacklist state). Wall-clock benchmarks
       # stay local — shared runners are too noisy; see bench/README.md.

--- a/bench/README.md
+++ b/bench/README.md
@@ -22,7 +22,10 @@ JIT treats it. Two kinds of output with two different purposes:
   `ideal` hand-written equivalent.
 - `tools/` — the runners and meters. `fnew_census.lua`, `tnew_census.lua`
   and `trace_report.lua` require LuaJIT (`jit.util`, `jit.attach`); the
-  timing runners work under both PUC Lua and LuaJIT.
+  timing runners work under both PUC Lua and LuaJIT. `diff_counters` is the
+  oracle comparison (which mismatch is re-measured, which fails — see
+  "Marginal trace spots"), and `counters_selftest` pins that verdict against
+  synthetic reports.
 - `goldens/` — committed counter reports; the CI oracle.
 
 ## Usage
@@ -33,6 +36,7 @@ lua bench/tools/run_micro.lua bench/micro/curried_apply.lua        # one bench
 luajit bench/tools/run_macro.lua bench/macro/array_foldl.lua 5e6   # custom n
 ./bench/ci                  # regenerate counters, verify against goldens/
 ./bench/ci --accept         # rewrite goldens/ after a deliberate change
+./bench/tools/counters_selftest   # pin the oracle's verdict logic (no LuaJIT run)
 ```
 
 Timings use `os.clock()` — CPU time, not wall time. That is deliberate:
@@ -87,12 +91,63 @@ rerun `./bench/ci --accept` and review the diff. And trace formation is not
 deterministic per process: LuaJIT's hot-counters live in a small hashed
 table keyed by bytecode address, and the retry penalty draws on an
 entropy-seeded PRNG, so a spot on the hot-count boundary can form a trace in
-one run and not the next. `trace_report.lua` absorbs this by taking a
-majority vote over several independent trials: a marginal spot is reported
-iff most processes form it, and the misreport odds decay binomially in the
-trial count for any per-process probability away from one half (the tool's
-header records the measured case that rules out a unanimity rule); the
-canonical report is then stable by construction. The FNEW census has no
-such channel — it never runs
-the code — so `./bench/ci` still generates it twice and compares byte for
-byte.
+one run and not the next. `trace_report.lua` absorbs most of this by taking a
+majority vote over several independent trials: a spot is reported iff most
+processes form it, and the misreport odds decay binomially in the trial count
+for any per-process probability away from one half (the tool's header records
+the measured case that rules out a unanimity rule). A probability *near* one
+half outlasts the vote, which is what the next section is about. The censuses
+have no such channel — they never run the code — so `./bench/ci` still
+generates each twice and compares byte for byte.
+
+## Marginal trace spots
+
+A spot's per-process formation probability `p` belongs to the whole process
+layout, not to the bytecode alone: the hot counters are keyed by bytecode
+address, so dropping one hoisted table from an artifact reshuffles which
+counters collide and can move a spot off `p = 1` without changing what the
+spot does. Any codegen change that shifts lines in a bench artifact can
+therefore manufacture a marginal spot, and a marginal spot turns the vote
+into a coin flip — reddening CI for a reason that has nothing to do with the
+change under review.
+
+That is a class, not a case. Measured over 30 raw single-process trials per
+spec (`trace_report.lua <spec> --trial`), 14 entries across 8 of the 12 specs
+land strictly between "never" and "always", the widest being:
+
+```
+spec         raw/30  golden   entry
+ref_loop     21/30   present  Bench.RefLoop.lua:32 JFUNCF
+ref_loop      8/30   absent   Bench.RefLoop.lua:35 -- inner loop in root trace
+record_set    4/30   absent   Bench.RecordSet.lua:6 -- inner loop in root trace
+ctor_build   26/30   present  Bench.CtorBuild.lua:3 JFUNCF
+array_foldl  27/30   present  Bench.ArrayFoldl.lua:20 -- NYI: bytecode FNEW
+```
+
+Both measured signals are affected — opcode end states *and* abort sites — and
+the two `ref_loop` entries are complementary, the abort being what gets
+recorded when the entry trace does not form.
+
+So `./bench/ci` treats the class uniformly instead of naming spots.
+`diff_counters` compares each report to its golden and, when a *trace* report
+differs **only** in the measured sets, re-measures it — a fresh canonical vote
+— failing only if every attempt still differs. Two re-measurements is the
+default; `BENCH_TRACE_RETRIES` overrides it, and `0` restores a plain diff.
+A difference in a census, in a trace report's header lines, or in which
+reports exist at all is deterministic by construction and fails immediately,
+buying no fresh processes.
+
+The re-measurements are conjunctive, which is why they beat spending the same
+processes on one longer vote: for a single entry at probability `p`, one
+nine-trial vote lands on the wrong side with `P(Binom(9,p) ≤ 4)`, and each
+re-measurement multiplies that in — 26.7% → 7.1% → 1.9% at `p = 0.6`, where
+pooling 25 trials into one vote only reaches 15.4%. What it gives up is a
+regression that itself lands near `p = 0.5`; such a regression has no pinnable
+golden on either side even with one vote, so nothing previously catchable
+becomes uncatchable. A reproducible change re-measures to the same thing every
+time and fails after spending the budget.
+
+`counters_selftest` pins those verdicts against synthetic reports — a marginal
+entry absorbed, a reproducible change failing after spending the budget, and a
+census or header difference failing without buying any processes — so CI checks
+the oracle's judgement before it trusts its counters.

--- a/bench/ci
+++ b/bench/ci
@@ -6,8 +6,11 @@
 # prove byte-stability outright. The trace report is nondeterministic per process (hot-count
 # aliasing plus an entropy-seeded penalty PRNG), so trace_report.lua makes it
 # stable by majority vote over independent trials rather than by hoping two
-# runs agree. Pass --accept after a deliberate codegen change to rewrite the
-# oracles from the current output.
+# runs agree. A spot whose per-process formation probability sits between 0
+# and 1 outlasts even the vote, so the comparison itself re-measures such a
+# report a bounded number of times before failing (diff_counters, which also
+# decides what counts as re-measurable). Pass --accept after a deliberate
+# codegen change to rewrite the oracles from the current output.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -46,6 +49,6 @@ if [ "$accept" = 1 ]; then
   cp "$out"/*.txt bench/goldens/
   echo "accepted $(find "$out" -name '*.txt' | wc -l) counter files into bench/goldens/"
 else
-  diff -ru bench/goldens "$out"
-  echo "bench counters match goldens"
+  ./bench/tools/diff_counters bench/goldens "$out" bench/macro \
+    luajit bench/tools/trace_report.lua
 fi

--- a/bench/tools/counters_selftest
+++ b/bench/tools/counters_selftest
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Pins the verdict logic of bench/tools/diff_counters: which oracle mismatch
+# is re-measured as trace-formation noise, which one fails outright, and how
+# many regenerations each costs. Synthetic reports stand in for real ones, so
+# the checks run in milliseconds instead of spawning the ~100 fresh LuaJIT
+# processes a real set of canonical reports needs -- and a marginal spot can
+# be staged deterministically, which is impossible with the real tool.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+diff_counters=bench/tools/diff_counters
+failures=0
+
+# A plausible canonical report for bench/macro/ref_loop.lua: three header
+# lines derived from the spec and a deterministic checksum, then the two
+# measured sets, then their tallies.
+golden_report() {
+  cat <<'EOF'
+spec: ref_loop
+runtime: LuaJIT 2.1.1741730670
+workload: n=100000 reps=4 result=4999950000
+aborts (distinct site -- reason):
+  Bench.RefLoop.lua:40 -- NYI: bytecode FNEW
+bytecode end state (J*=compiled, I*=blacklisted):
+  Bench.RefLoop.lua:10 JFUNCF
+  Bench.RefLoop.lua:34 JFORI
+  Bench.RefLoop.lua:34 JFORL
+counts: aborts=1 compiled=3 blacklisted=0
+EOF
+}
+
+# The same report with one extra function-entry trace: the shape a marginal
+# spot takes when its per-process formation lands on the reported side.
+marginal_report() {
+  golden_report \
+    | sed 's/^  Bench.RefLoop.lua:34 JFORI$/  Bench.RefLoop.lua:32 JFUNCF\n&/' \
+    | sed 's/^counts: aborts=1 compiled=3/counts: aborts=1 compiled=4/'
+}
+
+# A toolchain bump: nothing about the measured sets changed, but the report
+# is pinned to a specific LuaJIT snapshot.
+bumped_runtime_report() {
+  golden_report | sed 's/^runtime: .*/runtime: LuaJIT 2.1.9999999999/'
+}
+
+# One synthetic bench tree: matching goldens and output, plus a stand-in for
+# `luajit trace_report.lua <spec>` that counts its invocations and prints
+# whatever the case under test staged as the next canonical report.
+fixture() {
+  local dir=$1
+  mkdir -p "$dir/goldens" "$dir/out" "$dir/macro"
+  printf 'main chunk: 1\nfunction bodies: 0\n' >"$dir/goldens/fnew_Bench.RefLoop.txt"
+  cp "$dir/goldens/fnew_Bench.RefLoop.txt" "$dir/out/fnew_Bench.RefLoop.txt"
+  golden_report >"$dir/goldens/trace_ref_loop.txt"
+  golden_report >"$dir/out/trace_ref_loop.txt"
+  : >"$dir/macro/ref_loop.lua"
+  cat >"$dir/report" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+here=$(dirname "$0")
+echo "$1" >>"$here/regen.log"
+cat "$here/next_report.txt"
+EOF
+  chmod +x "$dir/report"
+  golden_report >"$dir/next_report.txt"
+  : >"$dir/regen.log"
+}
+
+# Run diff_counters over a fixture and pin both its verdict and its cost: a
+# retry budget spent on something deterministic is as much a defect as a
+# wrong verdict, because the whole point of the classification is to spend
+# fresh processes only where a second measurement can differ.
+check() {
+  local name=$1 retries=$2 want_exit=$3 want_regens=$4 dir=$5
+  local got_exit=0 got_regens
+  BENCH_TRACE_RETRIES=$retries "$diff_counters" \
+    "$dir/goldens" "$dir/out" "$dir/macro" "$dir/report" \
+    >"$dir/log" 2>&1 || got_exit=$?
+  got_regens=$(wc -l <"$dir/regen.log")
+  if [ "$got_exit" -ne "$want_exit" ] || [ "$got_regens" -ne "$want_regens" ]; then
+    printf 'FAIL %s\n       exit %d (want %d), regenerations %d (want %d)\n' \
+      "$name" "$got_exit" "$want_exit" "$got_regens" "$want_regens"
+    sed 's/^/       | /' "$dir/log"
+    failures=$((failures + 1))
+  else
+    printf 'ok   %s (exit %d, %d regenerations)\n' \
+      "$name" "$got_exit" "$got_regens"
+  fi
+}
+
+root=$(mktemp -d)
+trap 'rm -rf "$root"' EXIT
+
+case_dir() {
+  local dir=$root/$1
+  fixture "$dir"
+  printf '%s' "$dir"
+}
+
+dir=$(case_dir matching)
+check 'matching reports pass without re-measuring' 2 0 0 "$dir"
+
+# The failure this exists to absorb: a spot whose per-process trace-formation
+# probability sits between 0 and 1 shows up in this run and not in the golden.
+dir=$(case_dir marginal-absorbed)
+marginal_report >"$dir/out/trace_ref_loop.txt"
+check 'marginal trace entry absorbed by a re-measurement' 2 0 1 "$dir"
+
+# With no retry budget the same fixture reddens, which is the pre-retry
+# behaviour and the reason the knob is worth keeping addressable.
+dir=$(case_dir marginal-no-retry)
+marginal_report >"$dir/out/trace_ref_loop.txt"
+check 'marginal trace entry reddens with the retry budget at zero' 0 1 0 "$dir"
+
+# A genuine codegen change re-measures to the same thing every time, so it
+# spends the whole budget and still fails.
+dir=$(case_dir codegen-change)
+marginal_report >"$dir/out/trace_ref_loop.txt"
+marginal_report >"$dir/next_report.txt"
+check 'reproducible trace change fails after spending the budget' 2 1 2 "$dir"
+
+# The censuses never run the artifact, so a difference there is a real change
+# with nothing to re-measure.
+dir=$(case_dir census-change)
+printf 'main chunk: 2\nfunction bodies: 0\n' >"$dir/out/fnew_Bench.RefLoop.txt"
+check 'census difference fails without re-measuring' 2 1 0 "$dir"
+
+# A trace report's header is derived from the spec and a deterministic
+# checksum, so it is as fixed as a census.
+dir=$(case_dir runtime-bump)
+bumped_runtime_report >"$dir/out/trace_ref_loop.txt"
+check 'trace header change fails without re-measuring' 2 1 0 "$dir"
+
+dir=$(case_dir report-missing)
+rm "$dir/out/trace_ref_loop.txt"
+check 'report missing from the output fails without re-measuring' 2 1 0 "$dir"
+
+dir=$(case_dir report-added)
+golden_report >"$dir/out/trace_tuple_fold.txt"
+check 'report absent from the goldens fails without re-measuring' 2 1 0 "$dir"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nbench counter verdict logic behaves as pinned\n'

--- a/bench/tools/counters_selftest
+++ b/bench/tools/counters_selftest
@@ -59,6 +59,10 @@ fixture() {
 set -eu
 here=$(dirname "$0")
 echo "$1" >>"$here/regen.log"
+# trace_report.lua exits non-zero when a trial process fails or the
+# deterministic part of a report diverges between its own trials; `broken`
+# stages that.
+[ -e "$here/broken" ] && exit 1
 cat "$here/next_report.txt"
 EOF
   chmod +x "$dir/report"
@@ -138,6 +142,14 @@ check 'report missing from the output fails without re-measuring' 2 1 0 "$dir"
 dir=$(case_dir report-added)
 golden_report >"$dir/out/trace_tuple_fold.txt"
 check 'report absent from the goldens fails without re-measuring' 2 1 0 "$dir"
+
+# A measurement that did not happen is not a spent attempt. Burning the rest of
+# the budget on it would end in "still differs after N re-measurements",
+# blaming the counters for what the measuring tool reported about itself.
+dir=$(case_dir regen-broken)
+marginal_report >"$dir/out/trace_ref_loop.txt"
+: >"$dir/broken"
+check 'a failed re-measurement aborts instead of spending the budget' 2 1 1 "$dir"
 
 if [ "$failures" -ne 0 ]; then
   printf '\n%d check(s) failed\n' "$failures"

--- a/bench/tools/diff_counters
+++ b/bench/tools/diff_counters
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Compares a freshly generated directory of LuaJIT counter reports against the
+# committed oracles, re-measuring only what a second run of the same artifact
+# can legitimately change.
+#
+# usage: diff_counters <goldens-dir> <output-dir> <spec-dir> <regen-cmd...>
+#
+# <regen-cmd> is invoked as `<regen-cmd> <spec-dir>/<spec>.lua` and must print
+# a canonical trace report on stdout; its output replaces
+# <output-dir>/trace_<spec>.txt before the comparison is repeated.
+#
+# Why a re-measurement is worth a fresh set of processes at all: a trace
+# report records which source locations of the artifact ended up carrying a
+# compiled trace or a blacklist, and whether a given location does is a
+# per-process dice roll for spots sitting on LuaJIT's hot-count boundary --
+# its hot counters live in a small hashed table keyed by bytecode address, so
+# removing one `local` from an artifact reshuffles which counters collide.
+# trace_report.lua already votes over independent trials, which pins any spot
+# whose per-process formation probability p sits near 0 or 1; a spot in
+# between stays unpinnable, and a codegen change that merely shifts lines can
+# create one out of nothing.
+#
+# For such a spot, spending the process budget on a second vote beats spending
+# it on a longer one, because a longer vote only sharpens an estimate of a p
+# that is not near one half to begin with. With the default nine trials, the
+# chance one vote lands on the wrong side of the golden is P(Binom(9,p) <= 4):
+#
+#   p     one vote   +1 re-measurement   +2 (the default)   25 trials, one vote
+#   0.60  26.7%      7.1%                1.9%               15.4%
+#   0.70   9.9%      1.0%                0.1%                1.8%
+#   0.80   2.0%      0.04%               0.001%             0.04%
+#
+# The re-measurements are conjunctive -- every attempt must differ for the
+# oracle to fail -- which is what squares the odds where pooling the same
+# processes into one larger vote would not. Their independence is genuine
+# within a run: p is a property of the artifact plus the process layout, and
+# each trial is a fresh process, so the retry budget resamples the layout
+# while the artifact bytes and the LuaJIT binary stay fixed.
+#
+# The trade is that a regression landing near p = 0.5 is masked -- but such a
+# regression has no pinnable golden on either side even with one vote, so
+# nothing previously catchable becomes uncatchable. Everything else is
+# deterministic and re-measures to the same thing every time, so it spends the
+# budget and still fails.
+#
+# The retry budget is per report and overridable with BENCH_TRACE_RETRIES
+# (0 disables re-measurement, restoring a plain diff).
+set -euo pipefail
+
+goldens=$1
+out=$2
+specs=$3
+shift 3
+regen=("$@")
+
+# Clamped rather than validated, the way trace_report.lua treats its own trial
+# count: a knob that reads as garbage falls back to the documented default.
+retries=${BENCH_TRACE_RETRIES:-2}
+case $retries in
+'' | *[!0-9]*) retries=2 ;;
+esac
+
+report_names() {
+  local path
+  for path in "$1"/*.txt; do
+    [ -e "$path" ] || continue
+    basename "$path"
+  done | sort
+}
+
+# The censuses are static walks over the artifact and never run it, and a
+# trace report's header lines are derived from the spec plus a deterministic
+# checksum. Only a trace report's entries -- indented one level under their
+# section -- and the `counts:` line tallying them can differ between two runs
+# of the same artifact, so a difference anywhere else has nothing to
+# re-measure and must fail on the spot rather than buy fresh processes.
+noise_only() {
+  local line
+  while IFS= read -r line; do
+    case $line in
+    '  '* | 'counts: '*) ;;
+    *) return 1 ;;
+    esac
+  done < <(diff "$1" "$2" | sed -n 's/^[<>] \{0,1\}//p')
+}
+
+note() {
+  printf '%s\n' "$*" >&2
+}
+
+fail=0
+
+# A report on one side only means a spec or an artifact was added or removed,
+# which is a structural change to the oracle rather than a measurement.
+for name in $(comm -23 <(report_names "$goldens") <(report_names "$out")); do
+  note "$name: in the goldens but not in the output"
+  fail=1
+done
+for name in $(comm -13 <(report_names "$goldens") <(report_names "$out")); do
+  note "$name: in the output but not in the goldens"
+  fail=1
+done
+
+for name in $(comm -12 <(report_names "$goldens") <(report_names "$out")); do
+  if cmp -s "$goldens/$name" "$out/$name"; then
+    continue
+  fi
+
+  case $name in
+  trace_*.txt) ;;
+  *)
+    note "$name: differs from the golden"
+    diff -u "$goldens/$name" "$out/$name" >&2 || true
+    fail=1
+    continue
+    ;;
+  esac
+
+  if ! noise_only "$goldens/$name" "$out/$name"; then
+    note "$name: differs from the golden outside the measured sets"
+    diff -u "$goldens/$name" "$out/$name" >&2 || true
+    fail=1
+    continue
+  fi
+
+  first_diff=$(diff -u "$goldens/$name" "$out/$name" || true)
+  spec=${name#trace_}
+  spec=${spec%.txt}
+  attempt=0
+  matched=0
+  while [ "$attempt" -lt "$retries" ]; do
+    attempt=$((attempt + 1))
+    note "$name: differs in the measured sets; re-measuring ($attempt of $retries)"
+    "${regen[@]}" "$specs/$spec.lua" >"$out/$name.remeasured"
+    mv "$out/$name.remeasured" "$out/$name"
+    if cmp -s "$goldens/$name" "$out/$name"; then
+      matched=1
+      break
+    fi
+  done
+
+  if [ "$matched" = 1 ]; then
+    # Green, but never silently: a spot that resolves in some processes and
+    # not others is the one thing a reviewer cannot see in the committed
+    # goldens.
+    note "$name: matched on re-measurement $attempt -- the entries below are" \
+      "trace-formation noise, not a codegen change"
+    printf '%s\n' "$first_diff" >&2
+  else
+    if [ "$attempt" = 0 ]; then
+      note "$name: differs in the measured sets (re-measurement disabled)"
+    else
+      note "$name: still differs after $attempt re-measurement(s)"
+    fi
+    diff -u "$goldens/$name" "$out/$name" >&2 || true
+    fail=1
+  fi
+done
+
+if [ "$fail" != 0 ]; then
+  exit 1
+fi
+echo "bench counters match goldens"

--- a/bench/tools/diff_counters
+++ b/bench/tools/diff_counters
@@ -7,7 +7,13 @@
 #
 # <regen-cmd> is invoked as `<regen-cmd> <spec-dir>/<spec>.lua` and must print
 # a canonical trace report on stdout; its output replaces
-# <output-dir>/trace_<spec>.txt before the comparison is repeated.
+# <output-dir>/trace_<spec>.txt before the comparison is repeated. A regen that
+# exits non-zero aborts the comparison there and then rather than counting as a
+# spent attempt: trace_report.lua exits non-zero when a trial process fails or
+# when the deterministic part of a report diverges between its own trials, and
+# both mean the measurement did not happen. Retrying past that would report a
+# tool failure as "still differs after N re-measurements", attributing it to
+# the counters instead of to the measurement.
 #
 # Why a re-measurement is worth a fresh set of processes at all: a trace
 # report records which source locations of the artifact ended up carrying a

--- a/bench/tools/trace_report.lua
+++ b/bench/tools/trace_report.lua
@@ -32,8 +32,11 @@
 -- allocation addresses enough to move counter aliasing -- the same
 -- artifact measures p ~ 0.05 when loaded through a shorter relative path.
 -- ./bench/ci runs everything from the repository root, so the goldens pin
--- the counters for that layout. The canonical report is stable by
--- construction, so ./bench/ci verifies each report once.
+-- the counters for that layout. What the vote cannot pin is a p sitting near
+-- one half, and a codegen change that merely shifts artifact lines can put
+-- one there; the comparison against the goldens absorbs that by re-measuring
+-- a report that differs only in the measured sets (bench/tools/diff_counters,
+-- and "Marginal trace spots" in bench/README.md).
 --
 -- usage:
 --   luajit trace_report.lua <bench/macro/NAME.lua>          canonical report

--- a/changelog.d/20260729_190000_unisay_bench_trace_oracle_remeasure.md
+++ b/changelog.d/20260729_190000_unisay_bench_trace_oracle_remeasure.md
@@ -1,0 +1,49 @@
+### Fixed
+
+- The bench counter oracle no longer reddens CI on trace-formation noise
+  (#346). `./bench/ci` diffs committed reports of what LuaJIT did to each
+  linked benchmark artifact; two of the three are static walks and byte-stable,
+  but the per-spec trace report records which source locations ended up
+  carrying a compiled trace (`J*` opcodes) or a blacklist (`I*`), and whether a
+  given location does is a per-process dice roll — LuaJIT's hot counters live
+  in a small hashed table keyed by bytecode address, so dropping one hoisted
+  table from an artifact reshuffles which counters collide. `trace_report.lua`
+  votes over nine fresh processes, which pins any spot forming with per-process
+  probability near 0 or 1 and leaves one near ½ a coin flip.
+
+  Measured over 30 raw single-process trials per spec, that is a class rather
+  than a case: 14 entries across 8 of the 12 specs land strictly between
+  "never" and "always", in both measured signals, the widest being
+
+  ```
+  spec         raw/30  golden   entry
+  ref_loop     21/30   present  Bench.RefLoop.lua:32 JFUNCF
+  ref_loop      8/30   absent   Bench.RefLoop.lua:35 -- inner loop in root trace
+  record_set    4/30   absent   Bench.RecordSet.lua:6 -- inner loop in root trace
+  ctor_build   26/30   present  Bench.CtorBuild.lua:3 JFUNCF
+  array_foldl  27/30   present  Bench.ArrayFoldl.lua:20 -- NYI: bytecode FNEW
+  ```
+
+  The comparison now lives in `bench/tools/diff_counters`, which re-measures a
+  trace report that differs from its golden **only** in those two sets and
+  fails only if every attempt still differs (two re-measurements by default,
+  `BENCH_TRACE_RETRIES` overrides, `0` restores a plain diff). A census
+  difference, a report header difference, or a report existing on one side only
+  is deterministic by construction and fails at once, buying no fresh
+  processes. Replaying the comparison for `ref_loop` against its committed
+  golden 300 times, paired on the same measurements:
+
+  ```
+  retries=0 over 300 runs: red=9, absorbed-by-re-measurement=0
+  retries=2 over 300 runs: red=0, absorbed-by-re-measurement=10
+  ```
+
+  Re-measuring is conjunctive, which is what makes it a better use of fresh
+  processes than a longer vote: for one entry at probability `p`, a nine-trial
+  vote misreports with `P(Binom(9,p) ≤ 4)` and each re-measurement multiplies
+  that in — 26.7% → 7.1% → 1.9% at `p = 0.6`, where pooling 25 trials into a
+  single vote reaches only 15.4%. A reproducible change re-measures to the same
+  thing every time and still fails; what is given up is a regression landing
+  near `p = 0.5`, which has no pinnable golden on either side even with one
+  vote. `bench/tools/counters_selftest` pins those verdicts against synthetic
+  reports and runs in CI ahead of the counters.


### PR DESCRIPTION
Closes #346.

`./bench/ci` is the repository's benchmark oracle: it links the `Bench.*` PureScript modules to standalone Lua, meters what LuaJIT does with them, and diffs the result against reports committed under `bench/goldens/`, so a codegen change that adds a closure allocation or stops a loop from being compiled shows up as a reviewable diff. Two of the three meters are static walks over the artifact and byte-stable by construction. The third, the per-spec trace report, records which source locations ended up carrying a compiled trace (LuaJIT rewrites the opcode to a `J*` form) or a blacklist (an `I*` form) — and whether a given location does is a per-process dice roll, because LuaJIT's hot counters live in a small hashed table keyed by bytecode address, so removing one hoisted table from an artifact reshuffles which counters collide. `bench/tools/trace_report.lua` already absorbs that with a majority vote over nine fresh LuaJIT processes, which pins any spot whose per-process formation probability `p` sits near 0 or 1 and leaves a spot near one half a coin flip.

## The failure is a class, not the one spot

`Bench.RefLoop.lua:32 JFUNCF` — the entry of the ST thunk wrapping a hot loop — is the entry the issue names, having become marginal when an unrelated codegen change shifted a line. Measuring every spec's entries over 30 raw single-process trials (`trace_report.lua <spec> --trial` prints one unvoted measurement) shows it is one of fourteen: fourteen entries across 8 of the 12 specs land strictly between "never" and "always".

```
spec         raw/30  golden   entry
ref_loop     21/30   present  Bench.RefLoop.lua:32 JFUNCF
ref_loop      8/30   absent   Bench.RefLoop.lua:35 -- inner loop in root trace
record_set    4/30   absent   Bench.RecordSet.lua:6 -- inner loop in root trace
ctor_build    4/30   absent   Bench.CtorBuild.lua:6 -- inner loop in root trace
ctor_build   26/30   present  Bench.CtorBuild.lua:3 JFUNCF
record_set   26/30   present  Bench.RecordSet.lua:3 JFUNCF
record_set   26/30   present  Bench.RecordSet.lua:29 -- NYI: bytecode FNEW
array_foldl  27/30   present  Bench.ArrayFoldl.lua:20 -- NYI: bytecode FNEW
```

Two facts in that table decide the design. Both measured signals are affected, not just opcode end states: `-- inner loop in root trace` and `-- NYI: bytecode FNEW` are abort-site entries, which live in the report's other section. And the two `ref_loop` entries are complementary (21 + 8 ≈ 30) — the abort is what gets recorded when the entry trace does not form — so this is one phenomenon surfacing in two places, not two independent problems.

## What changes

The comparison moves out of `bench/ci` into `bench/tools/diff_counters`, which classifies each mismatch before deciding what it costs. A trace report differing **only** in its two measured sets (the indented entries and the `counts:` line tallying them) is re-measured — a fresh nine-process vote — and fails only if every attempt still differs; two re-measurements is the default, `BENCH_TRACE_RETRIES` overrides it, and `0` restores a plain diff. Everything else is deterministic by construction and fails at once, buying no fresh processes: a census difference, a difference in a trace report's header lines (`spec:`, `runtime:`, `workload:` — derived from the spec plus a deterministic checksum), or a report existing on one side only.

That second half is not just tidiness. A LuaJIT bump changes the `runtime:` line of all twelve reports, and re-measuring twelve reports twice only to rediscover a version string would spend about a minute of fresh processes reaching the same verdict:

```
trace_ref_loop.txt: differs from the golden outside the measured sets
--- bench/_build/demo/goldens/trace_ref_loop.txt	2026-07-29 16:09:00.122835133 +0200
+++ bench/_build/demo/out/trace_ref_loop.txt	2026-07-29 16:09:00.119835126 +0200
@@ -1,5 +1,5 @@
 spec: ref_loop
-runtime: LuaJIT 2.1.9999999999
+runtime: LuaJIT 2.1.1741730670
 workload: n=100000 reps=4 result=4999950000
 aborts (distinct site -- reason):
   Bench.RefLoop.lua:40 -- NYI: bytecode FNEW
```

## Evidence

Replaying the comparison for `ref_loop` against its committed golden 300 times, each iteration generating a fresh canonical report and then asking both configurations about it:

```
retries=0 over 300 runs: red=9, absorbed-by-re-measurement=0
retries=2 over 300 runs: red=0, absorbed-by-re-measurement=10
```

Those nine reds are the one entry the issue names, measured in isolation. Repeating the exercise over the whole twelve-spec pass, so every marginal entry is in play at once, puts the step-level rate in the same place and shows which entry dominates it:

```
iteration 23 would redden today: trace_ref_loop.txt

40 iterations of the full 12-spec trace pass:
  reddens with a plain diff (today): 1
  reddens with 2 re-measurements:    0
  absorbed by a re-measurement:      1
```

The other thirteen marginal entries sit far enough from one half that a nine-trial vote already pins them (each below 0.4% on its own), which is why `ref_loop` is the only spec that shows up; they matter because the next line-shifting codegen change can move any of them, not because they redden today.

A reproducible change to which bytecodes trace still fails, having spent the whole budget. Standing in for a regression that blacklists a hot loop instead of compiling it, `JFORL` → `IFORL` in the golden:

```
trace_ref_loop.txt: differs in the measured sets; re-measuring (1 of 2)
trace_ref_loop.txt: differs in the measured sets; re-measuring (2 of 2)
trace_ref_loop.txt: still differs after 2 re-measurement(s)
--- bench/_build/demo/goldens/trace_ref_loop.txt	2026-07-29 16:09:00.191835295 +0200
+++ bench/_build/demo/out/trace_ref_loop.txt	2026-07-29 16:09:00.310835574 +0200
@@ -7,5 +7,5 @@
   Bench.RefLoop.lua:10 JFUNCF
   Bench.RefLoop.lua:32 JFUNCF
   Bench.RefLoop.lua:34 JFORI
-  Bench.RefLoop.lua:34 IFORL
+  Bench.RefLoop.lua:34 JFORL
 counts: aborts=1 compiled=4 blacklisted=0
```

An absorbed flip is green but never silent — the entries that flickered are printed, since a spot resolving in some processes and not others is the one thing a reviewer cannot see in the committed goldens. This is not a staged mismatch: generating canonical reports against the real committed golden until one genuinely differed took 36 attempts, matching the measured rate, and the 36th is what the oracle then saw.

```
trace_ref_loop.txt: differs in the measured sets; re-measuring (1 of 2)
trace_ref_loop.txt: matched on re-measurement 1 -- the entries below are trace-formation noise, not a codegen change
--- bench/_build/demo/goldens/trace_ref_loop.txt	2026-07-29 16:09:15.689871641 +0200
+++ bench/_build/demo/out/trace_ref_loop.txt	2026-07-29 16:09:17.405875668 +0200
@@ -5,7 +5,6 @@
   Bench.RefLoop.lua:40 -- NYI: bytecode FNEW
 bytecode end state (J*=compiled, I*=blacklisted):
   Bench.RefLoop.lua:10 JFUNCF
-  Bench.RefLoop.lua:32 JFUNCF
   Bench.RefLoop.lua:34 JFORI
   Bench.RefLoop.lua:34 JFORL
-counts: aborts=1 compiled=4 blacklisted=0
+counts: aborts=1 compiled=3 blacklisted=0
bench counters match goldens
```

## Why re-measuring, and not the alternatives

Re-measurements are conjunctive — every attempt must differ for the oracle to fail — which is what makes them a better use of fresh processes than a longer vote. For one entry at probability `p`, a nine-trial vote lands on the wrong side with `P(Binom(9,p) ≤ 4)`, and each re-measurement multiplies that in:

```
p     one vote   +1 re-measurement   +2 (the default)   25 trials, one vote
0.60  26.7%      7.1%                1.9%               15.4%
0.70   9.9%      1.0%                0.1%                1.8%
0.80   2.0%      0.04%               0.001%             0.04%
```

The independence is genuine within a run: `p` is a property of the artifact plus the process layout, each trial is a fresh process, so the budget resamples the layout while the artifact bytes and the LuaJIT binary stay fixed. And re-measurements are free on a green run, where a longer vote costs its extra processes every time.

The measured table above is what rules out the issue's other three options. **Quarantining named spots** would exempt fourteen entries across 8 of 12 specs — most of what the oracle pins — and the list needs re-deriving after every codegen change that shifts lines, which is the very event that creates marginal spots. **Dropping the function-entry signal class** (`J*FUNCF`) leaves the abort-site entries untouched, and those are half the table, so it would give up real signal without removing the failure mode. **Classifying a middle band as a third state** needs a band edge, and the measured probabilities are spread across the whole range (4, 8, 21, 26, 27, 28, 29 out of 30), so some spot sits on whatever edge is chosen.

What re-measuring gives up is a regression that itself lands near `p = 0.5`. Such a regression has no pinnable golden on either side even with a single vote, so nothing previously catchable becomes uncatchable.

## Guard

`bench/tools/counters_selftest` pins the verdict logic against synthetic reports, so it runs in milliseconds instead of spawning the hundred-odd LuaJIT processes a real set of reports needs — and, more to the point, it can stage a marginal spot deterministically, which the real tool cannot. Each case pins both the verdict and its cost, because a retry budget spent on something deterministic is as much a defect as a wrong verdict. Written first, it was red on exactly the cases about re-measurement when run against a stand-in for today's plain `diff -ru`:

```
ok   matching reports pass without re-measuring (exit 0, 0 regenerations)
FAIL marginal trace entry absorbed by a re-measurement
       exit 1 (want 0), regenerations 0 (want 1)
ok   marginal trace entry reddens with the retry budget at zero (exit 1, 0 regenerations)
FAIL reproducible trace change fails after spending the budget
       exit 1 (want 1), regenerations 0 (want 2)
ok   census difference fails without re-measuring (exit 1, 0 regenerations)
ok   trace header change fails without re-measuring (exit 1, 0 regenerations)
ok   report missing from the output fails without re-measuring (exit 1, 0 regenerations)
ok   report absent from the goldens fails without re-measuring (exit 1, 0 regenerations)
FAIL a failed re-measurement aborts instead of spending the budget
       exit 1 (want 1), regenerations 0 (want 1)

3 check(s) failed
```

and green after:

```
ok   matching reports pass without re-measuring (exit 0, 0 regenerations)
ok   marginal trace entry absorbed by a re-measurement (exit 0, 1 regenerations)
ok   marginal trace entry reddens with the retry budget at zero (exit 1, 0 regenerations)
ok   reproducible trace change fails after spending the budget (exit 1, 2 regenerations)
ok   census difference fails without re-measuring (exit 1, 0 regenerations)
ok   trace header change fails without re-measuring (exit 1, 0 regenerations)
ok   report missing from the output fails without re-measuring (exit 1, 0 regenerations)
ok   report absent from the goldens fails without re-measuring (exit 1, 0 regenerations)
ok   a failed re-measurement aborts instead of spending the budget (exit 1, 1 regenerations)

bench counter verdict logic behaves as pinned
```

Two of those cases pin decisions rather than mechanics. `marginal trace entry reddens with the retry budget at zero` makes the differential permanent — `BENCH_TRACE_RETRIES=0` *is* the pre-change behaviour, so deleting the re-measurement reddens the guard instead of only showing up in this branch's history. And `a failed re-measurement aborts instead of spending the budget` pins the regen contract: `trace_report.lua` exits non-zero when a trial process fails or when the deterministic part of a report diverges between its own trials, and both mean the measurement did not happen, so burning the remaining attempts would end in "still differs after 2 re-measurements" — blaming the counters for what the measuring tool said about itself. That was raised by the automated review as a bug (a transient regen failure not being treated as a retry attempt); the behaviour is deliberate and unchanged, now documented at the regen contract in the tool header and pinned by that case.

CI runs the self-test as its own step ahead of the counters, so a broken verdict reads as itself instead of as a mystery counter diff.

## Sibling audit

The shape searched for was "a committed oracle compared by exact equality over a measurement that is not a pure function of the artifact". Inside `bench/`, that search is what produced the fourteen-entry table: the class is handled uniformly here rather than one spec at a time, and the two censuses are the deliberate contrast — they never run the code, and `./bench/ci` still generates each twice and compares byte for byte.

Outside `bench/`, the eval goldens (`test/ps/**/eval/golden.txt`) do run generated Lua and compare its printed output exactly, so they would have the same exposure if anything reachable iterated a table in unspecified order. Two such sites exist — `PSLUA_object_update` in `lib/Language/PureScript/Backend/Lua/Fixture.hs` and `unsafeSet`/`unsafeDelete` in the prelude fork's `Record/Unsafe.lua` — and both use `pairs` only to build an identically-keyed copy, so iteration order never reaches printed output. The differential spec compares against `luac -p` and `lua` themselves, which are deterministic. Nothing to fix, and nothing filed.

## Notes

Compiler code is untouched, so the committed goldens do not move and `cabal test all` is unaffected (1236 examples, 0 failures). `nix fmt` reports no changes.
