### PR TITLE
Fold constant chains within a sweep instead of one fixpoint round per layer

### DIFF
--- a/changelog.d/20260728_120000_unisay_default_directive_pack.md
+++ b/changelog.d/20260728_120000_unisay_default_directive_pack.md
@@ -17,7 +17,3 @@
 - Directive targets may now contain `_` and `'`, matching PureScript
   identifier syntax (previously `Effect.Ref.modify_` or a primed name could
   not be named by any pragma or directives file).
-- The optimizer fixpoint iteration backstop is raised from 100 to 1000
-  rounds: directive-driven inlining folds a constant chain one layer per
-  round, so legitimate iteration counts scale with the deepest such chain
-  in the module (the ~300-deep golden stress chains need several hundred).

--- a/changelog.d/20260730_120000_unisay_fold_chains_within_sweep.md
+++ b/changelog.d/20260730_120000_unisay_fold_chains_within_sweep.md
@@ -1,0 +1,40 @@
+### Changed
+
+- The IR optimizer no longer needs one whole-module sweep per layer of a
+  constant chain, so compile time stops scaling with the depth of the deepest
+  such chain (#328). Every fold that eliminates a let-bound constructor leaves
+  the payload behind in a spent field-binder — a `Let` nothing reads any more:
+
+  ```
+  let v = Just 2 in                     ->   let $field = 2 in
+    if justTag == reflectCtor v              Just 3
+      then Just (arg0 v + 1) else Nothing
+  ```
+
+  Only the separate dead-code-elimination pass dropped that residue, one pass
+  later in the round. Until it did, the enclosing layer's right-hand side was a
+  `Let` rather than the `Just 3` it wraps, so the fold there declined and the
+  chain advanced by exactly one layer per round. Dropping an unread binding is
+  now also a rewrite (`removeUnusedLetBindings`), on the licence dead-code
+  elimination already used — an effect run stays, anything else is evaluated
+  for a value nothing wants — so the whole cascade completes inside one sweep.
+
+  A ~300-deep chain now converges in as many rounds as a three-deep one:
+  `Golden.LongBindFlipped`'s `specialize+dce` fixpoint goes from 301 rounds to
+  3, and the deepest fixpoint over the whole golden corpus takes 4. Compiling
+  `Golden.LongApplyChain` drops from 42.6s to 1.2s, `Golden.LongBindFlipped`
+  from 8.2s to 1.2s, and the golden suite as a whole from 81.9s to 30.2s.
+
+- The optimizer fixpoint iteration backstop (`maxFixpointIterations`) is 100
+  rounds. Legitimate convergence no longer scales with chain depth, so the
+  bound can sit close to real work (4 rounds at the corpus maximum) and a pass
+  that over-reports changes or genuinely loops is caught after 100 sweeps
+  rather than 1000.
+
+- Collapsing the chains within the sweep unblocks a fold the growth veto used
+  to stall: `Golden.LongWriterBind` compiled a 200-deep `Writer` chain into a
+  nest of closures over `tell`/`discard` plus the `Data.Identity` dictionary
+  tables, and now compiles to straight-line code — the result's first component
+  is the literal `42`, the log a flat `concatArray` spine, and the dictionaries
+  are gone (847 lines of Lua down to 234). The module's execution output is
+  unchanged.

--- a/lib/Language/PureScript/Backend/IR/Optimizer.hs
+++ b/lib/Language/PureScript/Backend/IR/Optimizer.hs
@@ -1457,6 +1457,7 @@ optimizedExpressionWithPastes ctorTags canon pastes policy env =
         `thenRewrite` pushIfCondIntoBranches
         `thenRewrite` pushEliminatorIntoIfBranches
         `thenRewrite` inlineLocalBindings
+        `thenRewrite` removeUnusedLetBindings
     )
 
 {- | Tier 2 of Note [Canonical Effect/ST heads]: rewrite an Effect/ST
@@ -3423,6 +3424,64 @@ inlineLocalBinding rhsRefCounts grouping (body, inlined) =
       usage = countFreeRefUsage name body
       occurrences ∷ Natural
       occurrences = usageTotal usage
+
+{- | Drop the 'Standalone' bindings of a Let that nothing reads any more.
+
+Dead local bindings are the residue of the folds around them: the
+constructor propagation of 'propagateKnownCtorThroughLet' binds each
+read field to a fresh field-binder, 'inlineLocalBindings' then pastes a
+trivial one into its reads, and a pruned branch takes its reads with it
+— each leaving a binding no reference names. Dropping them is dead-code
+elimination, which the @dce@ pass also does; doing it here as a rewrite
+is what lets a /cascade/ complete inside one sweep. A layer of a
+constant chain folds to its result wrapped in the spent field-binder
+Let, and the enclosing layer's right-hand side is then a Let rather
+than the constructor it wraps, so the fold there declines: while the
+residue survives to the end of the sweep, one whole-module round
+advances the chain by exactly one layer, and rounds scale with chain
+depth (issue #328).
+
+The licence to discard an unread binding's right-hand side is the one
+dead-code elimination already takes
+('Language.PureScript.Backend.IR.DCE.eliminateDeadCode'): an effect run
+stays, because dropping it would silently discard the effect
+('isEffectRun'), and anything else is evaluated for a value nothing
+wants. Bindings are decided right to left, so one that is kept alive
+only by a binding itself dropped goes with it; sequential scoping puts a
+binder in scope for the groupings after it and the body, never the ones
+before (Note [Sequential scoping of Let bindings]).
+
+Recursive groups are left alone. Their members reference each other, so
+a dead group is only recognisable as a whole, and the shapes that block
+a cascade bind values rather than recursive closures — the @dce@ pass
+collects a group nothing calls at the end of the round.
+-}
+removeUnusedLetBindings ∷ Applicative m ⇒ RewriteRuleM m Ann
+removeUnusedLetBindings =
+  pure . \case
+    Let ann groupings body
+      | let kept = snd (foldr keep (countFreeRefs body, []) groupings)
+      , length kept < length groupings →
+          Just case nonEmpty kept of
+            Nothing → body
+            Just keptNE → Let ann keptNE body
+    _ → Nothing
+ where
+  keep
+    ∷ Grouping (Ann, Name, Exp)
+    → (Map (Qualified Name) Natural, [Grouping (Ann, Name, Exp)])
+    → (Map (Qualified Name) Natural, [Grouping (Ann, Name, Exp)])
+  keep grouping (refs, kept) = case grouping of
+    Standalone (_ann, name, rhs)
+      | Local name `Map.notMember` refs
+      , not (isEffectRun rhs) →
+          (refs, kept)
+    _ →
+      ( Map.unionsWith
+          (+)
+          (refs : [countFreeRefs rhs | (_ann, _n, rhs) ← listGrouping grouping])
+      , grouping : kept
+      )
 
 {- Note [Complexity and Capture gate inlining]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/Language/PureScript/Backend/IR/Pass.hs
+++ b/lib/Language/PureScript/Backend/IR/Pass.hs
@@ -162,17 +162,23 @@ renderPassCheckFailure = \case
       ["Optimized module contains dangling imported references:"]
         <> (show <$> toList violations)
 
-{- | Iteration backstop for 'RunFixpoint'. Convergence normally takes a
-handful of rounds, but directive-driven inlining folds a constant chain
-one layer per round, so legitimate rounds scale with the deepest such
-chain in the module (the ~300-deep golden stress chains need several
-hundred). Hitting the backstop anyway means a pass over-reports changes
-or genuinely loops — a bug, which the checked runner turns into a
+{- | Iteration backstop for 'RunFixpoint'. Legitimate rounds do not
+scale with the size or shape of the module: a rewrite cascade completes
+inside one sweep, so the deepest golden stress chains (~300 constant
+folds nested one in another) converge in as many rounds as a three-deep
+one. The whole golden corpus peaks at four, so this sits far clear of
+real work, and hitting it means a pass over-reports changes or genuinely
+loops — a bug, which the checked runner turns into a
 'FixpointDivergence' while the production runner accepts the (correct,
 possibly under-optimized) module reached.
+
+The bound is what keeps that bug cheap to find: each round is a sweep of
+the whole module, so a backstop generous enough to hide depth-scaled
+convergence would also make a loop burn hundreds of sweeps before
+reporting.
 -}
 maxFixpointIterations ∷ Natural
-maxFixpointIterations = 1000
+maxFixpointIterations = 100
 
 --------------------------------------------------------------------------------
 -- Runners ---------------------------------------------------------------------

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -2147,12 +2147,14 @@ spec = describe "IR Optimizer" do
       runIdentity (pushEliminatorIntoIfBranches original) `shouldBe` Nothing
 
   describe "inlines expressions" do
+    -- The Let itself is gone from each result below: pasting the body's
+    -- only reference leaves the binding unread, and an unread binding is
+    -- dropped in the same sweep ('removeUnusedLetBindings'). A result
+    -- still carrying the Let would mean the paste never happened.
     test "inlines literals" do
       name ← forAll Gen.name
       inlinee ← forAll Gen.scalarExp
-      let original = let1 name inlinee (refLocal name)
-          expected = let1 name inlinee inlinee
-      optimizedExpression original === expected
+      optimizedExpression (let1 name inlinee (refLocal name)) === inlinee
 
     test "inlines references" do
       name ← forAll Gen.name
@@ -2160,9 +2162,7 @@ spec = describe "IR Optimizer" do
       -- must NOT be inlined (see the self-inlining test below), so the
       -- inlinee is drawn from the other names.
       inlinee ← refLocal <$> forAll (mfilter (/= name) Gen.name)
-      let original = let1 name inlinee (refLocal name)
-          expected = let1 name inlinee inlinee
-      optimizedExpression original === expected
+      optimizedExpression (let1 name inlinee (refLocal name)) === inlinee
 
     -- Regression: substituting @x := x@ is a textual no-op, so the
     -- occurrence count of @x@ never reaches zero and an unguarded rule
@@ -2188,13 +2188,11 @@ spec = describe "IR Optimizer" do
                 && countFreeRef (Local name) e == 0
           )
           Gen.exp
-      let body = refLocal name
-          original = let1 name inlinee body
-          expected = let1 name inlinee inlinee
-      annotateShow body
+      let original = let1 name inlinee (refLocal name)
+      annotateShow original
       -- The inserted copy gets fresh binder names ('substituteCopyM'
       -- freshens every insertion), so compare up to alpha-equivalence.
-      diff (optimizedExpression original) alphaEq expected
+      diff (optimizedExpression original) alphaEq inlinee
 
     test "doesn't inline expressions referenced more than once" do
       name ← forAll Gen.name
@@ -2407,8 +2405,9 @@ spec = describe "IR Optimizer" do
                 PrimAdd
                 (application (refLocal incName) (literalInt 1))
                 (application (refLocal incName) (literalInt 2))
-      optimizedExpression original
-        `shouldSatisfy` alphaEq (let1 incName incExpr (literalInt 5))
+      -- Both call sites fold, so nothing reads the binding and it goes
+      -- with them — the same result the beta-reduced spelling below has.
+      optimizedExpression original `shouldSatisfy` alphaEq (literalInt 5)
 
     it "beta-reduces a small closed lambda argument used twice" do
       let body =

--- a/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
+++ b/test/Language/PureScript/Backend/IR/Optimizer/Spec.hs
@@ -861,6 +861,30 @@ spec = describe "IR Optimizer" do
               )
       optimizedExpression original `shouldSatisfy` alphaEq expected
 
+    it "collapses a chain of nested let-bound constructors in one sweep" do
+      -- Folding one layer leaves the payload behind in a spent field-binder
+      -- Let: the binder's reads are folded and then inlined, so nothing
+      -- reads it any more, yet the Let node stands. The enclosing layer's
+      -- right-hand side is then that Let rather than the constructor it
+      -- wraps, so the fold declines there — and a chain of depth N advances
+      -- one layer per whole-module sweep instead of collapsing in this one.
+      let layer ∷ Int → Exp → Exp
+          layer i inner =
+            let v = Name ("v" <> show i)
+             in let1 v inner $
+                  ifThenElse
+                    (eq (literalString justTag) (reflectCtor (refLocal v)))
+                    ( just
+                        ( primBinOp
+                            PrimAdd
+                            (dataArgumentByIndex SumType 0 (refLocal v))
+                            (literalInt 1)
+                        )
+                    )
+                    nothingCtor
+      optimizedExpression (foldr layer (just (literalInt 0)) [1 .. 8])
+        `shouldBe` just (literalInt 8)
+
     it "declines when the binder is read as a whole value" do
       -- v flows into a function as a whole value, so it cannot be dropped
       -- (nor is it inlinable, so the binding survives untouched).

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.ir
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.ir
@@ -2,4447 +2,2393 @@ UberModule
   { uberModuleBindings =
     [ Standalone
       ( QName
-        { qnameModuleName = ModuleName "Data.Unit", qnameName = Name "unit"
-        }, ObjectProp ( Just Never )
+        { qnameModuleName = ModuleName "Data.Semigroup", qnameName = Name "concatArray"
+        }, ObjectProp Nothing
         ( ForeignImport Nothing
-          ( ModuleName "Data.Unit" ) ".spago/p/prelude/5718c84fdde6247749cb053e816df696c30fe691/src/Data/Unit.purs"
-          [ ( Just Never, Name "unit" ) ]
+          ( ModuleName "Data.Semigroup" ) ".spago/p/prelude/5718c84fdde6247749cb053e816df696c30fe691/src/Data/Semigroup.purs"
+          [ ( Nothing, Name "concatArray" ) ]
         )
-        ( PropName "unit" )
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Data.Semigroup", qnameName = Name "foreign"
-        }, ForeignImport Nothing
-        ( ModuleName "Data.Semigroup" ) ".spago/p/prelude/5718c84fdde6247749cb053e816df696c30fe691/src/Data/Semigroup.purs"
-        [ ( Nothing, Name "concatArray" ) ]
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Data.Identity", qnameName = Name "applyIdentity"
-        }, LiteralObject Nothing
-        [
-          ( PropName "apply", AbsN Nothing
-            ( ParamNamed Nothing ( Name "v" ) :| [] )
-            ( AbsN Nothing
-              ( ParamNamed Nothing ( Name "v1" ) :| [] )
-              ( AppN Nothing
-                ( Ref Nothing ( Local ( Name "v" ) ) )
-                ( Ref Nothing ( Local ( Name "v1" ) ) :| [] )
-              )
-            )
-          ),
-          ( PropName "Functor0", AbsN Nothing
-            ( ParamUnused Nothing :| [] )
-            ( LiteralObject Nothing
-              [
-                ( PropName "map", AbsN Nothing
-                  ( ParamNamed Nothing ( Name "f$0" ) :| [] )
-                  ( AbsN Nothing
-                    ( ParamNamed Nothing ( Name "m$0" ) :| [] )
-                    ( AppN Nothing
-                      ( Ref Nothing ( Local ( Name "f$0" ) ) )
-                      ( Ref Nothing ( Local ( Name "m$0" ) ) :| [] )
-                    )
-                  )
-                )
-              ]
-            )
-          )
-        ]
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Data.Identity", qnameName = Name "applicativeIdentity"
-        }, LiteralObject Nothing
-        [
-          ( PropName "pure", AbsN Nothing
-            ( ParamNamed Nothing ( Name "x$0" ) :| [] )
-            ( Ref Nothing ( Local ( Name "x$0" ) ) )
-          ),
-          ( PropName "Apply0", AbsN Nothing
-            ( ParamUnused Nothing :| [] )
-            ( Ref Nothing ( Imported ( ModuleName "Data.Identity" ) ( Name "applyIdentity" ) ) )
-          )
-        ]
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "discard$w"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "v$0" ) :| [ ParamNamed Nothing ( Name "k$0" ) ] )
-        ( Let Nothing
-          ( Standalone
-            ( Nothing, Name "m$0", AppN Nothing
-              ( Ref Nothing ( Local ( Name "k$0" ) ) )
-              ( DataArgumentByIndex Nothing ProductType 0
-                ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
-              )
-            ) :| []
-          )
-          ( Ctor Nothing ProductType
-            ( ModuleName "Data.Tuple" )
-            ( TyName "Tuple" )
-            ( CtorName "Tuple" )
-            [ DataArgumentByIndex Nothing ProductType 0
-              ( Ref Nothing ( Local ( Name "m$0" ) ) ), AppN Nothing
-              ( AppN Nothing
-                ( ObjectProp Nothing
-                  ( Ref Nothing ( Imported ( ModuleName "Data.Semigroup" ) ( Name "foreign" ) ) )
-                  ( PropName "concatArray" )
-                )
-                ( DataArgumentByIndex Nothing ProductType 1
-                  ( Ref Nothing ( Local ( Name "v$0" ) ) ) :| []
-                )
-              )
-              ( DataArgumentByIndex Nothing ProductType 1
-                ( Ref Nothing ( Local ( Name "m$0" ) ) ) :| []
-              )
-            ]
-          )
-        )
-      ), Standalone
-      ( QName
-        { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "tell"
-        }, AbsN Nothing
-        ( ParamNamed Nothing ( Name "x$0" ) :| [] )
-        ( Ctor Nothing ProductType
-          ( ModuleName "Data.Tuple" )
-          ( TyName "Tuple" )
-          ( CtorName "Tuple" )
-          [ Ref Nothing
-            ( Imported ( ModuleName "Data.Unit" ) ( Name "unit" ) ), Ref Nothing
-            ( Local ( Name "x$0" ) )
-          ]
-        )
+        ( PropName "concatArray" )
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "go"
-        }, Let Nothing
-        ( Standalone
-          ( Nothing, Name "$kont0", AppN Nothing
-            ( Ref Nothing
-              ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-            )
-            ( AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
+        }, Ctor Nothing ProductType
+        ( ModuleName "Data.Tuple" )
+        ( TyName "Tuple" )
+        ( CtorName "Tuple" )
+        [ LiteralInt Nothing 42, Let Nothing
+          ( Standalone
+            ( Nothing, Name "$tmp0", AppN Nothing
+              ( AppN Nothing
+                ( Ref Nothing ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) ) )
+                ( LiteralArray Nothing [ LiteralInt Nothing 162 ] :| [] )
               )
-              ( LiteralArray Nothing [ LiteralInt Nothing 161 ] :| [] ) :|
-              [ AbsN Nothing
-                ( ParamUnused Nothing :| [] )
+              ( AppN Nothing
                 ( AppN Nothing
                   ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
+                    ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                   )
+                  ( LiteralArray Nothing [ LiteralInt Nothing 163 ] :| [] )
+                )
+                ( AppN Nothing
                   ( AppN Nothing
                     ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
+                      ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                     )
-                    ( LiteralArray Nothing [ LiteralInt Nothing 162 ] :| [] ) :|
-                    [ AbsN Nothing
-                      ( ParamUnused Nothing :| [] )
+                    ( LiteralArray Nothing [ LiteralInt Nothing 164 ] :| [] )
+                  )
+                  ( AppN Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                      )
+                      ( LiteralArray Nothing [ LiteralInt Nothing 165 ] :| [] )
+                    )
+                    ( AppN Nothing
                       ( AppN Nothing
                         ( Ref Nothing
-                          ( Imported
-                            ( ModuleName "Golden.LongWriterBind.Test" )
-                            ( Name "discard$w" )
-                          )
+                          ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                         )
+                        ( LiteralArray Nothing [ LiteralInt Nothing 166 ] :| [] )
+                      )
+                      ( AppN Nothing
                         ( AppN Nothing
                           ( Ref Nothing
-                            ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
+                            ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                           )
-                          ( LiteralArray Nothing [ LiteralInt Nothing 163 ] :| [] ) :|
-                          [ AbsN Nothing
-                            ( ParamUnused Nothing :| [] )
+                          ( LiteralArray Nothing [ LiteralInt Nothing 167 ] :| [] )
+                        )
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                            )
+                            ( LiteralArray Nothing [ LiteralInt Nothing 168 ] :| [] )
+                          )
+                          ( AppN Nothing
                             ( AppN Nothing
                               ( Ref Nothing
-                                ( Imported
-                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                  ( Name "discard$w" )
-                                )
+                                ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                               )
+                              ( LiteralArray Nothing [ LiteralInt Nothing 169 ] :| [] )
+                            )
+                            ( AppN Nothing
                               ( AppN Nothing
                                 ( Ref Nothing
                                   ( Imported
-                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                    ( Name "tell" )
+                                    ( ModuleName "Data.Semigroup" )
+                                    ( Name "concatArray" )
                                   )
                                 )
-                                ( LiteralArray Nothing [ LiteralInt Nothing 164 ] :| [] ) :|
-                                [ AbsN Nothing
-                                  ( ParamUnused Nothing :| [] )
+                                ( LiteralArray Nothing [ LiteralInt Nothing 170 ] :| [] )
+                              )
+                              ( AppN Nothing
+                                ( AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported
+                                      ( ModuleName "Data.Semigroup" )
+                                      ( Name "concatArray" )
+                                    )
+                                  )
+                                  ( LiteralArray Nothing [ LiteralInt Nothing 171 ] :| [] )
+                                )
+                                ( AppN Nothing
                                   ( AppN Nothing
                                     ( Ref Nothing
                                       ( Imported
-                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                        ( Name "discard$w" )
+                                        ( ModuleName "Data.Semigroup" )
+                                        ( Name "concatArray" )
                                       )
                                     )
+                                    ( LiteralArray Nothing [ LiteralInt Nothing 172 ] :| [] )
+                                  )
+                                  ( AppN Nothing
                                     ( AppN Nothing
                                       ( Ref Nothing
                                         ( Imported
-                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                          ( Name "tell" )
+                                          ( ModuleName "Data.Semigroup" )
+                                          ( Name "concatArray" )
                                         )
                                       )
-                                      ( LiteralArray Nothing [ LiteralInt Nothing 165 ] :| [] ) :|
-                                      [ AbsN Nothing
-                                        ( ParamUnused Nothing :| [] )
+                                      ( LiteralArray Nothing [ LiteralInt Nothing 173 ] :| [] )
+                                    )
+                                    ( AppN Nothing
+                                      ( AppN Nothing
+                                        ( Ref Nothing
+                                          ( Imported
+                                            ( ModuleName "Data.Semigroup" )
+                                            ( Name "concatArray" )
+                                          )
+                                        )
+                                        ( LiteralArray Nothing [ LiteralInt Nothing 174 ] :| [] )
+                                      )
+                                      ( AppN Nothing
                                         ( AppN Nothing
                                           ( Ref Nothing
                                             ( Imported
-                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                              ( Name "discard$w" )
+                                              ( ModuleName "Data.Semigroup" )
+                                              ( Name "concatArray" )
                                             )
                                           )
+                                          ( LiteralArray Nothing [ LiteralInt Nothing 175 ] :| [] )
+                                        )
+                                        ( AppN Nothing
                                           ( AppN Nothing
                                             ( Ref Nothing
                                               ( Imported
-                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                ( Name "tell" )
+                                                ( ModuleName "Data.Semigroup" )
+                                                ( Name "concatArray" )
                                               )
                                             )
                                             ( LiteralArray Nothing
-                                              [ LiteralInt Nothing 166 ] :| []
-                                            ) :|
-                                            [ AbsN Nothing
-                                              ( ParamUnused Nothing :| [] )
+                                              [ LiteralInt Nothing 176 ] :| []
+                                            )
+                                          )
+                                          ( AppN Nothing
+                                            ( AppN Nothing
+                                              ( Ref Nothing
+                                                ( Imported
+                                                  ( ModuleName "Data.Semigroup" )
+                                                  ( Name "concatArray" )
+                                                )
+                                              )
+                                              ( LiteralArray Nothing
+                                                [ LiteralInt Nothing 177 ] :| []
+                                              )
+                                            )
+                                            ( AppN Nothing
                                               ( AppN Nothing
                                                 ( Ref Nothing
                                                   ( Imported
-                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                    ( Name "discard$w" )
-                                                  )
-                                                )
-                                                ( AppN Nothing
-                                                  ( Ref Nothing
-                                                    ( Imported
-                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                      ( Name "tell" )
-                                                    )
-                                                  )
-                                                  ( LiteralArray Nothing
-                                                    [ LiteralInt Nothing 167 ] :| []
-                                                  ) :|
-                                                  [ AbsN Nothing
-                                                    ( ParamUnused Nothing :| [] )
-                                                    ( AppN Nothing
-                                                      ( Ref Nothing
-                                                        ( Imported
-                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                          ( Name "discard$w" )
-                                                        )
-                                                      )
-                                                      ( AppN Nothing
-                                                        ( Ref Nothing
-                                                          ( Imported
-                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                            ( Name "tell" )
-                                                          )
-                                                        )
-                                                        ( LiteralArray Nothing
-                                                          [ LiteralInt Nothing 168 ] :| []
-                                                        ) :|
-                                                        [ AbsN Nothing
-                                                          ( ParamUnused Nothing :| [] )
-                                                          ( AppN Nothing
-                                                            ( Ref Nothing
-                                                              ( Imported
-                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                ( Name "discard$w" )
-                                                              )
-                                                            )
-                                                            ( AppN Nothing
-                                                              ( Ref Nothing
-                                                                ( Imported
-                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                  ( Name "tell" )
-                                                                )
-                                                              )
-                                                              ( LiteralArray Nothing
-                                                                [ LiteralInt Nothing 169 ] :| []
-                                                              ) :|
-                                                              [ AbsN Nothing
-                                                                ( ParamUnused Nothing :| [] )
-                                                                ( AppN Nothing
-                                                                  ( Ref Nothing
-                                                                    ( Imported
-                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                      ( Name "discard$w" )
-                                                                    )
-                                                                  )
-                                                                  ( AppN Nothing
-                                                                    ( Ref Nothing
-                                                                      ( Imported
-                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                        ( Name "tell" )
-                                                                      )
-                                                                    )
-                                                                    ( LiteralArray Nothing
-                                                                      [ LiteralInt Nothing 170 ] :| []
-                                                                    ) :|
-                                                                    [ AbsN Nothing
-                                                                      ( ParamUnused Nothing :| [] )
-                                                                      ( AppN Nothing
-                                                                        ( Ref Nothing
-                                                                          ( Imported
-                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                            ( Name "discard$w" )
-                                                                          )
-                                                                        )
-                                                                        ( AppN Nothing
-                                                                          ( Ref Nothing
-                                                                            ( Imported
-                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                              ( Name "tell" )
-                                                                            )
-                                                                          )
-                                                                          ( LiteralArray Nothing
-                                                                            [ LiteralInt Nothing 171 ] :| []
-                                                                          ) :|
-                                                                          [ AbsN Nothing
-                                                                            ( ParamUnused Nothing :| [] )
-                                                                            ( AppN Nothing
-                                                                              ( Ref Nothing
-                                                                                ( Imported
-                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                  ( Name "discard$w" )
-                                                                                )
-                                                                              )
-                                                                              ( AppN Nothing
-                                                                                ( Ref Nothing
-                                                                                  ( Imported
-                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                    ( Name "tell" )
-                                                                                  )
-                                                                                )
-                                                                                ( LiteralArray Nothing
-                                                                                  [ LiteralInt Nothing 172 ] :| []
-                                                                                ) :|
-                                                                                [ AbsN Nothing
-                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                  ( AppN Nothing
-                                                                                    ( Ref Nothing
-                                                                                      ( Imported
-                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                        ( Name "discard$w" )
-                                                                                      )
-                                                                                    )
-                                                                                    ( AppN Nothing
-                                                                                      ( Ref Nothing
-                                                                                        ( Imported
-                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                          ( Name "tell" )
-                                                                                        )
-                                                                                      )
-                                                                                      ( LiteralArray Nothing
-                                                                                        [ LiteralInt Nothing 173 ] :| []
-                                                                                      ) :|
-                                                                                      [ AbsN Nothing
-                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                        ( AppN Nothing
-                                                                                          ( Ref Nothing
-                                                                                            ( Imported
-                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                              ( Name "discard$w" )
-                                                                                            )
-                                                                                          )
-                                                                                          ( AppN Nothing
-                                                                                            ( Ref Nothing
-                                                                                              ( Imported
-                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                ( Name "tell" )
-                                                                                              )
-                                                                                            )
-                                                                                            ( LiteralArray Nothing
-                                                                                              [ LiteralInt Nothing 174 ] :| []
-                                                                                            ) :|
-                                                                                            [ AbsN Nothing
-                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                              ( AppN Nothing
-                                                                                                ( Ref Nothing
-                                                                                                  ( Imported
-                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                    ( Name "discard$w" )
-                                                                                                  )
-                                                                                                )
-                                                                                                ( AppN Nothing
-                                                                                                  ( Ref Nothing
-                                                                                                    ( Imported
-                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                      ( Name "tell" )
-                                                                                                    )
-                                                                                                  )
-                                                                                                  ( LiteralArray Nothing
-                                                                                                    [ LiteralInt Nothing 175 ] :| []
-                                                                                                  ) :|
-                                                                                                  [ AbsN Nothing
-                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                    ( AppN Nothing
-                                                                                                      ( Ref Nothing
-                                                                                                        ( Imported
-                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                          ( Name "discard$w" )
-                                                                                                        )
-                                                                                                      )
-                                                                                                      ( AppN Nothing
-                                                                                                        ( Ref Nothing
-                                                                                                          ( Imported
-                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                            ( Name "tell" )
-                                                                                                          )
-                                                                                                        )
-                                                                                                        ( LiteralArray Nothing
-                                                                                                          [ LiteralInt Nothing 176 ] :| []
-                                                                                                        ) :|
-                                                                                                        [ AbsN Nothing
-                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                          ( AppN Nothing
-                                                                                                            ( Ref Nothing
-                                                                                                              ( Imported
-                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                ( Name "discard$w" )
-                                                                                                              )
-                                                                                                            )
-                                                                                                            ( AppN Nothing
-                                                                                                              ( Ref Nothing
-                                                                                                                ( Imported
-                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                  ( Name "tell" )
-                                                                                                                )
-                                                                                                              )
-                                                                                                              ( LiteralArray Nothing
-                                                                                                                [ LiteralInt Nothing 177 ] :| []
-                                                                                                              ) :|
-                                                                                                              [ AbsN Nothing
-                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                ( AppN Nothing
-                                                                                                                  ( Ref Nothing
-                                                                                                                    ( Imported
-                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                      ( Name "discard$w" )
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                  ( AppN Nothing
-                                                                                                                    ( Ref Nothing
-                                                                                                                      ( Imported
-                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                        ( Name "tell" )
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    ( LiteralArray Nothing
-                                                                                                                      [ LiteralInt Nothing 178 ] :| []
-                                                                                                                    ) :|
-                                                                                                                    [ AbsN Nothing
-                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                      ( AppN Nothing
-                                                                                                                        ( Ref Nothing
-                                                                                                                          ( Imported
-                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                            ( Name "discard$w" )
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                        ( AppN Nothing
-                                                                                                                          ( Ref Nothing
-                                                                                                                            ( Imported
-                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                              ( Name "tell" )
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                          ( LiteralArray Nothing
-                                                                                                                            [ LiteralInt Nothing 179 ] :| []
-                                                                                                                          ) :|
-                                                                                                                          [ AbsN Nothing
-                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                            ( AppN Nothing
-                                                                                                                              ( Ref Nothing
-                                                                                                                                ( Imported
-                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                              ( AppN Nothing
-                                                                                                                                ( Ref Nothing
-                                                                                                                                  ( Imported
-                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                    ( Name "tell" )
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                  [ LiteralInt Nothing 180 ] :| []
-                                                                                                                                ) :|
-                                                                                                                                [ AbsN Nothing
-                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                  ( AppN Nothing
-                                                                                                                                    ( Ref Nothing
-                                                                                                                                      ( Imported
-                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                      )
-                                                                                                                                    )
-                                                                                                                                    ( AppN Nothing
-                                                                                                                                      ( Ref Nothing
-                                                                                                                                        ( Imported
-                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                          ( Name "tell" )
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                        [ LiteralInt Nothing 181 ] :| []
-                                                                                                                                      ) :|
-                                                                                                                                      [ AbsN Nothing
-                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                        ( AppN Nothing
-                                                                                                                                          ( Ref Nothing
-                                                                                                                                            ( Imported
-                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                          ( AppN Nothing
-                                                                                                                                            ( Ref Nothing
-                                                                                                                                              ( Imported
-                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                ( Name "tell" )
-                                                                                                                                              )
-                                                                                                                                            )
-                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                              [ LiteralInt Nothing 182 ] :| []
-                                                                                                                                            ) :|
-                                                                                                                                            [ AbsN Nothing
-                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                              ( AppN Nothing
-                                                                                                                                                ( Ref Nothing
-                                                                                                                                                  ( Imported
-                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                                ( AppN Nothing
-                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                    ( Imported
-                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                    )
-                                                                                                                                                  )
-                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                    [ LiteralInt Nothing 183 ] :| []
-                                                                                                                                                  ) :|
-                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                        ( Imported
-                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                        )
-                                                                                                                                                      )
-                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                          ( Imported
-                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                          )
-                                                                                                                                                        )
-                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                          [ LiteralInt Nothing 184 ] :| []
-                                                                                                                                                        ) :|
-                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                              ( Imported
-                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                ( Imported
-                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                )
-                                                                                                                                                              )
-                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                [ LiteralInt Nothing 185 ] :| []
-                                                                                                                                                              ) :|
-                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                    ( Imported
-                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                      ( Imported
-                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                      [ LiteralInt Nothing 186 ] :| []
-                                                                                                                                                                    ) :|
-                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                          ( Imported
-                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                          )
-                                                                                                                                                                        )
-                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                            ( Imported
-                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                            )
-                                                                                                                                                                          )
-                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                            [ LiteralInt Nothing 187 ] :| []
-                                                                                                                                                                          ) :|
-                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                ( Imported
-                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                )
-                                                                                                                                                                              )
-                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                  )
-                                                                                                                                                                                )
-                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                  [ LiteralInt Nothing 188 ] :| []
-                                                                                                                                                                                ) :|
-                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                      )
-                                                                                                                                                                                    )
-                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                        )
-                                                                                                                                                                                      )
-                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                        [ LiteralInt Nothing 189 ] :| []
-                                                                                                                                                                                      ) :|
-                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
-                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
-                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                              [ LiteralInt Nothing 190 ] :| []
-                                                                                                                                                                                            ) :|
-                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                )
-                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                    [ LiteralInt Nothing 191 ] :| []
-                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                          [ LiteralInt Nothing 192 ] :| []
-                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                                [ LiteralInt Nothing 193 ] :| []
-                                                                                                                                                                                                              ) :|
-                                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                                      [ LiteralInt Nothing 194 ] :| []
-                                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                                            [ LiteralInt Nothing 195 ] :| []
-                                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                                                  [ LiteralInt Nothing 196 ] :| []
-                                                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                                                        [ LiteralInt Nothing 197 ] :| []
-                                                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                                                                              [ LiteralInt Nothing 198 ] :| []
-                                                                                                                                                                                                                                            ) :|
-                                                                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                                                                    [ LiteralInt Nothing 199 ] :| []
-                                                                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                                                                          [ LiteralInt Nothing 200 ] :| []
-                                                                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                                                            ( ObjectProp Nothing
-                                                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                                                  ( ModuleName "Data.Identity" )
-                                                                                                                                                                                                                                                                  ( Name "applicativeIdentity" )
-                                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                                              ( PropName "pure" )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                            ( Ctor Nothing ProductType
-                                                                                                                                                                                                                                                              ( ModuleName "Data.Tuple" )
-                                                                                                                                                                                                                                                              ( TyName "Tuple" )
-                                                                                                                                                                                                                                                              ( CtorName "Tuple" )
-                                                                                                                                                                                                                                                              [ LiteralInt Nothing 42, LiteralArray Nothing []
-                                                                                                                                                                                                                                                              ] :| []
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              ]
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        ]
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  ]
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            ]
-                                                                                                                                                                                          )
-                                                                                                                                                                                        )
-                                                                                                                                                                                      ]
-                                                                                                                                                                                    )
-                                                                                                                                                                                  )
-                                                                                                                                                                                ]
-                                                                                                                                                                              )
-                                                                                                                                                                            )
-                                                                                                                                                                          ]
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                    ]
-                                                                                                                                                                  )
-                                                                                                                                                                )
-                                                                                                                                                              ]
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                        ]
-                                                                                                                                                      )
-                                                                                                                                                    )
-                                                                                                                                                  ]
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                            ]
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                      ]
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                ]
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          )
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                    ]
-                                                                  )
-                                                                )
-                                                              ]
-                                                            )
-                                                          )
-                                                        ]
-                                                      )
-                                                    )
-                                                  ]
-                                                )
-                                              )
-                                            ]
-                                          )
-                                        )
-                                      ]
-                                    )
-                                  )
-                                ]
-                              )
-                            )
-                          ]
-                        )
-                      )
-                    ]
-                  )
-                )
-              ]
-            )
-          ) :|
-          [ Standalone
-            ( Nothing, Name "$kont1", AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-              )
-              ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                )
-                ( LiteralArray Nothing [ LiteralInt Nothing 121 ] :| [] ) :|
-                [ AbsN Nothing
-                  ( ParamUnused Nothing :| [] )
-                  ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-                    )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                      )
-                      ( LiteralArray Nothing [ LiteralInt Nothing 122 ] :| [] ) :|
-                      [ AbsN Nothing
-                        ( ParamUnused Nothing :| [] )
-                        ( AppN Nothing
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.LongWriterBind.Test" )
-                              ( Name "discard$w" )
-                            )
-                          )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                ( Name "tell" )
-                              )
-                            )
-                            ( LiteralArray Nothing [ LiteralInt Nothing 123 ] :| [] ) :|
-                            [ AbsN Nothing
-                              ( ParamUnused Nothing :| [] )
-                              ( AppN Nothing
-                                ( Ref Nothing
-                                  ( Imported
-                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                    ( Name "discard$w" )
-                                  )
-                                )
-                                ( AppN Nothing
-                                  ( Ref Nothing
-                                    ( Imported
-                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                      ( Name "tell" )
-                                    )
-                                  )
-                                  ( LiteralArray Nothing [ LiteralInt Nothing 124 ] :| [] ) :|
-                                  [ AbsN Nothing
-                                    ( ParamUnused Nothing :| [] )
-                                    ( AppN Nothing
-                                      ( Ref Nothing
-                                        ( Imported
-                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                          ( Name "discard$w" )
-                                        )
-                                      )
-                                      ( AppN Nothing
-                                        ( Ref Nothing
-                                          ( Imported
-                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                            ( Name "tell" )
-                                          )
-                                        )
-                                        ( LiteralArray Nothing
-                                          [ LiteralInt Nothing 125 ] :| []
-                                        ) :|
-                                        [ AbsN Nothing
-                                          ( ParamUnused Nothing :| [] )
-                                          ( AppN Nothing
-                                            ( Ref Nothing
-                                              ( Imported
-                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                ( Name "discard$w" )
-                                              )
-                                            )
-                                            ( AppN Nothing
-                                              ( Ref Nothing
-                                                ( Imported
-                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                  ( Name "tell" )
-                                                )
-                                              )
-                                              ( LiteralArray Nothing
-                                                [ LiteralInt Nothing 126 ] :| []
-                                              ) :|
-                                              [ AbsN Nothing
-                                                ( ParamUnused Nothing :| [] )
-                                                ( AppN Nothing
-                                                  ( Ref Nothing
-                                                    ( Imported
-                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                      ( Name "discard$w" )
-                                                    )
-                                                  )
-                                                  ( AppN Nothing
-                                                    ( Ref Nothing
-                                                      ( Imported
-                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                        ( Name "tell" )
-                                                      )
-                                                    )
-                                                    ( LiteralArray Nothing
-                                                      [ LiteralInt Nothing 127 ] :| []
-                                                    ) :|
-                                                    [ AbsN Nothing
-                                                      ( ParamUnused Nothing :| [] )
-                                                      ( AppN Nothing
-                                                        ( Ref Nothing
-                                                          ( Imported
-                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                            ( Name "discard$w" )
-                                                          )
-                                                        )
-                                                        ( AppN Nothing
-                                                          ( Ref Nothing
-                                                            ( Imported
-                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                              ( Name "tell" )
-                                                            )
-                                                          )
-                                                          ( LiteralArray Nothing
-                                                            [ LiteralInt Nothing 128 ] :| []
-                                                          ) :|
-                                                          [ AbsN Nothing
-                                                            ( ParamUnused Nothing :| [] )
-                                                            ( AppN Nothing
-                                                              ( Ref Nothing
-                                                                ( Imported
-                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                  ( Name "discard$w" )
-                                                                )
-                                                              )
-                                                              ( AppN Nothing
-                                                                ( Ref Nothing
-                                                                  ( Imported
-                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                    ( Name "tell" )
-                                                                  )
-                                                                )
-                                                                ( LiteralArray Nothing
-                                                                  [ LiteralInt Nothing 129 ] :| []
-                                                                ) :|
-                                                                [ AbsN Nothing
-                                                                  ( ParamUnused Nothing :| [] )
-                                                                  ( AppN Nothing
-                                                                    ( Ref Nothing
-                                                                      ( Imported
-                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                        ( Name "discard$w" )
-                                                                      )
-                                                                    )
-                                                                    ( AppN Nothing
-                                                                      ( Ref Nothing
-                                                                        ( Imported
-                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                          ( Name "tell" )
-                                                                        )
-                                                                      )
-                                                                      ( LiteralArray Nothing
-                                                                        [ LiteralInt Nothing 130 ] :| []
-                                                                      ) :|
-                                                                      [ AbsN Nothing
-                                                                        ( ParamUnused Nothing :| [] )
-                                                                        ( AppN Nothing
-                                                                          ( Ref Nothing
-                                                                            ( Imported
-                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                              ( Name "discard$w" )
-                                                                            )
-                                                                          )
-                                                                          ( AppN Nothing
-                                                                            ( Ref Nothing
-                                                                              ( Imported
-                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                ( Name "tell" )
-                                                                              )
-                                                                            )
-                                                                            ( LiteralArray Nothing
-                                                                              [ LiteralInt Nothing 131 ] :| []
-                                                                            ) :|
-                                                                            [ AbsN Nothing
-                                                                              ( ParamUnused Nothing :| [] )
-                                                                              ( AppN Nothing
-                                                                                ( Ref Nothing
-                                                                                  ( Imported
-                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                    ( Name "discard$w" )
-                                                                                  )
-                                                                                )
-                                                                                ( AppN Nothing
-                                                                                  ( Ref Nothing
-                                                                                    ( Imported
-                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                      ( Name "tell" )
-                                                                                    )
-                                                                                  )
-                                                                                  ( LiteralArray Nothing
-                                                                                    [ LiteralInt Nothing 132 ] :| []
-                                                                                  ) :|
-                                                                                  [ AbsN Nothing
-                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                    ( AppN Nothing
-                                                                                      ( Ref Nothing
-                                                                                        ( Imported
-                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                          ( Name "discard$w" )
-                                                                                        )
-                                                                                      )
-                                                                                      ( AppN Nothing
-                                                                                        ( Ref Nothing
-                                                                                          ( Imported
-                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                            ( Name "tell" )
-                                                                                          )
-                                                                                        )
-                                                                                        ( LiteralArray Nothing
-                                                                                          [ LiteralInt Nothing 133 ] :| []
-                                                                                        ) :|
-                                                                                        [ AbsN Nothing
-                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                          ( AppN Nothing
-                                                                                            ( Ref Nothing
-                                                                                              ( Imported
-                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                ( Name "discard$w" )
-                                                                                              )
-                                                                                            )
-                                                                                            ( AppN Nothing
-                                                                                              ( Ref Nothing
-                                                                                                ( Imported
-                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                  ( Name "tell" )
-                                                                                                )
-                                                                                              )
-                                                                                              ( LiteralArray Nothing
-                                                                                                [ LiteralInt Nothing 134 ] :| []
-                                                                                              ) :|
-                                                                                              [ AbsN Nothing
-                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                ( AppN Nothing
-                                                                                                  ( Ref Nothing
-                                                                                                    ( Imported
-                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                      ( Name "discard$w" )
-                                                                                                    )
-                                                                                                  )
-                                                                                                  ( AppN Nothing
-                                                                                                    ( Ref Nothing
-                                                                                                      ( Imported
-                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                        ( Name "tell" )
-                                                                                                      )
-                                                                                                    )
-                                                                                                    ( LiteralArray Nothing
-                                                                                                      [ LiteralInt Nothing 135 ] :| []
-                                                                                                    ) :|
-                                                                                                    [ AbsN Nothing
-                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                      ( AppN Nothing
-                                                                                                        ( Ref Nothing
-                                                                                                          ( Imported
-                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                            ( Name "discard$w" )
-                                                                                                          )
-                                                                                                        )
-                                                                                                        ( AppN Nothing
-                                                                                                          ( Ref Nothing
-                                                                                                            ( Imported
-                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                              ( Name "tell" )
-                                                                                                            )
-                                                                                                          )
-                                                                                                          ( LiteralArray Nothing
-                                                                                                            [ LiteralInt Nothing 136 ] :| []
-                                                                                                          ) :|
-                                                                                                          [ AbsN Nothing
-                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                            ( AppN Nothing
-                                                                                                              ( Ref Nothing
-                                                                                                                ( Imported
-                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                  ( Name "discard$w" )
-                                                                                                                )
-                                                                                                              )
-                                                                                                              ( AppN Nothing
-                                                                                                                ( Ref Nothing
-                                                                                                                  ( Imported
-                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                    ( Name "tell" )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                ( LiteralArray Nothing
-                                                                                                                  [ LiteralInt Nothing 137 ] :| []
-                                                                                                                ) :|
-                                                                                                                [ AbsN Nothing
-                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                  ( AppN Nothing
-                                                                                                                    ( Ref Nothing
-                                                                                                                      ( Imported
-                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                        ( Name "discard$w" )
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    ( AppN Nothing
-                                                                                                                      ( Ref Nothing
-                                                                                                                        ( Imported
-                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                          ( Name "tell" )
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      ( LiteralArray Nothing
-                                                                                                                        [ LiteralInt Nothing 138 ] :| []
-                                                                                                                      ) :|
-                                                                                                                      [ AbsN Nothing
-                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                        ( AppN Nothing
-                                                                                                                          ( Ref Nothing
-                                                                                                                            ( Imported
-                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                              ( Name "discard$w" )
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                          ( AppN Nothing
-                                                                                                                            ( Ref Nothing
-                                                                                                                              ( Imported
-                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                ( Name "tell" )
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                            ( LiteralArray Nothing
-                                                                                                                              [ LiteralInt Nothing 139 ] :| []
-                                                                                                                            ) :|
-                                                                                                                            [ AbsN Nothing
-                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                              ( AppN Nothing
-                                                                                                                                ( Ref Nothing
-                                                                                                                                  ( Imported
-                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                                ( AppN Nothing
-                                                                                                                                  ( Ref Nothing
-                                                                                                                                    ( Imported
-                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                      ( Name "tell" )
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                    [ LiteralInt Nothing 140 ] :| []
-                                                                                                                                  ) :|
-                                                                                                                                  [ AbsN Nothing
-                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                    ( AppN Nothing
-                                                                                                                                      ( Ref Nothing
-                                                                                                                                        ( Imported
-                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                      ( AppN Nothing
-                                                                                                                                        ( Ref Nothing
-                                                                                                                                          ( Imported
-                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                            ( Name "tell" )
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                          [ LiteralInt Nothing 141 ] :| []
-                                                                                                                                        ) :|
-                                                                                                                                        [ AbsN Nothing
-                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                          ( AppN Nothing
-                                                                                                                                            ( Ref Nothing
-                                                                                                                                              ( Imported
-                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                              )
-                                                                                                                                            )
-                                                                                                                                            ( AppN Nothing
-                                                                                                                                              ( Ref Nothing
-                                                                                                                                                ( Imported
-                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                [ LiteralInt Nothing 142 ] :| []
-                                                                                                                                              ) :|
-                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                ( AppN Nothing
-                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                    ( Imported
-                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                    )
-                                                                                                                                                  )
-                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                      ( Imported
-                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                      )
-                                                                                                                                                    )
-                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                      [ LiteralInt Nothing 143 ] :| []
-                                                                                                                                                    ) :|
-                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                          ( Imported
-                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                          )
-                                                                                                                                                        )
-                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                            ( Imported
-                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                            [ LiteralInt Nothing 144 ] :| []
-                                                                                                                                                          ) :|
-                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                ( Imported
-                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                )
-                                                                                                                                                              )
-                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                  ( Imported
-                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                  )
-                                                                                                                                                                )
-                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                  [ LiteralInt Nothing 145 ] :| []
-                                                                                                                                                                ) :|
-                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                      ( Imported
-                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                        ( Imported
-                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                        [ LiteralInt Nothing 146 ] :| []
-                                                                                                                                                                      ) :|
-                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                            ( Imported
-                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                            )
-                                                                                                                                                                          )
-                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                              ( Imported
-                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                              )
-                                                                                                                                                                            )
-                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                              [ LiteralInt Nothing 147 ] :| []
-                                                                                                                                                                            ) :|
-                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                  )
-                                                                                                                                                                                )
-                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  )
-                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                    [ LiteralInt Nothing 148 ] :| []
-                                                                                                                                                                                  ) :|
-                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                        )
-                                                                                                                                                                                      )
-                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        )
-                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                          [ LiteralInt Nothing 149 ] :| []
-                                                                                                                                                                                        ) :|
-                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
-                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                [ LiteralInt Nothing 150 ] :| []
-                                                                                                                                                                                              ) :|
-                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                      [ LiteralInt Nothing 151 ] :| []
-                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                            [ LiteralInt Nothing 152 ] :| []
-                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                                  [ LiteralInt Nothing 153 ] :| []
-                                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                                        [ LiteralInt Nothing 154 ] :| []
-                                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                                                              [ LiteralInt Nothing 155 ] :| []
-                                                                                                                                                                                                                            ) :|
-                                                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                                                    [ LiteralInt Nothing 156 ] :| []
-                                                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                                                          [ LiteralInt Nothing 157 ] :| []
-                                                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                                                                [ LiteralInt Nothing 158 ] :| []
-                                                                                                                                                                                                                                              ) :|
-                                                                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                                                                      [ LiteralInt Nothing 159 ] :| []
-                                                                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                                                                            [ LiteralInt Nothing 160 ] :| []
-                                                                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                                              ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont0" )
-                                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              ]
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    ]
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              ]
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        ]
-                                                                                                                                                                                      )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  ]
-                                                                                                                                                                                )
-                                                                                                                                                                              )
-                                                                                                                                                                            ]
-                                                                                                                                                                          )
-                                                                                                                                                                        )
-                                                                                                                                                                      ]
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                          ]
-                                                                                                                                                        )
-                                                                                                                                                      )
-                                                                                                                                                    ]
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                              ]
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                        ]
-                                                                                                                                      )
-                                                                                                                                    )
-                                                                                                                                  ]
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                ]
-                                                              )
-                                                            )
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                            )
-                                          )
-                                        ]
-                                      )
-                                    )
-                                  ]
-                                )
-                              )
-                            ]
-                          )
-                        )
-                      ]
-                    )
-                  )
-                ]
-              )
-            ), Standalone
-            ( Nothing, Name "$kont2", AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-              )
-              ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                )
-                ( LiteralArray Nothing [ LiteralInt Nothing 81 ] :| [] ) :|
-                [ AbsN Nothing
-                  ( ParamUnused Nothing :| [] )
-                  ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-                    )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                      )
-                      ( LiteralArray Nothing [ LiteralInt Nothing 82 ] :| [] ) :|
-                      [ AbsN Nothing
-                        ( ParamUnused Nothing :| [] )
-                        ( AppN Nothing
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.LongWriterBind.Test" )
-                              ( Name "discard$w" )
-                            )
-                          )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                ( Name "tell" )
-                              )
-                            )
-                            ( LiteralArray Nothing [ LiteralInt Nothing 83 ] :| [] ) :|
-                            [ AbsN Nothing
-                              ( ParamUnused Nothing :| [] )
-                              ( AppN Nothing
-                                ( Ref Nothing
-                                  ( Imported
-                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                    ( Name "discard$w" )
-                                  )
-                                )
-                                ( AppN Nothing
-                                  ( Ref Nothing
-                                    ( Imported
-                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                      ( Name "tell" )
-                                    )
-                                  )
-                                  ( LiteralArray Nothing [ LiteralInt Nothing 84 ] :| [] ) :|
-                                  [ AbsN Nothing
-                                    ( ParamUnused Nothing :| [] )
-                                    ( AppN Nothing
-                                      ( Ref Nothing
-                                        ( Imported
-                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                          ( Name "discard$w" )
-                                        )
-                                      )
-                                      ( AppN Nothing
-                                        ( Ref Nothing
-                                          ( Imported
-                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                            ( Name "tell" )
-                                          )
-                                        )
-                                        ( LiteralArray Nothing [ LiteralInt Nothing 85 ] :| [] ) :|
-                                        [ AbsN Nothing
-                                          ( ParamUnused Nothing :| [] )
-                                          ( AppN Nothing
-                                            ( Ref Nothing
-                                              ( Imported
-                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                ( Name "discard$w" )
-                                              )
-                                            )
-                                            ( AppN Nothing
-                                              ( Ref Nothing
-                                                ( Imported
-                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                  ( Name "tell" )
-                                                )
-                                              )
-                                              ( LiteralArray Nothing
-                                                [ LiteralInt Nothing 86 ] :| []
-                                              ) :|
-                                              [ AbsN Nothing
-                                                ( ParamUnused Nothing :| [] )
-                                                ( AppN Nothing
-                                                  ( Ref Nothing
-                                                    ( Imported
-                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                      ( Name "discard$w" )
-                                                    )
-                                                  )
-                                                  ( AppN Nothing
-                                                    ( Ref Nothing
-                                                      ( Imported
-                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                        ( Name "tell" )
-                                                      )
-                                                    )
-                                                    ( LiteralArray Nothing
-                                                      [ LiteralInt Nothing 87 ] :| []
-                                                    ) :|
-                                                    [ AbsN Nothing
-                                                      ( ParamUnused Nothing :| [] )
-                                                      ( AppN Nothing
-                                                        ( Ref Nothing
-                                                          ( Imported
-                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                            ( Name "discard$w" )
-                                                          )
-                                                        )
-                                                        ( AppN Nothing
-                                                          ( Ref Nothing
-                                                            ( Imported
-                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                              ( Name "tell" )
-                                                            )
-                                                          )
-                                                          ( LiteralArray Nothing
-                                                            [ LiteralInt Nothing 88 ] :| []
-                                                          ) :|
-                                                          [ AbsN Nothing
-                                                            ( ParamUnused Nothing :| [] )
-                                                            ( AppN Nothing
-                                                              ( Ref Nothing
-                                                                ( Imported
-                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                  ( Name "discard$w" )
-                                                                )
-                                                              )
-                                                              ( AppN Nothing
-                                                                ( Ref Nothing
-                                                                  ( Imported
-                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                    ( Name "tell" )
-                                                                  )
-                                                                )
-                                                                ( LiteralArray Nothing
-                                                                  [ LiteralInt Nothing 89 ] :| []
-                                                                ) :|
-                                                                [ AbsN Nothing
-                                                                  ( ParamUnused Nothing :| [] )
-                                                                  ( AppN Nothing
-                                                                    ( Ref Nothing
-                                                                      ( Imported
-                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                        ( Name "discard$w" )
-                                                                      )
-                                                                    )
-                                                                    ( AppN Nothing
-                                                                      ( Ref Nothing
-                                                                        ( Imported
-                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                          ( Name "tell" )
-                                                                        )
-                                                                      )
-                                                                      ( LiteralArray Nothing
-                                                                        [ LiteralInt Nothing 90 ] :| []
-                                                                      ) :|
-                                                                      [ AbsN Nothing
-                                                                        ( ParamUnused Nothing :| [] )
-                                                                        ( AppN Nothing
-                                                                          ( Ref Nothing
-                                                                            ( Imported
-                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                              ( Name "discard$w" )
-                                                                            )
-                                                                          )
-                                                                          ( AppN Nothing
-                                                                            ( Ref Nothing
-                                                                              ( Imported
-                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                ( Name "tell" )
-                                                                              )
-                                                                            )
-                                                                            ( LiteralArray Nothing
-                                                                              [ LiteralInt Nothing 91 ] :| []
-                                                                            ) :|
-                                                                            [ AbsN Nothing
-                                                                              ( ParamUnused Nothing :| [] )
-                                                                              ( AppN Nothing
-                                                                                ( Ref Nothing
-                                                                                  ( Imported
-                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                    ( Name "discard$w" )
-                                                                                  )
-                                                                                )
-                                                                                ( AppN Nothing
-                                                                                  ( Ref Nothing
-                                                                                    ( Imported
-                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                      ( Name "tell" )
-                                                                                    )
-                                                                                  )
-                                                                                  ( LiteralArray Nothing
-                                                                                    [ LiteralInt Nothing 92 ] :| []
-                                                                                  ) :|
-                                                                                  [ AbsN Nothing
-                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                    ( AppN Nothing
-                                                                                      ( Ref Nothing
-                                                                                        ( Imported
-                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                          ( Name "discard$w" )
-                                                                                        )
-                                                                                      )
-                                                                                      ( AppN Nothing
-                                                                                        ( Ref Nothing
-                                                                                          ( Imported
-                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                            ( Name "tell" )
-                                                                                          )
-                                                                                        )
-                                                                                        ( LiteralArray Nothing
-                                                                                          [ LiteralInt Nothing 93 ] :| []
-                                                                                        ) :|
-                                                                                        [ AbsN Nothing
-                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                          ( AppN Nothing
-                                                                                            ( Ref Nothing
-                                                                                              ( Imported
-                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                ( Name "discard$w" )
-                                                                                              )
-                                                                                            )
-                                                                                            ( AppN Nothing
-                                                                                              ( Ref Nothing
-                                                                                                ( Imported
-                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                  ( Name "tell" )
-                                                                                                )
-                                                                                              )
-                                                                                              ( LiteralArray Nothing
-                                                                                                [ LiteralInt Nothing 94 ] :| []
-                                                                                              ) :|
-                                                                                              [ AbsN Nothing
-                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                ( AppN Nothing
-                                                                                                  ( Ref Nothing
-                                                                                                    ( Imported
-                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                      ( Name "discard$w" )
-                                                                                                    )
-                                                                                                  )
-                                                                                                  ( AppN Nothing
-                                                                                                    ( Ref Nothing
-                                                                                                      ( Imported
-                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                        ( Name "tell" )
-                                                                                                      )
-                                                                                                    )
-                                                                                                    ( LiteralArray Nothing
-                                                                                                      [ LiteralInt Nothing 95 ] :| []
-                                                                                                    ) :|
-                                                                                                    [ AbsN Nothing
-                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                      ( AppN Nothing
-                                                                                                        ( Ref Nothing
-                                                                                                          ( Imported
-                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                            ( Name "discard$w" )
-                                                                                                          )
-                                                                                                        )
-                                                                                                        ( AppN Nothing
-                                                                                                          ( Ref Nothing
-                                                                                                            ( Imported
-                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                              ( Name "tell" )
-                                                                                                            )
-                                                                                                          )
-                                                                                                          ( LiteralArray Nothing
-                                                                                                            [ LiteralInt Nothing 96 ] :| []
-                                                                                                          ) :|
-                                                                                                          [ AbsN Nothing
-                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                            ( AppN Nothing
-                                                                                                              ( Ref Nothing
-                                                                                                                ( Imported
-                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                  ( Name "discard$w" )
-                                                                                                                )
-                                                                                                              )
-                                                                                                              ( AppN Nothing
-                                                                                                                ( Ref Nothing
-                                                                                                                  ( Imported
-                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                    ( Name "tell" )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                ( LiteralArray Nothing
-                                                                                                                  [ LiteralInt Nothing 97 ] :| []
-                                                                                                                ) :|
-                                                                                                                [ AbsN Nothing
-                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                  ( AppN Nothing
-                                                                                                                    ( Ref Nothing
-                                                                                                                      ( Imported
-                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                        ( Name "discard$w" )
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    ( AppN Nothing
-                                                                                                                      ( Ref Nothing
-                                                                                                                        ( Imported
-                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                          ( Name "tell" )
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      ( LiteralArray Nothing
-                                                                                                                        [ LiteralInt Nothing 98 ] :| []
-                                                                                                                      ) :|
-                                                                                                                      [ AbsN Nothing
-                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                        ( AppN Nothing
-                                                                                                                          ( Ref Nothing
-                                                                                                                            ( Imported
-                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                              ( Name "discard$w" )
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                          ( AppN Nothing
-                                                                                                                            ( Ref Nothing
-                                                                                                                              ( Imported
-                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                ( Name "tell" )
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                            ( LiteralArray Nothing
-                                                                                                                              [ LiteralInt Nothing 99 ] :| []
-                                                                                                                            ) :|
-                                                                                                                            [ AbsN Nothing
-                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                              ( AppN Nothing
-                                                                                                                                ( Ref Nothing
-                                                                                                                                  ( Imported
-                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                                ( AppN Nothing
-                                                                                                                                  ( Ref Nothing
-                                                                                                                                    ( Imported
-                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                      ( Name "tell" )
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                    [ LiteralInt Nothing 100 ] :| []
-                                                                                                                                  ) :|
-                                                                                                                                  [ AbsN Nothing
-                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                    ( AppN Nothing
-                                                                                                                                      ( Ref Nothing
-                                                                                                                                        ( Imported
-                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                      ( AppN Nothing
-                                                                                                                                        ( Ref Nothing
-                                                                                                                                          ( Imported
-                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                            ( Name "tell" )
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                          [ LiteralInt Nothing 101 ] :| []
-                                                                                                                                        ) :|
-                                                                                                                                        [ AbsN Nothing
-                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                          ( AppN Nothing
-                                                                                                                                            ( Ref Nothing
-                                                                                                                                              ( Imported
-                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                              )
-                                                                                                                                            )
-                                                                                                                                            ( AppN Nothing
-                                                                                                                                              ( Ref Nothing
-                                                                                                                                                ( Imported
-                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                [ LiteralInt Nothing 102 ] :| []
-                                                                                                                                              ) :|
-                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                ( AppN Nothing
-                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                    ( Imported
-                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                    )
-                                                                                                                                                  )
-                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                      ( Imported
-                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                      )
-                                                                                                                                                    )
-                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                      [ LiteralInt Nothing 103 ] :| []
-                                                                                                                                                    ) :|
-                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                          ( Imported
-                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                          )
-                                                                                                                                                        )
-                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                            ( Imported
-                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                            [ LiteralInt Nothing 104 ] :| []
-                                                                                                                                                          ) :|
-                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                ( Imported
-                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                )
-                                                                                                                                                              )
-                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                  ( Imported
-                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                  )
-                                                                                                                                                                )
-                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                  [ LiteralInt Nothing 105 ] :| []
-                                                                                                                                                                ) :|
-                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                      ( Imported
-                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                        ( Imported
-                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                        [ LiteralInt Nothing 106 ] :| []
-                                                                                                                                                                      ) :|
-                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                            ( Imported
-                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                            )
-                                                                                                                                                                          )
-                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                              ( Imported
-                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                              )
-                                                                                                                                                                            )
-                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                              [ LiteralInt Nothing 107 ] :| []
-                                                                                                                                                                            ) :|
-                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                  )
-                                                                                                                                                                                )
-                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  )
-                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                    [ LiteralInt Nothing 108 ] :| []
-                                                                                                                                                                                  ) :|
-                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                        )
-                                                                                                                                                                                      )
-                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        )
-                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                          [ LiteralInt Nothing 109 ] :| []
-                                                                                                                                                                                        ) :|
-                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
-                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                [ LiteralInt Nothing 110 ] :| []
-                                                                                                                                                                                              ) :|
-                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                      [ LiteralInt Nothing 111 ] :| []
-                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                            [ LiteralInt Nothing 112 ] :| []
-                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                                  [ LiteralInt Nothing 113 ] :| []
-                                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                                        [ LiteralInt Nothing 114 ] :| []
-                                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                                                              [ LiteralInt Nothing 115 ] :| []
-                                                                                                                                                                                                                            ) :|
-                                                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                                                    [ LiteralInt Nothing 116 ] :| []
-                                                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                                                          [ LiteralInt Nothing 117 ] :| []
-                                                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                                                                [ LiteralInt Nothing 118 ] :| []
-                                                                                                                                                                                                                                              ) :|
-                                                                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                                                                      [ LiteralInt Nothing 119 ] :| []
-                                                                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                                                                            [ LiteralInt Nothing 120 ] :| []
-                                                                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                                              ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont1" )
-                                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              ]
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    ]
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              ]
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        ]
-                                                                                                                                                                                      )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  ]
-                                                                                                                                                                                )
-                                                                                                                                                                              )
-                                                                                                                                                                            ]
-                                                                                                                                                                          )
-                                                                                                                                                                        )
-                                                                                                                                                                      ]
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                          ]
-                                                                                                                                                        )
-                                                                                                                                                      )
-                                                                                                                                                    ]
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                              ]
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                        ]
-                                                                                                                                      )
-                                                                                                                                    )
-                                                                                                                                  ]
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                ]
-                                                              )
-                                                            )
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                            )
-                                          )
-                                        ]
-                                      )
-                                    )
-                                  ]
-                                )
-                              )
-                            ]
-                          )
-                        )
-                      ]
-                    )
-                  )
-                ]
-              )
-            ), Standalone
-            ( Nothing, Name "$kont3", AppN Nothing
-              ( Ref Nothing
-                ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-              )
-              ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                )
-                ( LiteralArray Nothing [ LiteralInt Nothing 41 ] :| [] ) :|
-                [ AbsN Nothing
-                  ( ParamUnused Nothing :| [] )
-                  ( AppN Nothing
-                    ( Ref Nothing
-                      ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-                    )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                      )
-                      ( LiteralArray Nothing [ LiteralInt Nothing 42 ] :| [] ) :|
-                      [ AbsN Nothing
-                        ( ParamUnused Nothing :| [] )
-                        ( AppN Nothing
-                          ( Ref Nothing
-                            ( Imported
-                              ( ModuleName "Golden.LongWriterBind.Test" )
-                              ( Name "discard$w" )
-                            )
-                          )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                ( Name "tell" )
-                              )
-                            )
-                            ( LiteralArray Nothing [ LiteralInt Nothing 43 ] :| [] ) :|
-                            [ AbsN Nothing
-                              ( ParamUnused Nothing :| [] )
-                              ( AppN Nothing
-                                ( Ref Nothing
-                                  ( Imported
-                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                    ( Name "discard$w" )
-                                  )
-                                )
-                                ( AppN Nothing
-                                  ( Ref Nothing
-                                    ( Imported
-                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                      ( Name "tell" )
-                                    )
-                                  )
-                                  ( LiteralArray Nothing [ LiteralInt Nothing 44 ] :| [] ) :|
-                                  [ AbsN Nothing
-                                    ( ParamUnused Nothing :| [] )
-                                    ( AppN Nothing
-                                      ( Ref Nothing
-                                        ( Imported
-                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                          ( Name "discard$w" )
-                                        )
-                                      )
-                                      ( AppN Nothing
-                                        ( Ref Nothing
-                                          ( Imported
-                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                            ( Name "tell" )
-                                          )
-                                        )
-                                        ( LiteralArray Nothing [ LiteralInt Nothing 45 ] :| [] ) :|
-                                        [ AbsN Nothing
-                                          ( ParamUnused Nothing :| [] )
-                                          ( AppN Nothing
-                                            ( Ref Nothing
-                                              ( Imported
-                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                ( Name "discard$w" )
-                                              )
-                                            )
-                                            ( AppN Nothing
-                                              ( Ref Nothing
-                                                ( Imported
-                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                  ( Name "tell" )
-                                                )
-                                              )
-                                              ( LiteralArray Nothing
-                                                [ LiteralInt Nothing 46 ] :| []
-                                              ) :|
-                                              [ AbsN Nothing
-                                                ( ParamUnused Nothing :| [] )
-                                                ( AppN Nothing
-                                                  ( Ref Nothing
-                                                    ( Imported
-                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                      ( Name "discard$w" )
-                                                    )
-                                                  )
-                                                  ( AppN Nothing
-                                                    ( Ref Nothing
-                                                      ( Imported
-                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                        ( Name "tell" )
-                                                      )
-                                                    )
-                                                    ( LiteralArray Nothing
-                                                      [ LiteralInt Nothing 47 ] :| []
-                                                    ) :|
-                                                    [ AbsN Nothing
-                                                      ( ParamUnused Nothing :| [] )
-                                                      ( AppN Nothing
-                                                        ( Ref Nothing
-                                                          ( Imported
-                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                            ( Name "discard$w" )
-                                                          )
-                                                        )
-                                                        ( AppN Nothing
-                                                          ( Ref Nothing
-                                                            ( Imported
-                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                              ( Name "tell" )
-                                                            )
-                                                          )
-                                                          ( LiteralArray Nothing
-                                                            [ LiteralInt Nothing 48 ] :| []
-                                                          ) :|
-                                                          [ AbsN Nothing
-                                                            ( ParamUnused Nothing :| [] )
-                                                            ( AppN Nothing
-                                                              ( Ref Nothing
-                                                                ( Imported
-                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                  ( Name "discard$w" )
-                                                                )
-                                                              )
-                                                              ( AppN Nothing
-                                                                ( Ref Nothing
-                                                                  ( Imported
-                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                    ( Name "tell" )
-                                                                  )
-                                                                )
-                                                                ( LiteralArray Nothing
-                                                                  [ LiteralInt Nothing 49 ] :| []
-                                                                ) :|
-                                                                [ AbsN Nothing
-                                                                  ( ParamUnused Nothing :| [] )
-                                                                  ( AppN Nothing
-                                                                    ( Ref Nothing
-                                                                      ( Imported
-                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                        ( Name "discard$w" )
-                                                                      )
-                                                                    )
-                                                                    ( AppN Nothing
-                                                                      ( Ref Nothing
-                                                                        ( Imported
-                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                          ( Name "tell" )
-                                                                        )
-                                                                      )
-                                                                      ( LiteralArray Nothing
-                                                                        [ LiteralInt Nothing 50 ] :| []
-                                                                      ) :|
-                                                                      [ AbsN Nothing
-                                                                        ( ParamUnused Nothing :| [] )
-                                                                        ( AppN Nothing
-                                                                          ( Ref Nothing
-                                                                            ( Imported
-                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                              ( Name "discard$w" )
-                                                                            )
-                                                                          )
-                                                                          ( AppN Nothing
-                                                                            ( Ref Nothing
-                                                                              ( Imported
-                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                ( Name "tell" )
-                                                                              )
-                                                                            )
-                                                                            ( LiteralArray Nothing
-                                                                              [ LiteralInt Nothing 51 ] :| []
-                                                                            ) :|
-                                                                            [ AbsN Nothing
-                                                                              ( ParamUnused Nothing :| [] )
-                                                                              ( AppN Nothing
-                                                                                ( Ref Nothing
-                                                                                  ( Imported
-                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                    ( Name "discard$w" )
-                                                                                  )
-                                                                                )
-                                                                                ( AppN Nothing
-                                                                                  ( Ref Nothing
-                                                                                    ( Imported
-                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                      ( Name "tell" )
-                                                                                    )
-                                                                                  )
-                                                                                  ( LiteralArray Nothing
-                                                                                    [ LiteralInt Nothing 52 ] :| []
-                                                                                  ) :|
-                                                                                  [ AbsN Nothing
-                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                    ( AppN Nothing
-                                                                                      ( Ref Nothing
-                                                                                        ( Imported
-                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                          ( Name "discard$w" )
-                                                                                        )
-                                                                                      )
-                                                                                      ( AppN Nothing
-                                                                                        ( Ref Nothing
-                                                                                          ( Imported
-                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                            ( Name "tell" )
-                                                                                          )
-                                                                                        )
-                                                                                        ( LiteralArray Nothing
-                                                                                          [ LiteralInt Nothing 53 ] :| []
-                                                                                        ) :|
-                                                                                        [ AbsN Nothing
-                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                          ( AppN Nothing
-                                                                                            ( Ref Nothing
-                                                                                              ( Imported
-                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                ( Name "discard$w" )
-                                                                                              )
-                                                                                            )
-                                                                                            ( AppN Nothing
-                                                                                              ( Ref Nothing
-                                                                                                ( Imported
-                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                  ( Name "tell" )
-                                                                                                )
-                                                                                              )
-                                                                                              ( LiteralArray Nothing
-                                                                                                [ LiteralInt Nothing 54 ] :| []
-                                                                                              ) :|
-                                                                                              [ AbsN Nothing
-                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                ( AppN Nothing
-                                                                                                  ( Ref Nothing
-                                                                                                    ( Imported
-                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                      ( Name "discard$w" )
-                                                                                                    )
-                                                                                                  )
-                                                                                                  ( AppN Nothing
-                                                                                                    ( Ref Nothing
-                                                                                                      ( Imported
-                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                        ( Name "tell" )
-                                                                                                      )
-                                                                                                    )
-                                                                                                    ( LiteralArray Nothing
-                                                                                                      [ LiteralInt Nothing 55 ] :| []
-                                                                                                    ) :|
-                                                                                                    [ AbsN Nothing
-                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                      ( AppN Nothing
-                                                                                                        ( Ref Nothing
-                                                                                                          ( Imported
-                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                            ( Name "discard$w" )
-                                                                                                          )
-                                                                                                        )
-                                                                                                        ( AppN Nothing
-                                                                                                          ( Ref Nothing
-                                                                                                            ( Imported
-                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                              ( Name "tell" )
-                                                                                                            )
-                                                                                                          )
-                                                                                                          ( LiteralArray Nothing
-                                                                                                            [ LiteralInt Nothing 56 ] :| []
-                                                                                                          ) :|
-                                                                                                          [ AbsN Nothing
-                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                            ( AppN Nothing
-                                                                                                              ( Ref Nothing
-                                                                                                                ( Imported
-                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                  ( Name "discard$w" )
-                                                                                                                )
-                                                                                                              )
-                                                                                                              ( AppN Nothing
-                                                                                                                ( Ref Nothing
-                                                                                                                  ( Imported
-                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                    ( Name "tell" )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                ( LiteralArray Nothing
-                                                                                                                  [ LiteralInt Nothing 57 ] :| []
-                                                                                                                ) :|
-                                                                                                                [ AbsN Nothing
-                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                  ( AppN Nothing
-                                                                                                                    ( Ref Nothing
-                                                                                                                      ( Imported
-                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                        ( Name "discard$w" )
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                    ( AppN Nothing
-                                                                                                                      ( Ref Nothing
-                                                                                                                        ( Imported
-                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                          ( Name "tell" )
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      ( LiteralArray Nothing
-                                                                                                                        [ LiteralInt Nothing 58 ] :| []
-                                                                                                                      ) :|
-                                                                                                                      [ AbsN Nothing
-                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                        ( AppN Nothing
-                                                                                                                          ( Ref Nothing
-                                                                                                                            ( Imported
-                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                              ( Name "discard$w" )
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                          ( AppN Nothing
-                                                                                                                            ( Ref Nothing
-                                                                                                                              ( Imported
-                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                ( Name "tell" )
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                            ( LiteralArray Nothing
-                                                                                                                              [ LiteralInt Nothing 59 ] :| []
-                                                                                                                            ) :|
-                                                                                                                            [ AbsN Nothing
-                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                              ( AppN Nothing
-                                                                                                                                ( Ref Nothing
-                                                                                                                                  ( Imported
-                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                                ( AppN Nothing
-                                                                                                                                  ( Ref Nothing
-                                                                                                                                    ( Imported
-                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                      ( Name "tell" )
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                    [ LiteralInt Nothing 60 ] :| []
-                                                                                                                                  ) :|
-                                                                                                                                  [ AbsN Nothing
-                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                    ( AppN Nothing
-                                                                                                                                      ( Ref Nothing
-                                                                                                                                        ( Imported
-                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                      ( AppN Nothing
-                                                                                                                                        ( Ref Nothing
-                                                                                                                                          ( Imported
-                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                            ( Name "tell" )
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                          [ LiteralInt Nothing 61 ] :| []
-                                                                                                                                        ) :|
-                                                                                                                                        [ AbsN Nothing
-                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                          ( AppN Nothing
-                                                                                                                                            ( Ref Nothing
-                                                                                                                                              ( Imported
-                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                              )
-                                                                                                                                            )
-                                                                                                                                            ( AppN Nothing
-                                                                                                                                              ( Ref Nothing
-                                                                                                                                                ( Imported
-                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                [ LiteralInt Nothing 62 ] :| []
-                                                                                                                                              ) :|
-                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                ( AppN Nothing
-                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                    ( Imported
-                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                    )
-                                                                                                                                                  )
-                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                      ( Imported
-                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                      )
-                                                                                                                                                    )
-                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                      [ LiteralInt Nothing 63 ] :| []
-                                                                                                                                                    ) :|
-                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                          ( Imported
-                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                          )
-                                                                                                                                                        )
-                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                            ( Imported
-                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                            [ LiteralInt Nothing 64 ] :| []
-                                                                                                                                                          ) :|
-                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                ( Imported
-                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                )
-                                                                                                                                                              )
-                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                  ( Imported
-                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                  )
-                                                                                                                                                                )
-                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                  [ LiteralInt Nothing 65 ] :| []
-                                                                                                                                                                ) :|
-                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                      ( Imported
-                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                        ( Imported
-                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                        [ LiteralInt Nothing 66 ] :| []
-                                                                                                                                                                      ) :|
-                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                            ( Imported
-                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                            )
-                                                                                                                                                                          )
-                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                              ( Imported
-                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                              )
-                                                                                                                                                                            )
-                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                              [ LiteralInt Nothing 67 ] :| []
-                                                                                                                                                                            ) :|
-                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                  )
-                                                                                                                                                                                )
-                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  )
-                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                    [ LiteralInt Nothing 68 ] :| []
-                                                                                                                                                                                  ) :|
-                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                        )
-                                                                                                                                                                                      )
-                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        )
-                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                          [ LiteralInt Nothing 69 ] :| []
-                                                                                                                                                                                        ) :|
-                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
-                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                [ LiteralInt Nothing 70 ] :| []
-                                                                                                                                                                                              ) :|
-                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                      [ LiteralInt Nothing 71 ] :| []
-                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                            [ LiteralInt Nothing 72 ] :| []
-                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                                  [ LiteralInt Nothing 73 ] :| []
-                                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                                        [ LiteralInt Nothing 74 ] :| []
-                                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                                                              [ LiteralInt Nothing 75 ] :| []
-                                                                                                                                                                                                                            ) :|
-                                                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                                                    [ LiteralInt Nothing 76 ] :| []
-                                                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                                                          [ LiteralInt Nothing 77 ] :| []
-                                                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                                                                [ LiteralInt Nothing 78 ] :| []
-                                                                                                                                                                                                                                              ) :|
-                                                                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                                                                      [ LiteralInt Nothing 79 ] :| []
-                                                                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                                                                            [ LiteralInt Nothing 80 ] :| []
-                                                                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                                                              ( Local
-                                                                                                                                                                                                                                                                ( Name "$kont2" )
-                                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              ]
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            ]
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    ]
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              ]
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        ]
-                                                                                                                                                                                      )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  ]
-                                                                                                                                                                                )
-                                                                                                                                                                              )
-                                                                                                                                                                            ]
-                                                                                                                                                                          )
-                                                                                                                                                                        )
-                                                                                                                                                                      ]
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                          ]
-                                                                                                                                                        )
-                                                                                                                                                      )
-                                                                                                                                                    ]
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                              ]
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                        ]
-                                                                                                                                      )
-                                                                                                                                    )
-                                                                                                                                  ]
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                ]
-                                                              )
-                                                            )
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                            )
-                                          )
-                                        ]
-                                      )
-                                    )
-                                  ]
-                                )
-                              )
-                            ]
-                          )
-                        )
-                      ]
-                    )
-                  )
-                ]
-              )
-            )
-          ]
-        )
-        ( AppN Nothing
-          ( Ref Nothing
-            ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-          )
-          ( AppN Nothing
-            ( Ref Nothing
-              ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-            )
-            ( LiteralArray Nothing [ LiteralInt Nothing 1 ] :| [] ) :|
-            [ AbsN Nothing
-              ( ParamUnused Nothing :| [] )
-              ( AppN Nothing
-                ( Ref Nothing
-                  ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "discard$w" ) )
-                )
-                ( AppN Nothing
-                  ( Ref Nothing
-                    ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                  )
-                  ( LiteralArray Nothing [ LiteralInt Nothing 2 ] :| [] ) :|
-                  [ AbsN Nothing
-                    ( ParamUnused Nothing :| [] )
-                    ( AppN Nothing
-                      ( Ref Nothing
-                        ( Imported
-                          ( ModuleName "Golden.LongWriterBind.Test" )
-                          ( Name "discard$w" )
-                        )
-                      )
-                      ( AppN Nothing
-                        ( Ref Nothing
-                          ( Imported ( ModuleName "Golden.LongWriterBind.Test" ) ( Name "tell" ) )
-                        )
-                        ( LiteralArray Nothing [ LiteralInt Nothing 3 ] :| [] ) :|
-                        [ AbsN Nothing
-                          ( ParamUnused Nothing :| [] )
-                          ( AppN Nothing
-                            ( Ref Nothing
-                              ( Imported
-                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                ( Name "discard$w" )
-                              )
-                            )
-                            ( AppN Nothing
-                              ( Ref Nothing
-                                ( Imported
-                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                  ( Name "tell" )
-                                )
-                              )
-                              ( LiteralArray Nothing [ LiteralInt Nothing 4 ] :| [] ) :|
-                              [ AbsN Nothing
-                                ( ParamUnused Nothing :| [] )
-                                ( AppN Nothing
-                                  ( Ref Nothing
-                                    ( Imported
-                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                      ( Name "discard$w" )
-                                    )
-                                  )
-                                  ( AppN Nothing
-                                    ( Ref Nothing
-                                      ( Imported
-                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                        ( Name "tell" )
-                                      )
-                                    )
-                                    ( LiteralArray Nothing [ LiteralInt Nothing 5 ] :| [] ) :|
-                                    [ AbsN Nothing
-                                      ( ParamUnused Nothing :| [] )
-                                      ( AppN Nothing
-                                        ( Ref Nothing
-                                          ( Imported
-                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                            ( Name "discard$w" )
-                                          )
-                                        )
-                                        ( AppN Nothing
-                                          ( Ref Nothing
-                                            ( Imported
-                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                              ( Name "tell" )
-                                            )
-                                          )
-                                          ( LiteralArray Nothing
-                                            [ LiteralInt Nothing 6 ] :| []
-                                          ) :|
-                                          [ AbsN Nothing
-                                            ( ParamUnused Nothing :| [] )
-                                            ( AppN Nothing
-                                              ( Ref Nothing
-                                                ( Imported
-                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                  ( Name "discard$w" )
-                                                )
-                                              )
-                                              ( AppN Nothing
-                                                ( Ref Nothing
-                                                  ( Imported
-                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                    ( Name "tell" )
+                                                    ( ModuleName "Data.Semigroup" )
+                                                    ( Name "concatArray" )
                                                   )
                                                 )
                                                 ( LiteralArray Nothing
-                                                  [ LiteralInt Nothing 7 ] :| []
-                                                ) :|
-                                                [ AbsN Nothing
-                                                  ( ParamUnused Nothing :| [] )
+                                                  [ LiteralInt Nothing 178 ] :| []
+                                                )
+                                              )
+                                              ( AppN Nothing
+                                                ( AppN Nothing
+                                                  ( Ref Nothing
+                                                    ( Imported
+                                                      ( ModuleName "Data.Semigroup" )
+                                                      ( Name "concatArray" )
+                                                    )
+                                                  )
+                                                  ( LiteralArray Nothing
+                                                    [ LiteralInt Nothing 179 ] :| []
+                                                  )
+                                                )
+                                                ( AppN Nothing
                                                   ( AppN Nothing
                                                     ( Ref Nothing
                                                       ( Imported
-                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                        ( Name "discard$w" )
+                                                        ( ModuleName "Data.Semigroup" )
+                                                        ( Name "concatArray" )
                                                       )
                                                     )
+                                                    ( LiteralArray Nothing
+                                                      [ LiteralInt Nothing 180 ] :| []
+                                                    )
+                                                  )
+                                                  ( AppN Nothing
                                                     ( AppN Nothing
                                                       ( Ref Nothing
                                                         ( Imported
-                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                          ( Name "tell" )
+                                                          ( ModuleName "Data.Semigroup" )
+                                                          ( Name "concatArray" )
                                                         )
                                                       )
                                                       ( LiteralArray Nothing
-                                                        [ LiteralInt Nothing 8 ] :| []
-                                                      ) :|
-                                                      [ AbsN Nothing
-                                                        ( ParamUnused Nothing :| [] )
+                                                        [ LiteralInt Nothing 181 ] :| []
+                                                      )
+                                                    )
+                                                    ( AppN Nothing
+                                                      ( AppN Nothing
+                                                        ( Ref Nothing
+                                                          ( Imported
+                                                            ( ModuleName "Data.Semigroup" )
+                                                            ( Name "concatArray" )
+                                                          )
+                                                        )
+                                                        ( LiteralArray Nothing
+                                                          [ LiteralInt Nothing 182 ] :| []
+                                                        )
+                                                      )
+                                                      ( AppN Nothing
                                                         ( AppN Nothing
                                                           ( Ref Nothing
                                                             ( Imported
-                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                              ( Name "discard$w" )
+                                                              ( ModuleName "Data.Semigroup" )
+                                                              ( Name "concatArray" )
                                                             )
                                                           )
+                                                          ( LiteralArray Nothing
+                                                            [ LiteralInt Nothing 183 ] :| []
+                                                          )
+                                                        )
+                                                        ( AppN Nothing
                                                           ( AppN Nothing
                                                             ( Ref Nothing
                                                               ( Imported
-                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                ( Name "tell" )
+                                                                ( ModuleName "Data.Semigroup" )
+                                                                ( Name "concatArray" )
                                                               )
                                                             )
                                                             ( LiteralArray Nothing
-                                                              [ LiteralInt Nothing 9 ] :| []
-                                                            ) :|
-                                                            [ AbsN Nothing
-                                                              ( ParamUnused Nothing :| [] )
+                                                              [ LiteralInt Nothing 184 ] :| []
+                                                            )
+                                                          )
+                                                          ( AppN Nothing
+                                                            ( AppN Nothing
+                                                              ( Ref Nothing
+                                                                ( Imported
+                                                                  ( ModuleName "Data.Semigroup" )
+                                                                  ( Name "concatArray" )
+                                                                )
+                                                              )
+                                                              ( LiteralArray Nothing
+                                                                [ LiteralInt Nothing 185 ] :| []
+                                                              )
+                                                            )
+                                                            ( AppN Nothing
                                                               ( AppN Nothing
                                                                 ( Ref Nothing
                                                                   ( Imported
-                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                    ( Name "discard$w" )
+                                                                    ( ModuleName "Data.Semigroup" )
+                                                                    ( Name "concatArray" )
                                                                   )
                                                                 )
+                                                                ( LiteralArray Nothing
+                                                                  [ LiteralInt Nothing 186 ] :| []
+                                                                )
+                                                              )
+                                                              ( AppN Nothing
                                                                 ( AppN Nothing
                                                                   ( Ref Nothing
                                                                     ( Imported
-                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                      ( Name "tell" )
+                                                                      ( ModuleName "Data.Semigroup" )
+                                                                      ( Name "concatArray" )
                                                                     )
                                                                   )
                                                                   ( LiteralArray Nothing
-                                                                    [ LiteralInt Nothing 10 ] :| []
-                                                                  ) :|
-                                                                  [ AbsN Nothing
-                                                                    ( ParamUnused Nothing :| [] )
+                                                                    [ LiteralInt Nothing 187 ] :| []
+                                                                  )
+                                                                )
+                                                                ( AppN Nothing
+                                                                  ( AppN Nothing
+                                                                    ( Ref Nothing
+                                                                      ( Imported
+                                                                        ( ModuleName "Data.Semigroup" )
+                                                                        ( Name "concatArray" )
+                                                                      )
+                                                                    )
+                                                                    ( LiteralArray Nothing
+                                                                      [ LiteralInt Nothing 188 ] :| []
+                                                                    )
+                                                                  )
+                                                                  ( AppN Nothing
                                                                     ( AppN Nothing
                                                                       ( Ref Nothing
                                                                         ( Imported
-                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                          ( Name "discard$w" )
+                                                                          ( ModuleName "Data.Semigroup" )
+                                                                          ( Name "concatArray" )
                                                                         )
                                                                       )
+                                                                      ( LiteralArray Nothing
+                                                                        [ LiteralInt Nothing 189 ] :| []
+                                                                      )
+                                                                    )
+                                                                    ( AppN Nothing
                                                                       ( AppN Nothing
                                                                         ( Ref Nothing
                                                                           ( Imported
-                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                            ( Name "tell" )
+                                                                            ( ModuleName "Data.Semigroup" )
+                                                                            ( Name "concatArray" )
                                                                           )
                                                                         )
                                                                         ( LiteralArray Nothing
-                                                                          [ LiteralInt Nothing 11 ] :| []
-                                                                        ) :|
-                                                                        [ AbsN Nothing
-                                                                          ( ParamUnused Nothing :| [] )
+                                                                          [ LiteralInt Nothing 190 ] :| []
+                                                                        )
+                                                                      )
+                                                                      ( AppN Nothing
+                                                                        ( AppN Nothing
+                                                                          ( Ref Nothing
+                                                                            ( Imported
+                                                                              ( ModuleName "Data.Semigroup" )
+                                                                              ( Name "concatArray" )
+                                                                            )
+                                                                          )
+                                                                          ( LiteralArray Nothing
+                                                                            [ LiteralInt Nothing 191 ] :| []
+                                                                          )
+                                                                        )
+                                                                        ( AppN Nothing
                                                                           ( AppN Nothing
                                                                             ( Ref Nothing
                                                                               ( Imported
-                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                ( Name "discard$w" )
+                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                ( Name "concatArray" )
                                                                               )
                                                                             )
+                                                                            ( LiteralArray Nothing
+                                                                              [ LiteralInt Nothing 192 ] :| []
+                                                                            )
+                                                                          )
+                                                                          ( AppN Nothing
                                                                             ( AppN Nothing
                                                                               ( Ref Nothing
                                                                                 ( Imported
-                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                  ( Name "tell" )
+                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                  ( Name "concatArray" )
                                                                                 )
                                                                               )
                                                                               ( LiteralArray Nothing
-                                                                                [ LiteralInt Nothing 12 ] :| []
-                                                                              ) :|
-                                                                              [ AbsN Nothing
-                                                                                ( ParamUnused Nothing :| [] )
+                                                                                [ LiteralInt Nothing 193 ] :| []
+                                                                              )
+                                                                            )
+                                                                            ( AppN Nothing
+                                                                              ( AppN Nothing
+                                                                                ( Ref Nothing
+                                                                                  ( Imported
+                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                    ( Name "concatArray" )
+                                                                                  )
+                                                                                )
+                                                                                ( LiteralArray Nothing
+                                                                                  [ LiteralInt Nothing 194 ] :| []
+                                                                                )
+                                                                              )
+                                                                              ( AppN Nothing
                                                                                 ( AppN Nothing
                                                                                   ( Ref Nothing
                                                                                     ( Imported
-                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                      ( Name "discard$w" )
+                                                                                      ( ModuleName "Data.Semigroup" )
+                                                                                      ( Name "concatArray" )
                                                                                     )
                                                                                   )
+                                                                                  ( LiteralArray Nothing
+                                                                                    [ LiteralInt Nothing 195 ] :| []
+                                                                                  )
+                                                                                )
+                                                                                ( AppN Nothing
                                                                                   ( AppN Nothing
                                                                                     ( Ref Nothing
                                                                                       ( Imported
-                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                        ( Name "tell" )
+                                                                                        ( ModuleName "Data.Semigroup" )
+                                                                                        ( Name "concatArray" )
                                                                                       )
                                                                                     )
                                                                                     ( LiteralArray Nothing
-                                                                                      [ LiteralInt Nothing 13 ] :| []
-                                                                                    ) :|
-                                                                                    [ AbsN Nothing
-                                                                                      ( ParamUnused Nothing :| [] )
+                                                                                      [ LiteralInt Nothing 196 ] :| []
+                                                                                    )
+                                                                                  )
+                                                                                  ( AppN Nothing
+                                                                                    ( AppN Nothing
+                                                                                      ( Ref Nothing
+                                                                                        ( Imported
+                                                                                          ( ModuleName "Data.Semigroup" )
+                                                                                          ( Name "concatArray" )
+                                                                                        )
+                                                                                      )
+                                                                                      ( LiteralArray Nothing
+                                                                                        [ LiteralInt Nothing 197 ] :| []
+                                                                                      )
+                                                                                    )
+                                                                                    ( AppN Nothing
                                                                                       ( AppN Nothing
                                                                                         ( Ref Nothing
                                                                                           ( Imported
-                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                            ( Name "discard$w" )
+                                                                                            ( ModuleName "Data.Semigroup" )
+                                                                                            ( Name "concatArray" )
                                                                                           )
                                                                                         )
+                                                                                        ( LiteralArray Nothing
+                                                                                          [ LiteralInt Nothing 198 ] :| []
+                                                                                        )
+                                                                                      )
+                                                                                      ( AppN Nothing
                                                                                         ( AppN Nothing
                                                                                           ( Ref Nothing
                                                                                             ( Imported
-                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                              ( Name "tell" )
+                                                                                              ( ModuleName "Data.Semigroup" )
+                                                                                              ( Name "concatArray" )
                                                                                             )
                                                                                           )
                                                                                           ( LiteralArray Nothing
-                                                                                            [ LiteralInt Nothing 14 ] :| []
-                                                                                          ) :|
-                                                                                          [ AbsN Nothing
-                                                                                            ( ParamUnused Nothing :| [] )
+                                                                                            [ LiteralInt Nothing 199 ] :| []
+                                                                                          )
+                                                                                        )
+                                                                                        ( AppN Nothing
+                                                                                          ( AppN Nothing
+                                                                                            ( Ref Nothing
+                                                                                              ( Imported
+                                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                                ( Name "concatArray" )
+                                                                                              )
+                                                                                            )
+                                                                                            ( LiteralArray Nothing
+                                                                                              [ LiteralInt Nothing 200 ] :| []
+                                                                                            )
+                                                                                          )
+                                                                                          ( LiteralArray Nothing [] :| [] ) :| []
+                                                                                        ) :| []
+                                                                                      ) :| []
+                                                                                    ) :| []
+                                                                                  ) :| []
+                                                                                ) :| []
+                                                                              ) :| []
+                                                                            ) :| []
+                                                                          ) :| []
+                                                                        ) :| []
+                                                                      ) :| []
+                                                                    ) :| []
+                                                                  ) :| []
+                                                                ) :| []
+                                                              ) :| []
+                                                            ) :| []
+                                                          ) :| []
+                                                        ) :| []
+                                                      ) :| []
+                                                    ) :| []
+                                                  ) :| []
+                                                ) :| []
+                                              ) :| []
+                                            ) :| []
+                                          ) :| []
+                                        ) :| []
+                                      ) :| []
+                                    ) :| []
+                                  ) :| []
+                                ) :| []
+                              ) :| []
+                            ) :| []
+                          ) :| []
+                        ) :| []
+                      ) :| []
+                    ) :| []
+                  ) :| []
+                ) :| []
+              )
+            ) :|
+            [ Standalone
+              ( Nothing, Name "$tmp1", AppN Nothing
+                ( AppN Nothing
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                  )
+                  ( LiteralArray Nothing [ LiteralInt Nothing 122 ] :| [] )
+                )
+                ( AppN Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                    )
+                    ( LiteralArray Nothing [ LiteralInt Nothing 123 ] :| [] )
+                  )
+                  ( AppN Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                      )
+                      ( LiteralArray Nothing [ LiteralInt Nothing 124 ] :| [] )
+                    )
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                        )
+                        ( LiteralArray Nothing [ LiteralInt Nothing 125 ] :| [] )
+                      )
+                      ( AppN Nothing
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                          )
+                          ( LiteralArray Nothing [ LiteralInt Nothing 126 ] :| [] )
+                        )
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                            )
+                            ( LiteralArray Nothing [ LiteralInt Nothing 127 ] :| [] )
+                          )
+                          ( AppN Nothing
+                            ( AppN Nothing
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                              )
+                              ( LiteralArray Nothing [ LiteralInt Nothing 128 ] :| [] )
+                            )
+                            ( AppN Nothing
+                              ( AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Data.Semigroup" )
+                                    ( Name "concatArray" )
+                                  )
+                                )
+                                ( LiteralArray Nothing [ LiteralInt Nothing 129 ] :| [] )
+                              )
+                              ( AppN Nothing
+                                ( AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported
+                                      ( ModuleName "Data.Semigroup" )
+                                      ( Name "concatArray" )
+                                    )
+                                  )
+                                  ( LiteralArray Nothing [ LiteralInt Nothing 130 ] :| [] )
+                                )
+                                ( AppN Nothing
+                                  ( AppN Nothing
+                                    ( Ref Nothing
+                                      ( Imported
+                                        ( ModuleName "Data.Semigroup" )
+                                        ( Name "concatArray" )
+                                      )
+                                    )
+                                    ( LiteralArray Nothing [ LiteralInt Nothing 131 ] :| [] )
+                                  )
+                                  ( AppN Nothing
+                                    ( AppN Nothing
+                                      ( Ref Nothing
+                                        ( Imported
+                                          ( ModuleName "Data.Semigroup" )
+                                          ( Name "concatArray" )
+                                        )
+                                      )
+                                      ( LiteralArray Nothing [ LiteralInt Nothing 132 ] :| [] )
+                                    )
+                                    ( AppN Nothing
+                                      ( AppN Nothing
+                                        ( Ref Nothing
+                                          ( Imported
+                                            ( ModuleName "Data.Semigroup" )
+                                            ( Name "concatArray" )
+                                          )
+                                        )
+                                        ( LiteralArray Nothing [ LiteralInt Nothing 133 ] :| [] )
+                                      )
+                                      ( AppN Nothing
+                                        ( AppN Nothing
+                                          ( Ref Nothing
+                                            ( Imported
+                                              ( ModuleName "Data.Semigroup" )
+                                              ( Name "concatArray" )
+                                            )
+                                          )
+                                          ( LiteralArray Nothing [ LiteralInt Nothing 134 ] :| [] )
+                                        )
+                                        ( AppN Nothing
+                                          ( AppN Nothing
+                                            ( Ref Nothing
+                                              ( Imported
+                                                ( ModuleName "Data.Semigroup" )
+                                                ( Name "concatArray" )
+                                              )
+                                            )
+                                            ( LiteralArray Nothing
+                                              [ LiteralInt Nothing 135 ] :| []
+                                            )
+                                          )
+                                          ( AppN Nothing
+                                            ( AppN Nothing
+                                              ( Ref Nothing
+                                                ( Imported
+                                                  ( ModuleName "Data.Semigroup" )
+                                                  ( Name "concatArray" )
+                                                )
+                                              )
+                                              ( LiteralArray Nothing
+                                                [ LiteralInt Nothing 136 ] :| []
+                                              )
+                                            )
+                                            ( AppN Nothing
+                                              ( AppN Nothing
+                                                ( Ref Nothing
+                                                  ( Imported
+                                                    ( ModuleName "Data.Semigroup" )
+                                                    ( Name "concatArray" )
+                                                  )
+                                                )
+                                                ( LiteralArray Nothing
+                                                  [ LiteralInt Nothing 137 ] :| []
+                                                )
+                                              )
+                                              ( AppN Nothing
+                                                ( AppN Nothing
+                                                  ( Ref Nothing
+                                                    ( Imported
+                                                      ( ModuleName "Data.Semigroup" )
+                                                      ( Name "concatArray" )
+                                                    )
+                                                  )
+                                                  ( LiteralArray Nothing
+                                                    [ LiteralInt Nothing 138 ] :| []
+                                                  )
+                                                )
+                                                ( AppN Nothing
+                                                  ( AppN Nothing
+                                                    ( Ref Nothing
+                                                      ( Imported
+                                                        ( ModuleName "Data.Semigroup" )
+                                                        ( Name "concatArray" )
+                                                      )
+                                                    )
+                                                    ( LiteralArray Nothing
+                                                      [ LiteralInt Nothing 139 ] :| []
+                                                    )
+                                                  )
+                                                  ( AppN Nothing
+                                                    ( AppN Nothing
+                                                      ( Ref Nothing
+                                                        ( Imported
+                                                          ( ModuleName "Data.Semigroup" )
+                                                          ( Name "concatArray" )
+                                                        )
+                                                      )
+                                                      ( LiteralArray Nothing
+                                                        [ LiteralInt Nothing 140 ] :| []
+                                                      )
+                                                    )
+                                                    ( AppN Nothing
+                                                      ( AppN Nothing
+                                                        ( Ref Nothing
+                                                          ( Imported
+                                                            ( ModuleName "Data.Semigroup" )
+                                                            ( Name "concatArray" )
+                                                          )
+                                                        )
+                                                        ( LiteralArray Nothing
+                                                          [ LiteralInt Nothing 141 ] :| []
+                                                        )
+                                                      )
+                                                      ( AppN Nothing
+                                                        ( AppN Nothing
+                                                          ( Ref Nothing
+                                                            ( Imported
+                                                              ( ModuleName "Data.Semigroup" )
+                                                              ( Name "concatArray" )
+                                                            )
+                                                          )
+                                                          ( LiteralArray Nothing
+                                                            [ LiteralInt Nothing 142 ] :| []
+                                                          )
+                                                        )
+                                                        ( AppN Nothing
+                                                          ( AppN Nothing
+                                                            ( Ref Nothing
+                                                              ( Imported
+                                                                ( ModuleName "Data.Semigroup" )
+                                                                ( Name "concatArray" )
+                                                              )
+                                                            )
+                                                            ( LiteralArray Nothing
+                                                              [ LiteralInt Nothing 143 ] :| []
+                                                            )
+                                                          )
+                                                          ( AppN Nothing
+                                                            ( AppN Nothing
+                                                              ( Ref Nothing
+                                                                ( Imported
+                                                                  ( ModuleName "Data.Semigroup" )
+                                                                  ( Name "concatArray" )
+                                                                )
+                                                              )
+                                                              ( LiteralArray Nothing
+                                                                [ LiteralInt Nothing 144 ] :| []
+                                                              )
+                                                            )
+                                                            ( AppN Nothing
+                                                              ( AppN Nothing
+                                                                ( Ref Nothing
+                                                                  ( Imported
+                                                                    ( ModuleName "Data.Semigroup" )
+                                                                    ( Name "concatArray" )
+                                                                  )
+                                                                )
+                                                                ( LiteralArray Nothing
+                                                                  [ LiteralInt Nothing 145 ] :| []
+                                                                )
+                                                              )
+                                                              ( AppN Nothing
+                                                                ( AppN Nothing
+                                                                  ( Ref Nothing
+                                                                    ( Imported
+                                                                      ( ModuleName "Data.Semigroup" )
+                                                                      ( Name "concatArray" )
+                                                                    )
+                                                                  )
+                                                                  ( LiteralArray Nothing
+                                                                    [ LiteralInt Nothing 146 ] :| []
+                                                                  )
+                                                                )
+                                                                ( AppN Nothing
+                                                                  ( AppN Nothing
+                                                                    ( Ref Nothing
+                                                                      ( Imported
+                                                                        ( ModuleName "Data.Semigroup" )
+                                                                        ( Name "concatArray" )
+                                                                      )
+                                                                    )
+                                                                    ( LiteralArray Nothing
+                                                                      [ LiteralInt Nothing 147 ] :| []
+                                                                    )
+                                                                  )
+                                                                  ( AppN Nothing
+                                                                    ( AppN Nothing
+                                                                      ( Ref Nothing
+                                                                        ( Imported
+                                                                          ( ModuleName "Data.Semigroup" )
+                                                                          ( Name "concatArray" )
+                                                                        )
+                                                                      )
+                                                                      ( LiteralArray Nothing
+                                                                        [ LiteralInt Nothing 148 ] :| []
+                                                                      )
+                                                                    )
+                                                                    ( AppN Nothing
+                                                                      ( AppN Nothing
+                                                                        ( Ref Nothing
+                                                                          ( Imported
+                                                                            ( ModuleName "Data.Semigroup" )
+                                                                            ( Name "concatArray" )
+                                                                          )
+                                                                        )
+                                                                        ( LiteralArray Nothing
+                                                                          [ LiteralInt Nothing 149 ] :| []
+                                                                        )
+                                                                      )
+                                                                      ( AppN Nothing
+                                                                        ( AppN Nothing
+                                                                          ( Ref Nothing
+                                                                            ( Imported
+                                                                              ( ModuleName "Data.Semigroup" )
+                                                                              ( Name "concatArray" )
+                                                                            )
+                                                                          )
+                                                                          ( LiteralArray Nothing
+                                                                            [ LiteralInt Nothing 150 ] :| []
+                                                                          )
+                                                                        )
+                                                                        ( AppN Nothing
+                                                                          ( AppN Nothing
+                                                                            ( Ref Nothing
+                                                                              ( Imported
+                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                ( Name "concatArray" )
+                                                                              )
+                                                                            )
+                                                                            ( LiteralArray Nothing
+                                                                              [ LiteralInt Nothing 151 ] :| []
+                                                                            )
+                                                                          )
+                                                                          ( AppN Nothing
+                                                                            ( AppN Nothing
+                                                                              ( Ref Nothing
+                                                                                ( Imported
+                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                  ( Name "concatArray" )
+                                                                                )
+                                                                              )
+                                                                              ( LiteralArray Nothing
+                                                                                [ LiteralInt Nothing 152 ] :| []
+                                                                              )
+                                                                            )
+                                                                            ( AppN Nothing
+                                                                              ( AppN Nothing
+                                                                                ( Ref Nothing
+                                                                                  ( Imported
+                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                    ( Name "concatArray" )
+                                                                                  )
+                                                                                )
+                                                                                ( LiteralArray Nothing
+                                                                                  [ LiteralInt Nothing 153 ] :| []
+                                                                                )
+                                                                              )
+                                                                              ( AppN Nothing
+                                                                                ( AppN Nothing
+                                                                                  ( Ref Nothing
+                                                                                    ( Imported
+                                                                                      ( ModuleName "Data.Semigroup" )
+                                                                                      ( Name "concatArray" )
+                                                                                    )
+                                                                                  )
+                                                                                  ( LiteralArray Nothing
+                                                                                    [ LiteralInt Nothing 154 ] :| []
+                                                                                  )
+                                                                                )
+                                                                                ( AppN Nothing
+                                                                                  ( AppN Nothing
+                                                                                    ( Ref Nothing
+                                                                                      ( Imported
+                                                                                        ( ModuleName "Data.Semigroup" )
+                                                                                        ( Name "concatArray" )
+                                                                                      )
+                                                                                    )
+                                                                                    ( LiteralArray Nothing
+                                                                                      [ LiteralInt Nothing 155 ] :| []
+                                                                                    )
+                                                                                  )
+                                                                                  ( AppN Nothing
+                                                                                    ( AppN Nothing
+                                                                                      ( Ref Nothing
+                                                                                        ( Imported
+                                                                                          ( ModuleName "Data.Semigroup" )
+                                                                                          ( Name "concatArray" )
+                                                                                        )
+                                                                                      )
+                                                                                      ( LiteralArray Nothing
+                                                                                        [ LiteralInt Nothing 156 ] :| []
+                                                                                      )
+                                                                                    )
+                                                                                    ( AppN Nothing
+                                                                                      ( AppN Nothing
+                                                                                        ( Ref Nothing
+                                                                                          ( Imported
+                                                                                            ( ModuleName "Data.Semigroup" )
+                                                                                            ( Name "concatArray" )
+                                                                                          )
+                                                                                        )
+                                                                                        ( LiteralArray Nothing
+                                                                                          [ LiteralInt Nothing 157 ] :| []
+                                                                                        )
+                                                                                      )
+                                                                                      ( AppN Nothing
+                                                                                        ( AppN Nothing
+                                                                                          ( Ref Nothing
+                                                                                            ( Imported
+                                                                                              ( ModuleName "Data.Semigroup" )
+                                                                                              ( Name "concatArray" )
+                                                                                            )
+                                                                                          )
+                                                                                          ( LiteralArray Nothing
+                                                                                            [ LiteralInt Nothing 158 ] :| []
+                                                                                          )
+                                                                                        )
+                                                                                        ( AppN Nothing
+                                                                                          ( AppN Nothing
+                                                                                            ( Ref Nothing
+                                                                                              ( Imported
+                                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                                ( Name "concatArray" )
+                                                                                              )
+                                                                                            )
+                                                                                            ( LiteralArray Nothing
+                                                                                              [ LiteralInt Nothing 159 ] :| []
+                                                                                            )
+                                                                                          )
+                                                                                          ( AppN Nothing
                                                                                             ( AppN Nothing
                                                                                               ( Ref Nothing
                                                                                                 ( Imported
-                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                  ( Name "discard$w" )
+                                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                                  ( Name "concatArray" )
                                                                                                 )
                                                                                               )
+                                                                                              ( LiteralArray Nothing
+                                                                                                [ LiteralInt Nothing 160 ] :| []
+                                                                                              )
+                                                                                            )
+                                                                                            ( AppN Nothing
                                                                                               ( AppN Nothing
                                                                                                 ( Ref Nothing
                                                                                                   ( Imported
-                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                    ( Name "tell" )
+                                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                                    ( Name "concatArray" )
                                                                                                   )
                                                                                                 )
                                                                                                 ( LiteralArray Nothing
-                                                                                                  [ LiteralInt Nothing 15 ] :| []
-                                                                                                ) :|
-                                                                                                [ AbsN Nothing
-                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                  ( AppN Nothing
-                                                                                                    ( Ref Nothing
-                                                                                                      ( Imported
-                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                        ( Name "discard$w" )
-                                                                                                      )
-                                                                                                    )
-                                                                                                    ( AppN Nothing
-                                                                                                      ( Ref Nothing
-                                                                                                        ( Imported
-                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                          ( Name "tell" )
-                                                                                                        )
-                                                                                                      )
-                                                                                                      ( LiteralArray Nothing
-                                                                                                        [ LiteralInt Nothing 16 ] :| []
-                                                                                                      ) :|
-                                                                                                      [ AbsN Nothing
-                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                        ( AppN Nothing
-                                                                                                          ( Ref Nothing
-                                                                                                            ( Imported
-                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                              ( Name "discard$w" )
-                                                                                                            )
-                                                                                                          )
-                                                                                                          ( AppN Nothing
-                                                                                                            ( Ref Nothing
-                                                                                                              ( Imported
-                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                ( Name "tell" )
-                                                                                                              )
-                                                                                                            )
-                                                                                                            ( LiteralArray Nothing
-                                                                                                              [ LiteralInt Nothing 17 ] :| []
-                                                                                                            ) :|
-                                                                                                            [ AbsN Nothing
-                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                              ( AppN Nothing
-                                                                                                                ( Ref Nothing
-                                                                                                                  ( Imported
-                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                    ( Name "discard$w" )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                                ( AppN Nothing
-                                                                                                                  ( Ref Nothing
-                                                                                                                    ( Imported
-                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                      ( Name "tell" )
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                  ( LiteralArray Nothing
-                                                                                                                    [ LiteralInt Nothing 18 ] :| []
-                                                                                                                  ) :|
-                                                                                                                  [ AbsN Nothing
-                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                    ( AppN Nothing
-                                                                                                                      ( Ref Nothing
-                                                                                                                        ( Imported
-                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                          ( Name "discard$w" )
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                      ( AppN Nothing
-                                                                                                                        ( Ref Nothing
-                                                                                                                          ( Imported
-                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                            ( Name "tell" )
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                        ( LiteralArray Nothing
-                                                                                                                          [ LiteralInt Nothing 19 ] :| []
-                                                                                                                        ) :|
-                                                                                                                        [ AbsN Nothing
-                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                          ( AppN Nothing
-                                                                                                                            ( Ref Nothing
-                                                                                                                              ( Imported
-                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                ( Name "discard$w" )
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                            ( AppN Nothing
-                                                                                                                              ( Ref Nothing
-                                                                                                                                ( Imported
-                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                  ( Name "tell" )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                [ LiteralInt Nothing 20 ] :| []
-                                                                                                                              ) :|
-                                                                                                                              [ AbsN Nothing
-                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                ( AppN Nothing
-                                                                                                                                  ( Ref Nothing
-                                                                                                                                    ( Imported
-                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                  ( AppN Nothing
-                                                                                                                                    ( Ref Nothing
-                                                                                                                                      ( Imported
-                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                        ( Name "tell" )
-                                                                                                                                      )
-                                                                                                                                    )
-                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                      [ LiteralInt Nothing 21 ] :| []
-                                                                                                                                    ) :|
-                                                                                                                                    [ AbsN Nothing
-                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                      ( AppN Nothing
-                                                                                                                                        ( Ref Nothing
-                                                                                                                                          ( Imported
-                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                          )
-                                                                                                                                        )
-                                                                                                                                        ( AppN Nothing
-                                                                                                                                          ( Ref Nothing
-                                                                                                                                            ( Imported
-                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                              ( Name "tell" )
-                                                                                                                                            )
-                                                                                                                                          )
-                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                            [ LiteralInt Nothing 22 ] :| []
-                                                                                                                                          ) :|
-                                                                                                                                          [ AbsN Nothing
-                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                            ( AppN Nothing
-                                                                                                                                              ( Ref Nothing
-                                                                                                                                                ( Imported
-                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                              ( AppN Nothing
-                                                                                                                                                ( Ref Nothing
-                                                                                                                                                  ( Imported
-                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                  [ LiteralInt Nothing 23 ] :| []
-                                                                                                                                                ) :|
-                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                      ( Imported
-                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                      )
-                                                                                                                                                    )
-                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                        ( Imported
-                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                        )
-                                                                                                                                                      )
-                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                        [ LiteralInt Nothing 24 ] :| []
-                                                                                                                                                      ) :|
-                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                            ( Imported
-                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                              ( Imported
-                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                              [ LiteralInt Nothing 25 ] :| []
-                                                                                                                                                            ) :|
-                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                  ( Imported
-                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                  )
-                                                                                                                                                                )
-                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                    ( Imported
-                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                    [ LiteralInt Nothing 26 ] :| []
-                                                                                                                                                                  ) :|
-                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                        ( Imported
-                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                        )
-                                                                                                                                                                      )
-                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                          ( Imported
-                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                          )
-                                                                                                                                                                        )
-                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                          [ LiteralInt Nothing 27 ] :| []
-                                                                                                                                                                        ) :|
-                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                              ( Imported
-                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                              )
-                                                                                                                                                                            )
-                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                ( Imported
-                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                )
-                                                                                                                                                                              )
-                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                [ LiteralInt Nothing 28 ] :| []
-                                                                                                                                                                              ) :|
-                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                    )
-                                                                                                                                                                                  )
-                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                      )
-                                                                                                                                                                                    )
-                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                      [ LiteralInt Nothing 29 ] :| []
-                                                                                                                                                                                    ) :|
-                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                          )
-                                                                                                                                                                                        )
-                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                            )
-                                                                                                                                                                                          )
-                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                            [ LiteralInt Nothing 30 ] :| []
-                                                                                                                                                                                          ) :|
-                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                )
-                                                                                                                                                                                              )
-                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                )
-                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                  [ LiteralInt Nothing 31 ] :| []
-                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                        [ LiteralInt Nothing 32 ] :| []
-                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                              ( Name "discard$w" )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                ( Name "tell" )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                            ( LiteralArray Nothing
-                                                                                                                                                                                                              [ LiteralInt Nothing 33 ] :| []
-                                                                                                                                                                                                            ) :|
-                                                                                                                                                                                                            [ AbsN Nothing
-                                                                                                                                                                                                              ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                    ( Name "discard$w" )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                      ( Name "tell" )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                  ( LiteralArray Nothing
-                                                                                                                                                                                                                    [ LiteralInt Nothing 34 ] :| []
-                                                                                                                                                                                                                  ) :|
-                                                                                                                                                                                                                  [ AbsN Nothing
-                                                                                                                                                                                                                    ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                          ( Name "discard$w" )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                            ( Name "tell" )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                        ( LiteralArray Nothing
-                                                                                                                                                                                                                          [ LiteralInt Nothing 35 ] :| []
-                                                                                                                                                                                                                        ) :|
-                                                                                                                                                                                                                        [ AbsN Nothing
-                                                                                                                                                                                                                          ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                          ( AppN Nothing
-                                                                                                                                                                                                                            ( Ref Nothing
-                                                                                                                                                                                                                              ( Imported
-                                                                                                                                                                                                                                ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                ( Name "discard$w" )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                  ( Name "tell" )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                              ( LiteralArray Nothing
-                                                                                                                                                                                                                                [ LiteralInt Nothing 36 ] :| []
-                                                                                                                                                                                                                              ) :|
-                                                                                                                                                                                                                              [ AbsN Nothing
-                                                                                                                                                                                                                                ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                ( AppN Nothing
-                                                                                                                                                                                                                                  ( Ref Nothing
-                                                                                                                                                                                                                                    ( Imported
-                                                                                                                                                                                                                                      ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                      ( Name "discard$w" )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                        ( Name "tell" )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                    ( LiteralArray Nothing
-                                                                                                                                                                                                                                      [ LiteralInt Nothing 37 ] :| []
-                                                                                                                                                                                                                                    ) :|
-                                                                                                                                                                                                                                    [ AbsN Nothing
-                                                                                                                                                                                                                                      ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                      ( AppN Nothing
-                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                          ( Imported
-                                                                                                                                                                                                                                            ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                            ( Name "discard$w" )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                        ( AppN Nothing
-                                                                                                                                                                                                                                          ( Ref Nothing
-                                                                                                                                                                                                                                            ( Imported
-                                                                                                                                                                                                                                              ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                              ( Name "tell" )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                          ( LiteralArray Nothing
-                                                                                                                                                                                                                                            [ LiteralInt Nothing 38 ] :| []
-                                                                                                                                                                                                                                          ) :|
-                                                                                                                                                                                                                                          [ AbsN Nothing
-                                                                                                                                                                                                                                            ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                            ( AppN Nothing
-                                                                                                                                                                                                                                              ( Ref Nothing
-                                                                                                                                                                                                                                                ( Imported
-                                                                                                                                                                                                                                                  ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                  ( Name "discard$w" )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                              ( AppN Nothing
-                                                                                                                                                                                                                                                ( Ref Nothing
-                                                                                                                                                                                                                                                  ( Imported
-                                                                                                                                                                                                                                                    ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                    ( Name "tell" )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                                                ( LiteralArray Nothing
-                                                                                                                                                                                                                                                  [ LiteralInt Nothing 39 ] :| []
-                                                                                                                                                                                                                                                ) :|
-                                                                                                                                                                                                                                                [ AbsN Nothing
-                                                                                                                                                                                                                                                  ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                  ( AppN Nothing
-                                                                                                                                                                                                                                                    ( Ref Nothing
-                                                                                                                                                                                                                                                      ( Imported
-                                                                                                                                                                                                                                                        ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                        ( Name "discard$w" )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                    ( AppN Nothing
-                                                                                                                                                                                                                                                      ( Ref Nothing
-                                                                                                                                                                                                                                                        ( Imported
-                                                                                                                                                                                                                                                          ( ModuleName "Golden.LongWriterBind.Test" )
-                                                                                                                                                                                                                                                          ( Name "tell" )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                                      ( LiteralArray Nothing
-                                                                                                                                                                                                                                                        [ LiteralInt Nothing 40 ] :| []
-                                                                                                                                                                                                                                                      ) :|
-                                                                                                                                                                                                                                                      [ AbsN Nothing
-                                                                                                                                                                                                                                                        ( ParamUnused Nothing :| [] )
-                                                                                                                                                                                                                                                        ( Ref Nothing
-                                                                                                                                                                                                                                                          ( Local
-                                                                                                                                                                                                                                                            ( Name "$kont3" )
-                                                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                                              )
-                                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                                          ]
-                                                                                                                                                                                                                                        )
-                                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                                    ]
-                                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                                )
-                                                                                                                                                                                                                              ]
-                                                                                                                                                                                                                            )
-                                                                                                                                                                                                                          )
-                                                                                                                                                                                                                        ]
-                                                                                                                                                                                                                      )
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                )
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            ]
-                                                                                                                                                                                                          )
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      ]
-                                                                                                                                                                                                    )
-                                                                                                                                                                                                  )
-                                                                                                                                                                                                ]
-                                                                                                                                                                                              )
-                                                                                                                                                                                            )
-                                                                                                                                                                                          ]
-                                                                                                                                                                                        )
-                                                                                                                                                                                      )
-                                                                                                                                                                                    ]
-                                                                                                                                                                                  )
-                                                                                                                                                                                )
-                                                                                                                                                                              ]
-                                                                                                                                                                            )
-                                                                                                                                                                          )
-                                                                                                                                                                        ]
-                                                                                                                                                                      )
-                                                                                                                                                                    )
-                                                                                                                                                                  ]
-                                                                                                                                                                )
-                                                                                                                                                              )
-                                                                                                                                                            ]
-                                                                                                                                                          )
-                                                                                                                                                        )
-                                                                                                                                                      ]
-                                                                                                                                                    )
-                                                                                                                                                  )
-                                                                                                                                                ]
-                                                                                                                                              )
-                                                                                                                                            )
-                                                                                                                                          ]
-                                                                                                                                        )
-                                                                                                                                      )
-                                                                                                                                    ]
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                              ]
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              )
-                                                                                                            ]
-                                                                                                          )
-                                                                                                        )
-                                                                                                      ]
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
+                                                                                                  [ LiteralInt Nothing 161 ] :| []
+                                                                                                )
                                                                                               )
-                                                                                            )
-                                                                                          ]
-                                                                                        )
-                                                                                      )
-                                                                                    ]
-                                                                                  )
-                                                                                )
-                                                                              ]
-                                                                            )
-                                                                          )
-                                                                        ]
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                )
-                                                              )
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                    )
-                                                  )
-                                                ]
-                                              )
-                                            )
-                                          ]
-                                        )
-                                      )
-                                    ]
+                                                                                              ( Ref Nothing
+                                                                                                ( Local
+                                                                                                  ( Name "$tmp0" )
+                                                                                                ) :| []
+                                                                                              ) :| []
+                                                                                            ) :| []
+                                                                                          ) :| []
+                                                                                        ) :| []
+                                                                                      ) :| []
+                                                                                    ) :| []
+                                                                                  ) :| []
+                                                                                ) :| []
+                                                                              ) :| []
+                                                                            ) :| []
+                                                                          ) :| []
+                                                                        ) :| []
+                                                                      ) :| []
+                                                                    ) :| []
+                                                                  ) :| []
+                                                                ) :| []
+                                                              ) :| []
+                                                            ) :| []
+                                                          ) :| []
+                                                        ) :| []
+                                                      ) :| []
+                                                    ) :| []
+                                                  ) :| []
+                                                ) :| []
+                                              ) :| []
+                                            ) :| []
+                                          ) :| []
+                                        ) :| []
+                                      ) :| []
+                                    ) :| []
+                                  ) :| []
+                                ) :| []
+                              ) :| []
+                            ) :| []
+                          ) :| []
+                        ) :| []
+                      ) :| []
+                    ) :| []
+                  ) :| []
+                )
+              ), Standalone
+              ( Nothing, Name "$tmp2", AppN Nothing
+                ( AppN Nothing
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                  )
+                  ( LiteralArray Nothing [ LiteralInt Nothing 82 ] :| [] )
+                )
+                ( AppN Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                    )
+                    ( LiteralArray Nothing [ LiteralInt Nothing 83 ] :| [] )
+                  )
+                  ( AppN Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                      )
+                      ( LiteralArray Nothing [ LiteralInt Nothing 84 ] :| [] )
+                    )
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                        )
+                        ( LiteralArray Nothing [ LiteralInt Nothing 85 ] :| [] )
+                      )
+                      ( AppN Nothing
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                          )
+                          ( LiteralArray Nothing [ LiteralInt Nothing 86 ] :| [] )
+                        )
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                            )
+                            ( LiteralArray Nothing [ LiteralInt Nothing 87 ] :| [] )
+                          )
+                          ( AppN Nothing
+                            ( AppN Nothing
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                              )
+                              ( LiteralArray Nothing [ LiteralInt Nothing 88 ] :| [] )
+                            )
+                            ( AppN Nothing
+                              ( AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Data.Semigroup" )
+                                    ( Name "concatArray" )
                                   )
                                 )
-                              ]
-                            )
-                          )
-                        ]
-                      )
+                                ( LiteralArray Nothing [ LiteralInt Nothing 89 ] :| [] )
+                              )
+                              ( AppN Nothing
+                                ( AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported
+                                      ( ModuleName "Data.Semigroup" )
+                                      ( Name "concatArray" )
+                                    )
+                                  )
+                                  ( LiteralArray Nothing [ LiteralInt Nothing 90 ] :| [] )
+                                )
+                                ( AppN Nothing
+                                  ( AppN Nothing
+                                    ( Ref Nothing
+                                      ( Imported
+                                        ( ModuleName "Data.Semigroup" )
+                                        ( Name "concatArray" )
+                                      )
+                                    )
+                                    ( LiteralArray Nothing [ LiteralInt Nothing 91 ] :| [] )
+                                  )
+                                  ( AppN Nothing
+                                    ( AppN Nothing
+                                      ( Ref Nothing
+                                        ( Imported
+                                          ( ModuleName "Data.Semigroup" )
+                                          ( Name "concatArray" )
+                                        )
+                                      )
+                                      ( LiteralArray Nothing [ LiteralInt Nothing 92 ] :| [] )
+                                    )
+                                    ( AppN Nothing
+                                      ( AppN Nothing
+                                        ( Ref Nothing
+                                          ( Imported
+                                            ( ModuleName "Data.Semigroup" )
+                                            ( Name "concatArray" )
+                                          )
+                                        )
+                                        ( LiteralArray Nothing [ LiteralInt Nothing 93 ] :| [] )
+                                      )
+                                      ( AppN Nothing
+                                        ( AppN Nothing
+                                          ( Ref Nothing
+                                            ( Imported
+                                              ( ModuleName "Data.Semigroup" )
+                                              ( Name "concatArray" )
+                                            )
+                                          )
+                                          ( LiteralArray Nothing [ LiteralInt Nothing 94 ] :| [] )
+                                        )
+                                        ( AppN Nothing
+                                          ( AppN Nothing
+                                            ( Ref Nothing
+                                              ( Imported
+                                                ( ModuleName "Data.Semigroup" )
+                                                ( Name "concatArray" )
+                                              )
+                                            )
+                                            ( LiteralArray Nothing [ LiteralInt Nothing 95 ] :| [] )
+                                          )
+                                          ( AppN Nothing
+                                            ( AppN Nothing
+                                              ( Ref Nothing
+                                                ( Imported
+                                                  ( ModuleName "Data.Semigroup" )
+                                                  ( Name "concatArray" )
+                                                )
+                                              )
+                                              ( LiteralArray Nothing
+                                                [ LiteralInt Nothing 96 ] :| []
+                                              )
+                                            )
+                                            ( AppN Nothing
+                                              ( AppN Nothing
+                                                ( Ref Nothing
+                                                  ( Imported
+                                                    ( ModuleName "Data.Semigroup" )
+                                                    ( Name "concatArray" )
+                                                  )
+                                                )
+                                                ( LiteralArray Nothing
+                                                  [ LiteralInt Nothing 97 ] :| []
+                                                )
+                                              )
+                                              ( AppN Nothing
+                                                ( AppN Nothing
+                                                  ( Ref Nothing
+                                                    ( Imported
+                                                      ( ModuleName "Data.Semigroup" )
+                                                      ( Name "concatArray" )
+                                                    )
+                                                  )
+                                                  ( LiteralArray Nothing
+                                                    [ LiteralInt Nothing 98 ] :| []
+                                                  )
+                                                )
+                                                ( AppN Nothing
+                                                  ( AppN Nothing
+                                                    ( Ref Nothing
+                                                      ( Imported
+                                                        ( ModuleName "Data.Semigroup" )
+                                                        ( Name "concatArray" )
+                                                      )
+                                                    )
+                                                    ( LiteralArray Nothing
+                                                      [ LiteralInt Nothing 99 ] :| []
+                                                    )
+                                                  )
+                                                  ( AppN Nothing
+                                                    ( AppN Nothing
+                                                      ( Ref Nothing
+                                                        ( Imported
+                                                          ( ModuleName "Data.Semigroup" )
+                                                          ( Name "concatArray" )
+                                                        )
+                                                      )
+                                                      ( LiteralArray Nothing
+                                                        [ LiteralInt Nothing 100 ] :| []
+                                                      )
+                                                    )
+                                                    ( AppN Nothing
+                                                      ( AppN Nothing
+                                                        ( Ref Nothing
+                                                          ( Imported
+                                                            ( ModuleName "Data.Semigroup" )
+                                                            ( Name "concatArray" )
+                                                          )
+                                                        )
+                                                        ( LiteralArray Nothing
+                                                          [ LiteralInt Nothing 101 ] :| []
+                                                        )
+                                                      )
+                                                      ( AppN Nothing
+                                                        ( AppN Nothing
+                                                          ( Ref Nothing
+                                                            ( Imported
+                                                              ( ModuleName "Data.Semigroup" )
+                                                              ( Name "concatArray" )
+                                                            )
+                                                          )
+                                                          ( LiteralArray Nothing
+                                                            [ LiteralInt Nothing 102 ] :| []
+                                                          )
+                                                        )
+                                                        ( AppN Nothing
+                                                          ( AppN Nothing
+                                                            ( Ref Nothing
+                                                              ( Imported
+                                                                ( ModuleName "Data.Semigroup" )
+                                                                ( Name "concatArray" )
+                                                              )
+                                                            )
+                                                            ( LiteralArray Nothing
+                                                              [ LiteralInt Nothing 103 ] :| []
+                                                            )
+                                                          )
+                                                          ( AppN Nothing
+                                                            ( AppN Nothing
+                                                              ( Ref Nothing
+                                                                ( Imported
+                                                                  ( ModuleName "Data.Semigroup" )
+                                                                  ( Name "concatArray" )
+                                                                )
+                                                              )
+                                                              ( LiteralArray Nothing
+                                                                [ LiteralInt Nothing 104 ] :| []
+                                                              )
+                                                            )
+                                                            ( AppN Nothing
+                                                              ( AppN Nothing
+                                                                ( Ref Nothing
+                                                                  ( Imported
+                                                                    ( ModuleName "Data.Semigroup" )
+                                                                    ( Name "concatArray" )
+                                                                  )
+                                                                )
+                                                                ( LiteralArray Nothing
+                                                                  [ LiteralInt Nothing 105 ] :| []
+                                                                )
+                                                              )
+                                                              ( AppN Nothing
+                                                                ( AppN Nothing
+                                                                  ( Ref Nothing
+                                                                    ( Imported
+                                                                      ( ModuleName "Data.Semigroup" )
+                                                                      ( Name "concatArray" )
+                                                                    )
+                                                                  )
+                                                                  ( LiteralArray Nothing
+                                                                    [ LiteralInt Nothing 106 ] :| []
+                                                                  )
+                                                                )
+                                                                ( AppN Nothing
+                                                                  ( AppN Nothing
+                                                                    ( Ref Nothing
+                                                                      ( Imported
+                                                                        ( ModuleName "Data.Semigroup" )
+                                                                        ( Name "concatArray" )
+                                                                      )
+                                                                    )
+                                                                    ( LiteralArray Nothing
+                                                                      [ LiteralInt Nothing 107 ] :| []
+                                                                    )
+                                                                  )
+                                                                  ( AppN Nothing
+                                                                    ( AppN Nothing
+                                                                      ( Ref Nothing
+                                                                        ( Imported
+                                                                          ( ModuleName "Data.Semigroup" )
+                                                                          ( Name "concatArray" )
+                                                                        )
+                                                                      )
+                                                                      ( LiteralArray Nothing
+                                                                        [ LiteralInt Nothing 108 ] :| []
+                                                                      )
+                                                                    )
+                                                                    ( AppN Nothing
+                                                                      ( AppN Nothing
+                                                                        ( Ref Nothing
+                                                                          ( Imported
+                                                                            ( ModuleName "Data.Semigroup" )
+                                                                            ( Name "concatArray" )
+                                                                          )
+                                                                        )
+                                                                        ( LiteralArray Nothing
+                                                                          [ LiteralInt Nothing 109 ] :| []
+                                                                        )
+                                                                      )
+                                                                      ( AppN Nothing
+                                                                        ( AppN Nothing
+                                                                          ( Ref Nothing
+                                                                            ( Imported
+                                                                              ( ModuleName "Data.Semigroup" )
+                                                                              ( Name "concatArray" )
+                                                                            )
+                                                                          )
+                                                                          ( LiteralArray Nothing
+                                                                            [ LiteralInt Nothing 110 ] :| []
+                                                                          )
+                                                                        )
+                                                                        ( AppN Nothing
+                                                                          ( AppN Nothing
+                                                                            ( Ref Nothing
+                                                                              ( Imported
+                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                ( Name "concatArray" )
+                                                                              )
+                                                                            )
+                                                                            ( LiteralArray Nothing
+                                                                              [ LiteralInt Nothing 111 ] :| []
+                                                                            )
+                                                                          )
+                                                                          ( AppN Nothing
+                                                                            ( AppN Nothing
+                                                                              ( Ref Nothing
+                                                                                ( Imported
+                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                  ( Name "concatArray" )
+                                                                                )
+                                                                              )
+                                                                              ( LiteralArray Nothing
+                                                                                [ LiteralInt Nothing 112 ] :| []
+                                                                              )
+                                                                            )
+                                                                            ( AppN Nothing
+                                                                              ( AppN Nothing
+                                                                                ( Ref Nothing
+                                                                                  ( Imported
+                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                    ( Name "concatArray" )
+                                                                                  )
+                                                                                )
+                                                                                ( LiteralArray Nothing
+                                                                                  [ LiteralInt Nothing 113 ] :| []
+                                                                                )
+                                                                              )
+                                                                              ( AppN Nothing
+                                                                                ( AppN Nothing
+                                                                                  ( Ref Nothing
+                                                                                    ( Imported
+                                                                                      ( ModuleName "Data.Semigroup" )
+                                                                                      ( Name "concatArray" )
+                                                                                    )
+                                                                                  )
+                                                                                  ( LiteralArray Nothing
+                                                                                    [ LiteralInt Nothing 114 ] :| []
+                                                                                  )
+                                                                                )
+                                                                                ( AppN Nothing
+                                                                                  ( AppN Nothing
+                                                                                    ( Ref Nothing
+                                                                                      ( Imported
+                                                                                        ( ModuleName "Data.Semigroup" )
+                                                                                        ( Name "concatArray" )
+                                                                                      )
+                                                                                    )
+                                                                                    ( LiteralArray Nothing
+                                                                                      [ LiteralInt Nothing 115 ] :| []
+                                                                                    )
+                                                                                  )
+                                                                                  ( AppN Nothing
+                                                                                    ( AppN Nothing
+                                                                                      ( Ref Nothing
+                                                                                        ( Imported
+                                                                                          ( ModuleName "Data.Semigroup" )
+                                                                                          ( Name "concatArray" )
+                                                                                        )
+                                                                                      )
+                                                                                      ( LiteralArray Nothing
+                                                                                        [ LiteralInt Nothing 116 ] :| []
+                                                                                      )
+                                                                                    )
+                                                                                    ( AppN Nothing
+                                                                                      ( AppN Nothing
+                                                                                        ( Ref Nothing
+                                                                                          ( Imported
+                                                                                            ( ModuleName "Data.Semigroup" )
+                                                                                            ( Name "concatArray" )
+                                                                                          )
+                                                                                        )
+                                                                                        ( LiteralArray Nothing
+                                                                                          [ LiteralInt Nothing 117 ] :| []
+                                                                                        )
+                                                                                      )
+                                                                                      ( AppN Nothing
+                                                                                        ( AppN Nothing
+                                                                                          ( Ref Nothing
+                                                                                            ( Imported
+                                                                                              ( ModuleName "Data.Semigroup" )
+                                                                                              ( Name "concatArray" )
+                                                                                            )
+                                                                                          )
+                                                                                          ( LiteralArray Nothing
+                                                                                            [ LiteralInt Nothing 118 ] :| []
+                                                                                          )
+                                                                                        )
+                                                                                        ( AppN Nothing
+                                                                                          ( AppN Nothing
+                                                                                            ( Ref Nothing
+                                                                                              ( Imported
+                                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                                ( Name "concatArray" )
+                                                                                              )
+                                                                                            )
+                                                                                            ( LiteralArray Nothing
+                                                                                              [ LiteralInt Nothing 119 ] :| []
+                                                                                            )
+                                                                                          )
+                                                                                          ( AppN Nothing
+                                                                                            ( AppN Nothing
+                                                                                              ( Ref Nothing
+                                                                                                ( Imported
+                                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                                  ( Name "concatArray" )
+                                                                                                )
+                                                                                              )
+                                                                                              ( LiteralArray Nothing
+                                                                                                [ LiteralInt Nothing 120 ] :| []
+                                                                                              )
+                                                                                            )
+                                                                                            ( AppN Nothing
+                                                                                              ( AppN Nothing
+                                                                                                ( Ref Nothing
+                                                                                                  ( Imported
+                                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                                    ( Name "concatArray" )
+                                                                                                  )
+                                                                                                )
+                                                                                                ( LiteralArray Nothing
+                                                                                                  [ LiteralInt Nothing 121 ] :| []
+                                                                                                )
+                                                                                              )
+                                                                                              ( Ref Nothing
+                                                                                                ( Local
+                                                                                                  ( Name "$tmp1" )
+                                                                                                ) :| []
+                                                                                              ) :| []
+                                                                                            ) :| []
+                                                                                          ) :| []
+                                                                                        ) :| []
+                                                                                      ) :| []
+                                                                                    ) :| []
+                                                                                  ) :| []
+                                                                                ) :| []
+                                                                              ) :| []
+                                                                            ) :| []
+                                                                          ) :| []
+                                                                        ) :| []
+                                                                      ) :| []
+                                                                    ) :| []
+                                                                  ) :| []
+                                                                ) :| []
+                                                              ) :| []
+                                                            ) :| []
+                                                          ) :| []
+                                                        ) :| []
+                                                      ) :| []
+                                                    ) :| []
+                                                  ) :| []
+                                                ) :| []
+                                              ) :| []
+                                            ) :| []
+                                          ) :| []
+                                        ) :| []
+                                      ) :| []
+                                    ) :| []
+                                  ) :| []
+                                ) :| []
+                              ) :| []
+                            ) :| []
+                          ) :| []
+                        ) :| []
+                      ) :| []
+                    ) :| []
+                  ) :| []
+                )
+              ), Standalone
+              ( Nothing, Name "$tmp3", AppN Nothing
+                ( AppN Nothing
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                  )
+                  ( LiteralArray Nothing [ LiteralInt Nothing 42 ] :| [] )
+                )
+                ( AppN Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
                     )
-                  ]
+                    ( LiteralArray Nothing [ LiteralInt Nothing 43 ] :| [] )
+                  )
+                  ( AppN Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                      )
+                      ( LiteralArray Nothing [ LiteralInt Nothing 44 ] :| [] )
+                    )
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                        )
+                        ( LiteralArray Nothing [ LiteralInt Nothing 45 ] :| [] )
+                      )
+                      ( AppN Nothing
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                          )
+                          ( LiteralArray Nothing [ LiteralInt Nothing 46 ] :| [] )
+                        )
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                            )
+                            ( LiteralArray Nothing [ LiteralInt Nothing 47 ] :| [] )
+                          )
+                          ( AppN Nothing
+                            ( AppN Nothing
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                              )
+                              ( LiteralArray Nothing [ LiteralInt Nothing 48 ] :| [] )
+                            )
+                            ( AppN Nothing
+                              ( AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Data.Semigroup" )
+                                    ( Name "concatArray" )
+                                  )
+                                )
+                                ( LiteralArray Nothing [ LiteralInt Nothing 49 ] :| [] )
+                              )
+                              ( AppN Nothing
+                                ( AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported
+                                      ( ModuleName "Data.Semigroup" )
+                                      ( Name "concatArray" )
+                                    )
+                                  )
+                                  ( LiteralArray Nothing [ LiteralInt Nothing 50 ] :| [] )
+                                )
+                                ( AppN Nothing
+                                  ( AppN Nothing
+                                    ( Ref Nothing
+                                      ( Imported
+                                        ( ModuleName "Data.Semigroup" )
+                                        ( Name "concatArray" )
+                                      )
+                                    )
+                                    ( LiteralArray Nothing [ LiteralInt Nothing 51 ] :| [] )
+                                  )
+                                  ( AppN Nothing
+                                    ( AppN Nothing
+                                      ( Ref Nothing
+                                        ( Imported
+                                          ( ModuleName "Data.Semigroup" )
+                                          ( Name "concatArray" )
+                                        )
+                                      )
+                                      ( LiteralArray Nothing [ LiteralInt Nothing 52 ] :| [] )
+                                    )
+                                    ( AppN Nothing
+                                      ( AppN Nothing
+                                        ( Ref Nothing
+                                          ( Imported
+                                            ( ModuleName "Data.Semigroup" )
+                                            ( Name "concatArray" )
+                                          )
+                                        )
+                                        ( LiteralArray Nothing [ LiteralInt Nothing 53 ] :| [] )
+                                      )
+                                      ( AppN Nothing
+                                        ( AppN Nothing
+                                          ( Ref Nothing
+                                            ( Imported
+                                              ( ModuleName "Data.Semigroup" )
+                                              ( Name "concatArray" )
+                                            )
+                                          )
+                                          ( LiteralArray Nothing [ LiteralInt Nothing 54 ] :| [] )
+                                        )
+                                        ( AppN Nothing
+                                          ( AppN Nothing
+                                            ( Ref Nothing
+                                              ( Imported
+                                                ( ModuleName "Data.Semigroup" )
+                                                ( Name "concatArray" )
+                                              )
+                                            )
+                                            ( LiteralArray Nothing [ LiteralInt Nothing 55 ] :| [] )
+                                          )
+                                          ( AppN Nothing
+                                            ( AppN Nothing
+                                              ( Ref Nothing
+                                                ( Imported
+                                                  ( ModuleName "Data.Semigroup" )
+                                                  ( Name "concatArray" )
+                                                )
+                                              )
+                                              ( LiteralArray Nothing
+                                                [ LiteralInt Nothing 56 ] :| []
+                                              )
+                                            )
+                                            ( AppN Nothing
+                                              ( AppN Nothing
+                                                ( Ref Nothing
+                                                  ( Imported
+                                                    ( ModuleName "Data.Semigroup" )
+                                                    ( Name "concatArray" )
+                                                  )
+                                                )
+                                                ( LiteralArray Nothing
+                                                  [ LiteralInt Nothing 57 ] :| []
+                                                )
+                                              )
+                                              ( AppN Nothing
+                                                ( AppN Nothing
+                                                  ( Ref Nothing
+                                                    ( Imported
+                                                      ( ModuleName "Data.Semigroup" )
+                                                      ( Name "concatArray" )
+                                                    )
+                                                  )
+                                                  ( LiteralArray Nothing
+                                                    [ LiteralInt Nothing 58 ] :| []
+                                                  )
+                                                )
+                                                ( AppN Nothing
+                                                  ( AppN Nothing
+                                                    ( Ref Nothing
+                                                      ( Imported
+                                                        ( ModuleName "Data.Semigroup" )
+                                                        ( Name "concatArray" )
+                                                      )
+                                                    )
+                                                    ( LiteralArray Nothing
+                                                      [ LiteralInt Nothing 59 ] :| []
+                                                    )
+                                                  )
+                                                  ( AppN Nothing
+                                                    ( AppN Nothing
+                                                      ( Ref Nothing
+                                                        ( Imported
+                                                          ( ModuleName "Data.Semigroup" )
+                                                          ( Name "concatArray" )
+                                                        )
+                                                      )
+                                                      ( LiteralArray Nothing
+                                                        [ LiteralInt Nothing 60 ] :| []
+                                                      )
+                                                    )
+                                                    ( AppN Nothing
+                                                      ( AppN Nothing
+                                                        ( Ref Nothing
+                                                          ( Imported
+                                                            ( ModuleName "Data.Semigroup" )
+                                                            ( Name "concatArray" )
+                                                          )
+                                                        )
+                                                        ( LiteralArray Nothing
+                                                          [ LiteralInt Nothing 61 ] :| []
+                                                        )
+                                                      )
+                                                      ( AppN Nothing
+                                                        ( AppN Nothing
+                                                          ( Ref Nothing
+                                                            ( Imported
+                                                              ( ModuleName "Data.Semigroup" )
+                                                              ( Name "concatArray" )
+                                                            )
+                                                          )
+                                                          ( LiteralArray Nothing
+                                                            [ LiteralInt Nothing 62 ] :| []
+                                                          )
+                                                        )
+                                                        ( AppN Nothing
+                                                          ( AppN Nothing
+                                                            ( Ref Nothing
+                                                              ( Imported
+                                                                ( ModuleName "Data.Semigroup" )
+                                                                ( Name "concatArray" )
+                                                              )
+                                                            )
+                                                            ( LiteralArray Nothing
+                                                              [ LiteralInt Nothing 63 ] :| []
+                                                            )
+                                                          )
+                                                          ( AppN Nothing
+                                                            ( AppN Nothing
+                                                              ( Ref Nothing
+                                                                ( Imported
+                                                                  ( ModuleName "Data.Semigroup" )
+                                                                  ( Name "concatArray" )
+                                                                )
+                                                              )
+                                                              ( LiteralArray Nothing
+                                                                [ LiteralInt Nothing 64 ] :| []
+                                                              )
+                                                            )
+                                                            ( AppN Nothing
+                                                              ( AppN Nothing
+                                                                ( Ref Nothing
+                                                                  ( Imported
+                                                                    ( ModuleName "Data.Semigroup" )
+                                                                    ( Name "concatArray" )
+                                                                  )
+                                                                )
+                                                                ( LiteralArray Nothing
+                                                                  [ LiteralInt Nothing 65 ] :| []
+                                                                )
+                                                              )
+                                                              ( AppN Nothing
+                                                                ( AppN Nothing
+                                                                  ( Ref Nothing
+                                                                    ( Imported
+                                                                      ( ModuleName "Data.Semigroup" )
+                                                                      ( Name "concatArray" )
+                                                                    )
+                                                                  )
+                                                                  ( LiteralArray Nothing
+                                                                    [ LiteralInt Nothing 66 ] :| []
+                                                                  )
+                                                                )
+                                                                ( AppN Nothing
+                                                                  ( AppN Nothing
+                                                                    ( Ref Nothing
+                                                                      ( Imported
+                                                                        ( ModuleName "Data.Semigroup" )
+                                                                        ( Name "concatArray" )
+                                                                      )
+                                                                    )
+                                                                    ( LiteralArray Nothing
+                                                                      [ LiteralInt Nothing 67 ] :| []
+                                                                    )
+                                                                  )
+                                                                  ( AppN Nothing
+                                                                    ( AppN Nothing
+                                                                      ( Ref Nothing
+                                                                        ( Imported
+                                                                          ( ModuleName "Data.Semigroup" )
+                                                                          ( Name "concatArray" )
+                                                                        )
+                                                                      )
+                                                                      ( LiteralArray Nothing
+                                                                        [ LiteralInt Nothing 68 ] :| []
+                                                                      )
+                                                                    )
+                                                                    ( AppN Nothing
+                                                                      ( AppN Nothing
+                                                                        ( Ref Nothing
+                                                                          ( Imported
+                                                                            ( ModuleName "Data.Semigroup" )
+                                                                            ( Name "concatArray" )
+                                                                          )
+                                                                        )
+                                                                        ( LiteralArray Nothing
+                                                                          [ LiteralInt Nothing 69 ] :| []
+                                                                        )
+                                                                      )
+                                                                      ( AppN Nothing
+                                                                        ( AppN Nothing
+                                                                          ( Ref Nothing
+                                                                            ( Imported
+                                                                              ( ModuleName "Data.Semigroup" )
+                                                                              ( Name "concatArray" )
+                                                                            )
+                                                                          )
+                                                                          ( LiteralArray Nothing
+                                                                            [ LiteralInt Nothing 70 ] :| []
+                                                                          )
+                                                                        )
+                                                                        ( AppN Nothing
+                                                                          ( AppN Nothing
+                                                                            ( Ref Nothing
+                                                                              ( Imported
+                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                ( Name "concatArray" )
+                                                                              )
+                                                                            )
+                                                                            ( LiteralArray Nothing
+                                                                              [ LiteralInt Nothing 71 ] :| []
+                                                                            )
+                                                                          )
+                                                                          ( AppN Nothing
+                                                                            ( AppN Nothing
+                                                                              ( Ref Nothing
+                                                                                ( Imported
+                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                  ( Name "concatArray" )
+                                                                                )
+                                                                              )
+                                                                              ( LiteralArray Nothing
+                                                                                [ LiteralInt Nothing 72 ] :| []
+                                                                              )
+                                                                            )
+                                                                            ( AppN Nothing
+                                                                              ( AppN Nothing
+                                                                                ( Ref Nothing
+                                                                                  ( Imported
+                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                    ( Name "concatArray" )
+                                                                                  )
+                                                                                )
+                                                                                ( LiteralArray Nothing
+                                                                                  [ LiteralInt Nothing 73 ] :| []
+                                                                                )
+                                                                              )
+                                                                              ( AppN Nothing
+                                                                                ( AppN Nothing
+                                                                                  ( Ref Nothing
+                                                                                    ( Imported
+                                                                                      ( ModuleName "Data.Semigroup" )
+                                                                                      ( Name "concatArray" )
+                                                                                    )
+                                                                                  )
+                                                                                  ( LiteralArray Nothing
+                                                                                    [ LiteralInt Nothing 74 ] :| []
+                                                                                  )
+                                                                                )
+                                                                                ( AppN Nothing
+                                                                                  ( AppN Nothing
+                                                                                    ( Ref Nothing
+                                                                                      ( Imported
+                                                                                        ( ModuleName "Data.Semigroup" )
+                                                                                        ( Name "concatArray" )
+                                                                                      )
+                                                                                    )
+                                                                                    ( LiteralArray Nothing
+                                                                                      [ LiteralInt Nothing 75 ] :| []
+                                                                                    )
+                                                                                  )
+                                                                                  ( AppN Nothing
+                                                                                    ( AppN Nothing
+                                                                                      ( Ref Nothing
+                                                                                        ( Imported
+                                                                                          ( ModuleName "Data.Semigroup" )
+                                                                                          ( Name "concatArray" )
+                                                                                        )
+                                                                                      )
+                                                                                      ( LiteralArray Nothing
+                                                                                        [ LiteralInt Nothing 76 ] :| []
+                                                                                      )
+                                                                                    )
+                                                                                    ( AppN Nothing
+                                                                                      ( AppN Nothing
+                                                                                        ( Ref Nothing
+                                                                                          ( Imported
+                                                                                            ( ModuleName "Data.Semigroup" )
+                                                                                            ( Name "concatArray" )
+                                                                                          )
+                                                                                        )
+                                                                                        ( LiteralArray Nothing
+                                                                                          [ LiteralInt Nothing 77 ] :| []
+                                                                                        )
+                                                                                      )
+                                                                                      ( AppN Nothing
+                                                                                        ( AppN Nothing
+                                                                                          ( Ref Nothing
+                                                                                            ( Imported
+                                                                                              ( ModuleName "Data.Semigroup" )
+                                                                                              ( Name "concatArray" )
+                                                                                            )
+                                                                                          )
+                                                                                          ( LiteralArray Nothing
+                                                                                            [ LiteralInt Nothing 78 ] :| []
+                                                                                          )
+                                                                                        )
+                                                                                        ( AppN Nothing
+                                                                                          ( AppN Nothing
+                                                                                            ( Ref Nothing
+                                                                                              ( Imported
+                                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                                ( Name "concatArray" )
+                                                                                              )
+                                                                                            )
+                                                                                            ( LiteralArray Nothing
+                                                                                              [ LiteralInt Nothing 79 ] :| []
+                                                                                            )
+                                                                                          )
+                                                                                          ( AppN Nothing
+                                                                                            ( AppN Nothing
+                                                                                              ( Ref Nothing
+                                                                                                ( Imported
+                                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                                  ( Name "concatArray" )
+                                                                                                )
+                                                                                              )
+                                                                                              ( LiteralArray Nothing
+                                                                                                [ LiteralInt Nothing 80 ] :| []
+                                                                                              )
+                                                                                            )
+                                                                                            ( AppN Nothing
+                                                                                              ( AppN Nothing
+                                                                                                ( Ref Nothing
+                                                                                                  ( Imported
+                                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                                    ( Name "concatArray" )
+                                                                                                  )
+                                                                                                )
+                                                                                                ( LiteralArray Nothing
+                                                                                                  [ LiteralInt Nothing 81 ] :| []
+                                                                                                )
+                                                                                              )
+                                                                                              ( Ref Nothing
+                                                                                                ( Local
+                                                                                                  ( Name "$tmp2" )
+                                                                                                ) :| []
+                                                                                              ) :| []
+                                                                                            ) :| []
+                                                                                          ) :| []
+                                                                                        ) :| []
+                                                                                      ) :| []
+                                                                                    ) :| []
+                                                                                  ) :| []
+                                                                                ) :| []
+                                                                              ) :| []
+                                                                            ) :| []
+                                                                          ) :| []
+                                                                        ) :| []
+                                                                      ) :| []
+                                                                    ) :| []
+                                                                  ) :| []
+                                                                ) :| []
+                                                              ) :| []
+                                                            ) :| []
+                                                          ) :| []
+                                                        ) :| []
+                                                      ) :| []
+                                                    ) :| []
+                                                  ) :| []
+                                                ) :| []
+                                              ) :| []
+                                            ) :| []
+                                          ) :| []
+                                        ) :| []
+                                      ) :| []
+                                    ) :| []
+                                  ) :| []
+                                ) :| []
+                              ) :| []
+                            ) :| []
+                          ) :| []
+                        ) :| []
+                      ) :| []
+                    ) :| []
+                  ) :| []
+                )
+              ), Standalone
+              ( Nothing, Name "$tmp4", AppN Nothing
+                ( AppN Nothing
+                  ( Ref Nothing
+                    ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                  )
+                  ( LiteralArray Nothing [ LiteralInt Nothing 2 ] :| [] )
+                )
+                ( AppN Nothing
+                  ( AppN Nothing
+                    ( Ref Nothing
+                      ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                    )
+                    ( LiteralArray Nothing [ LiteralInt Nothing 3 ] :| [] )
+                  )
+                  ( AppN Nothing
+                    ( AppN Nothing
+                      ( Ref Nothing
+                        ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                      )
+                      ( LiteralArray Nothing [ LiteralInt Nothing 4 ] :| [] )
+                    )
+                    ( AppN Nothing
+                      ( AppN Nothing
+                        ( Ref Nothing
+                          ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                        )
+                        ( LiteralArray Nothing [ LiteralInt Nothing 5 ] :| [] )
+                      )
+                      ( AppN Nothing
+                        ( AppN Nothing
+                          ( Ref Nothing
+                            ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                          )
+                          ( LiteralArray Nothing [ LiteralInt Nothing 6 ] :| [] )
+                        )
+                        ( AppN Nothing
+                          ( AppN Nothing
+                            ( Ref Nothing
+                              ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                            )
+                            ( LiteralArray Nothing [ LiteralInt Nothing 7 ] :| [] )
+                          )
+                          ( AppN Nothing
+                            ( AppN Nothing
+                              ( Ref Nothing
+                                ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) )
+                              )
+                              ( LiteralArray Nothing [ LiteralInt Nothing 8 ] :| [] )
+                            )
+                            ( AppN Nothing
+                              ( AppN Nothing
+                                ( Ref Nothing
+                                  ( Imported
+                                    ( ModuleName "Data.Semigroup" )
+                                    ( Name "concatArray" )
+                                  )
+                                )
+                                ( LiteralArray Nothing [ LiteralInt Nothing 9 ] :| [] )
+                              )
+                              ( AppN Nothing
+                                ( AppN Nothing
+                                  ( Ref Nothing
+                                    ( Imported
+                                      ( ModuleName "Data.Semigroup" )
+                                      ( Name "concatArray" )
+                                    )
+                                  )
+                                  ( LiteralArray Nothing [ LiteralInt Nothing 10 ] :| [] )
+                                )
+                                ( AppN Nothing
+                                  ( AppN Nothing
+                                    ( Ref Nothing
+                                      ( Imported
+                                        ( ModuleName "Data.Semigroup" )
+                                        ( Name "concatArray" )
+                                      )
+                                    )
+                                    ( LiteralArray Nothing [ LiteralInt Nothing 11 ] :| [] )
+                                  )
+                                  ( AppN Nothing
+                                    ( AppN Nothing
+                                      ( Ref Nothing
+                                        ( Imported
+                                          ( ModuleName "Data.Semigroup" )
+                                          ( Name "concatArray" )
+                                        )
+                                      )
+                                      ( LiteralArray Nothing [ LiteralInt Nothing 12 ] :| [] )
+                                    )
+                                    ( AppN Nothing
+                                      ( AppN Nothing
+                                        ( Ref Nothing
+                                          ( Imported
+                                            ( ModuleName "Data.Semigroup" )
+                                            ( Name "concatArray" )
+                                          )
+                                        )
+                                        ( LiteralArray Nothing [ LiteralInt Nothing 13 ] :| [] )
+                                      )
+                                      ( AppN Nothing
+                                        ( AppN Nothing
+                                          ( Ref Nothing
+                                            ( Imported
+                                              ( ModuleName "Data.Semigroup" )
+                                              ( Name "concatArray" )
+                                            )
+                                          )
+                                          ( LiteralArray Nothing [ LiteralInt Nothing 14 ] :| [] )
+                                        )
+                                        ( AppN Nothing
+                                          ( AppN Nothing
+                                            ( Ref Nothing
+                                              ( Imported
+                                                ( ModuleName "Data.Semigroup" )
+                                                ( Name "concatArray" )
+                                              )
+                                            )
+                                            ( LiteralArray Nothing [ LiteralInt Nothing 15 ] :| [] )
+                                          )
+                                          ( AppN Nothing
+                                            ( AppN Nothing
+                                              ( Ref Nothing
+                                                ( Imported
+                                                  ( ModuleName "Data.Semigroup" )
+                                                  ( Name "concatArray" )
+                                                )
+                                              )
+                                              ( LiteralArray Nothing
+                                                [ LiteralInt Nothing 16 ] :| []
+                                              )
+                                            )
+                                            ( AppN Nothing
+                                              ( AppN Nothing
+                                                ( Ref Nothing
+                                                  ( Imported
+                                                    ( ModuleName "Data.Semigroup" )
+                                                    ( Name "concatArray" )
+                                                  )
+                                                )
+                                                ( LiteralArray Nothing
+                                                  [ LiteralInt Nothing 17 ] :| []
+                                                )
+                                              )
+                                              ( AppN Nothing
+                                                ( AppN Nothing
+                                                  ( Ref Nothing
+                                                    ( Imported
+                                                      ( ModuleName "Data.Semigroup" )
+                                                      ( Name "concatArray" )
+                                                    )
+                                                  )
+                                                  ( LiteralArray Nothing
+                                                    [ LiteralInt Nothing 18 ] :| []
+                                                  )
+                                                )
+                                                ( AppN Nothing
+                                                  ( AppN Nothing
+                                                    ( Ref Nothing
+                                                      ( Imported
+                                                        ( ModuleName "Data.Semigroup" )
+                                                        ( Name "concatArray" )
+                                                      )
+                                                    )
+                                                    ( LiteralArray Nothing
+                                                      [ LiteralInt Nothing 19 ] :| []
+                                                    )
+                                                  )
+                                                  ( AppN Nothing
+                                                    ( AppN Nothing
+                                                      ( Ref Nothing
+                                                        ( Imported
+                                                          ( ModuleName "Data.Semigroup" )
+                                                          ( Name "concatArray" )
+                                                        )
+                                                      )
+                                                      ( LiteralArray Nothing
+                                                        [ LiteralInt Nothing 20 ] :| []
+                                                      )
+                                                    )
+                                                    ( AppN Nothing
+                                                      ( AppN Nothing
+                                                        ( Ref Nothing
+                                                          ( Imported
+                                                            ( ModuleName "Data.Semigroup" )
+                                                            ( Name "concatArray" )
+                                                          )
+                                                        )
+                                                        ( LiteralArray Nothing
+                                                          [ LiteralInt Nothing 21 ] :| []
+                                                        )
+                                                      )
+                                                      ( AppN Nothing
+                                                        ( AppN Nothing
+                                                          ( Ref Nothing
+                                                            ( Imported
+                                                              ( ModuleName "Data.Semigroup" )
+                                                              ( Name "concatArray" )
+                                                            )
+                                                          )
+                                                          ( LiteralArray Nothing
+                                                            [ LiteralInt Nothing 22 ] :| []
+                                                          )
+                                                        )
+                                                        ( AppN Nothing
+                                                          ( AppN Nothing
+                                                            ( Ref Nothing
+                                                              ( Imported
+                                                                ( ModuleName "Data.Semigroup" )
+                                                                ( Name "concatArray" )
+                                                              )
+                                                            )
+                                                            ( LiteralArray Nothing
+                                                              [ LiteralInt Nothing 23 ] :| []
+                                                            )
+                                                          )
+                                                          ( AppN Nothing
+                                                            ( AppN Nothing
+                                                              ( Ref Nothing
+                                                                ( Imported
+                                                                  ( ModuleName "Data.Semigroup" )
+                                                                  ( Name "concatArray" )
+                                                                )
+                                                              )
+                                                              ( LiteralArray Nothing
+                                                                [ LiteralInt Nothing 24 ] :| []
+                                                              )
+                                                            )
+                                                            ( AppN Nothing
+                                                              ( AppN Nothing
+                                                                ( Ref Nothing
+                                                                  ( Imported
+                                                                    ( ModuleName "Data.Semigroup" )
+                                                                    ( Name "concatArray" )
+                                                                  )
+                                                                )
+                                                                ( LiteralArray Nothing
+                                                                  [ LiteralInt Nothing 25 ] :| []
+                                                                )
+                                                              )
+                                                              ( AppN Nothing
+                                                                ( AppN Nothing
+                                                                  ( Ref Nothing
+                                                                    ( Imported
+                                                                      ( ModuleName "Data.Semigroup" )
+                                                                      ( Name "concatArray" )
+                                                                    )
+                                                                  )
+                                                                  ( LiteralArray Nothing
+                                                                    [ LiteralInt Nothing 26 ] :| []
+                                                                  )
+                                                                )
+                                                                ( AppN Nothing
+                                                                  ( AppN Nothing
+                                                                    ( Ref Nothing
+                                                                      ( Imported
+                                                                        ( ModuleName "Data.Semigroup" )
+                                                                        ( Name "concatArray" )
+                                                                      )
+                                                                    )
+                                                                    ( LiteralArray Nothing
+                                                                      [ LiteralInt Nothing 27 ] :| []
+                                                                    )
+                                                                  )
+                                                                  ( AppN Nothing
+                                                                    ( AppN Nothing
+                                                                      ( Ref Nothing
+                                                                        ( Imported
+                                                                          ( ModuleName "Data.Semigroup" )
+                                                                          ( Name "concatArray" )
+                                                                        )
+                                                                      )
+                                                                      ( LiteralArray Nothing
+                                                                        [ LiteralInt Nothing 28 ] :| []
+                                                                      )
+                                                                    )
+                                                                    ( AppN Nothing
+                                                                      ( AppN Nothing
+                                                                        ( Ref Nothing
+                                                                          ( Imported
+                                                                            ( ModuleName "Data.Semigroup" )
+                                                                            ( Name "concatArray" )
+                                                                          )
+                                                                        )
+                                                                        ( LiteralArray Nothing
+                                                                          [ LiteralInt Nothing 29 ] :| []
+                                                                        )
+                                                                      )
+                                                                      ( AppN Nothing
+                                                                        ( AppN Nothing
+                                                                          ( Ref Nothing
+                                                                            ( Imported
+                                                                              ( ModuleName "Data.Semigroup" )
+                                                                              ( Name "concatArray" )
+                                                                            )
+                                                                          )
+                                                                          ( LiteralArray Nothing
+                                                                            [ LiteralInt Nothing 30 ] :| []
+                                                                          )
+                                                                        )
+                                                                        ( AppN Nothing
+                                                                          ( AppN Nothing
+                                                                            ( Ref Nothing
+                                                                              ( Imported
+                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                ( Name "concatArray" )
+                                                                              )
+                                                                            )
+                                                                            ( LiteralArray Nothing
+                                                                              [ LiteralInt Nothing 31 ] :| []
+                                                                            )
+                                                                          )
+                                                                          ( AppN Nothing
+                                                                            ( AppN Nothing
+                                                                              ( Ref Nothing
+                                                                                ( Imported
+                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                  ( Name "concatArray" )
+                                                                                )
+                                                                              )
+                                                                              ( LiteralArray Nothing
+                                                                                [ LiteralInt Nothing 32 ] :| []
+                                                                              )
+                                                                            )
+                                                                            ( AppN Nothing
+                                                                              ( AppN Nothing
+                                                                                ( Ref Nothing
+                                                                                  ( Imported
+                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                    ( Name "concatArray" )
+                                                                                  )
+                                                                                )
+                                                                                ( LiteralArray Nothing
+                                                                                  [ LiteralInt Nothing 33 ] :| []
+                                                                                )
+                                                                              )
+                                                                              ( AppN Nothing
+                                                                                ( AppN Nothing
+                                                                                  ( Ref Nothing
+                                                                                    ( Imported
+                                                                                      ( ModuleName "Data.Semigroup" )
+                                                                                      ( Name "concatArray" )
+                                                                                    )
+                                                                                  )
+                                                                                  ( LiteralArray Nothing
+                                                                                    [ LiteralInt Nothing 34 ] :| []
+                                                                                  )
+                                                                                )
+                                                                                ( AppN Nothing
+                                                                                  ( AppN Nothing
+                                                                                    ( Ref Nothing
+                                                                                      ( Imported
+                                                                                        ( ModuleName "Data.Semigroup" )
+                                                                                        ( Name "concatArray" )
+                                                                                      )
+                                                                                    )
+                                                                                    ( LiteralArray Nothing
+                                                                                      [ LiteralInt Nothing 35 ] :| []
+                                                                                    )
+                                                                                  )
+                                                                                  ( AppN Nothing
+                                                                                    ( AppN Nothing
+                                                                                      ( Ref Nothing
+                                                                                        ( Imported
+                                                                                          ( ModuleName "Data.Semigroup" )
+                                                                                          ( Name "concatArray" )
+                                                                                        )
+                                                                                      )
+                                                                                      ( LiteralArray Nothing
+                                                                                        [ LiteralInt Nothing 36 ] :| []
+                                                                                      )
+                                                                                    )
+                                                                                    ( AppN Nothing
+                                                                                      ( AppN Nothing
+                                                                                        ( Ref Nothing
+                                                                                          ( Imported
+                                                                                            ( ModuleName "Data.Semigroup" )
+                                                                                            ( Name "concatArray" )
+                                                                                          )
+                                                                                        )
+                                                                                        ( LiteralArray Nothing
+                                                                                          [ LiteralInt Nothing 37 ] :| []
+                                                                                        )
+                                                                                      )
+                                                                                      ( AppN Nothing
+                                                                                        ( AppN Nothing
+                                                                                          ( Ref Nothing
+                                                                                            ( Imported
+                                                                                              ( ModuleName "Data.Semigroup" )
+                                                                                              ( Name "concatArray" )
+                                                                                            )
+                                                                                          )
+                                                                                          ( LiteralArray Nothing
+                                                                                            [ LiteralInt Nothing 38 ] :| []
+                                                                                          )
+                                                                                        )
+                                                                                        ( AppN Nothing
+                                                                                          ( AppN Nothing
+                                                                                            ( Ref Nothing
+                                                                                              ( Imported
+                                                                                                ( ModuleName "Data.Semigroup" )
+                                                                                                ( Name "concatArray" )
+                                                                                              )
+                                                                                            )
+                                                                                            ( LiteralArray Nothing
+                                                                                              [ LiteralInt Nothing 39 ] :| []
+                                                                                            )
+                                                                                          )
+                                                                                          ( AppN Nothing
+                                                                                            ( AppN Nothing
+                                                                                              ( Ref Nothing
+                                                                                                ( Imported
+                                                                                                  ( ModuleName "Data.Semigroup" )
+                                                                                                  ( Name "concatArray" )
+                                                                                                )
+                                                                                              )
+                                                                                              ( LiteralArray Nothing
+                                                                                                [ LiteralInt Nothing 40 ] :| []
+                                                                                              )
+                                                                                            )
+                                                                                            ( AppN Nothing
+                                                                                              ( AppN Nothing
+                                                                                                ( Ref Nothing
+                                                                                                  ( Imported
+                                                                                                    ( ModuleName "Data.Semigroup" )
+                                                                                                    ( Name "concatArray" )
+                                                                                                  )
+                                                                                                )
+                                                                                                ( LiteralArray Nothing
+                                                                                                  [ LiteralInt Nothing 41 ] :| []
+                                                                                                )
+                                                                                              )
+                                                                                              ( Ref Nothing
+                                                                                                ( Local
+                                                                                                  ( Name "$tmp3" )
+                                                                                                ) :| []
+                                                                                              ) :| []
+                                                                                            ) :| []
+                                                                                          ) :| []
+                                                                                        ) :| []
+                                                                                      ) :| []
+                                                                                    ) :| []
+                                                                                  ) :| []
+                                                                                ) :| []
+                                                                              ) :| []
+                                                                            ) :| []
+                                                                          ) :| []
+                                                                        ) :| []
+                                                                      ) :| []
+                                                                    ) :| []
+                                                                  ) :| []
+                                                                ) :| []
+                                                              ) :| []
+                                                            ) :| []
+                                                          ) :| []
+                                                        ) :| []
+                                                      ) :| []
+                                                    ) :| []
+                                                  ) :| []
+                                                ) :| []
+                                              ) :| []
+                                            ) :| []
+                                          ) :| []
+                                        ) :| []
+                                      ) :| []
+                                    ) :| []
+                                  ) :| []
+                                ) :| []
+                              ) :| []
+                            ) :| []
+                          ) :| []
+                        ) :| []
+                      ) :| []
+                    ) :| []
+                  ) :| []
                 )
               )
             ]
           )
-        )
+          ( AppN Nothing
+            ( AppN Nothing
+              ( Ref Nothing ( Imported ( ModuleName "Data.Semigroup" ) ( Name "concatArray" ) ) )
+              ( LiteralArray Nothing [ LiteralInt Nothing 1 ] :| [] )
+            )
+            ( Ref Nothing ( Local ( Name "$tmp4" ) ) :| [] )
+          )
+        ]
       ), Standalone
       ( QName
         { qnameModuleName = ModuleName "Golden.LongWriterBind.Test", qnameName = Name "compute"

--- a/test/ps/output/Golden.LongWriterBind.Test/golden.lua
+++ b/test/ps/output/Golden.LongWriterBind.Test/golden.lua
@@ -1,846 +1,233 @@
-local Data_Unit_unit = {}
-local Data_Semigroup_foreign = {
-  concatArray = function(xs)
-    return function(ys)
-      if #(xs) == 0 then return ys end
-      if #(ys) == 0 then return xs end
-      local result = {}
-      for index, value in ipairs(xs) do result[index] = value end
-      local offset = #(result)
-      for index, value in ipairs(ys) do result[index + offset] = value end
-      return result
-    end
+local Data_Semigroup_concatArray = function(xs)
+  return function(ys)
+    if #(xs) == 0 then return ys end
+    if #(ys) == 0 then return xs end
+    local result = {}
+    for index, value in ipairs(xs) do result[index] = value end
+    local offset = #(result)
+    for index, value in ipairs(ys) do result[index + offset] = value end
+    return result
   end
-}
-local Data_Identity_applyIdentity = {
-  apply = function(v) return function(v1) return v(v1) end end,
-  Functor0 = function()
-    return {
-      map = function(f_S_0) return function(m_S_0) return f_S_0(m_S_0) end end
-    }
-  end
-}
-local Data_Identity_applicativeIdentity = {
-  pure = function(x_S_0) return x_S_0 end,
-  Apply0 = function() return Data_Identity_applyIdentity end
-}
-local Golden_LongWriterBind_Test_discard_S_w = function(v_S_0, k_S_0)
-  local m_S_1 = k_S_0(v_S_0[1])
-  return { m_S_1[1], (Data_Semigroup_foreign.concatArray(v_S_0[2])(m_S_1[2])) }
 end
-local Golden_LongWriterBind_Test_tell = function(x_S_1)
-  return { Data_Unit_unit, x_S_1 }
-end
-local Golden_LongWriterBind_Test_go = (function()
-  local _S_kont0 = Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-    [1] = 161
-  }), function()
-    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
+local Golden_LongWriterBind_Test_go = {
+  42,
+  ((function()
+    local _S_tmp0 = Data_Semigroup_concatArray({
       [1] = 162
-    }), function()
-      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-        [1] = 163
-      }), function()
-        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-          [1] = 164
-        }), function()
-          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-            [1] = 165
-          }), function()
-            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-              [1] = 166
-            }), function()
-              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                [1] = 167
-              }), function()
-                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                  [1] = 168
-                }), function()
-                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                    [1] = 169
-                  }), function()
-                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                      [1] = 170
-                    }), function()
-                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                        [1] = 171
-                      }), function()
-                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                          [1] = 172
-                        }), function()
-                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                            [1] = 173
-                          }), function()
-                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                              [1] = 174
-                            }), function()
-                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                [1] = 175
-                              }), function()
-                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                  [1] = 176
-                                }), function()
-                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                    [1] = 177
-                                  }), function()
-                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                      [1] = 178
-                                    }), function()
-                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                        [1] = 179
-                                      }), function()
-                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                          [1] = 180
-                                        }), function()
-                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                            [1] = 181
-                                          }), function()
-                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                              [1] = 182
-                                            }), function()
-                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                [1] = 183
-                                              }), function()
-                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                  [1] = 184
-                                                }), function()
-                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                    [1] = 185
-                                                  }), function()
-                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                      [1] = 186
-                                                    }), function()
-                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                        [1] = 187
-                                                      }), function()
-                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                          [1] = 188
-                                                        }), function()
-                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                            [1] = 189
-                                                          }), function()
-                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                              [1] = 190
-                                                            }), function()
-                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                [1] = 191
-                                                              }), function()
-                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                  [1] = 192
-                                                                }), function()
-                                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                    [1] = 193
-                                                                  }), function()
-                                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                      [1] = 194
-                                                                    }), function(  )
-                                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                        [1] = 195
-                                                                      }), function(  )
-                                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                          [1] = 196
-                                                                        }), function(  )
-                                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                            [1] = 197
-                                                                          }), function(  )
-                                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                              [1] = 198
-                                                                            }), function(  )
-                                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                [1] = 199
-                                                                              }), function(  )
-                                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                  [1] = 200
-                                                                                }), function(  )
-                                                                                  return Data_Identity_applicativeIdentity.pure({
-                                                                                    42,
-                                                                                    {}
-                                                                                  })
-                                                                                end)
-                                                                              end)
-                                                                            end)
-                                                                          end)
-                                                                        end)
-                                                                      end)
-                                                                    end)
-                                                                  end)
-                                                                end)
-                                                              end)
-                                                            end)
-                                                          end)
-                                                        end)
-                                                      end)
-                                                    end)
-                                                  end)
-                                                end)
-                                              end)
-                                            end)
-                                          end)
-                                        end)
-                                      end)
-                                    end)
-                                  end)
-                                end)
-                              end)
-                            end)
-                          end)
-                        end)
-                      end)
-                    end)
-                  end)
-                end)
-              end)
-            end)
-          end)
-        end)
-      end)
-    end)
-  end)
-  local _S_kont1 = Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-    [1] = 121
-  }), function()
-    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
+    })(Data_Semigroup_concatArray({ [1] = 163 })(Data_Semigroup_concatArray({
+      [1] = 164
+    })(Data_Semigroup_concatArray({ [1] = 165 })(Data_Semigroup_concatArray({
+      [1] = 166
+    })(Data_Semigroup_concatArray({ [1] = 167 })(Data_Semigroup_concatArray({
+      [1] = 168
+    })(Data_Semigroup_concatArray({ [1] = 169 })(Data_Semigroup_concatArray({
+      [1] = 170
+    })(Data_Semigroup_concatArray({ [1] = 171 })(Data_Semigroup_concatArray({
+      [1] = 172
+    })(Data_Semigroup_concatArray({ [1] = 173 })(Data_Semigroup_concatArray({
+      [1] = 174
+    })(Data_Semigroup_concatArray({ [1] = 175 })(Data_Semigroup_concatArray({
+      [1] = 176
+    })(Data_Semigroup_concatArray({ [1] = 177 })(Data_Semigroup_concatArray({
+      [1] = 178
+    })(Data_Semigroup_concatArray({ [1] = 179 })(Data_Semigroup_concatArray({
+      [1] = 180
+    })(Data_Semigroup_concatArray({ [1] = 181 })(Data_Semigroup_concatArray({
+      [1] = 182
+    })(Data_Semigroup_concatArray({ [1] = 183 })(Data_Semigroup_concatArray({
+      [1] = 184
+    })(Data_Semigroup_concatArray({ [1] = 185 })(Data_Semigroup_concatArray({
+      [1] = 186
+    })(Data_Semigroup_concatArray({ [1] = 187 })(Data_Semigroup_concatArray({
+      [1] = 188
+    })(Data_Semigroup_concatArray({ [1] = 189 })(Data_Semigroup_concatArray({
+      [1] = 190
+    })(Data_Semigroup_concatArray({ [1] = 191 })(Data_Semigroup_concatArray({
+      [1] = 192
+    })(Data_Semigroup_concatArray({ [1] = 193 })(Data_Semigroup_concatArray({
+      [1] = 194
+    })(Data_Semigroup_concatArray({ [1] = 195 })(Data_Semigroup_concatArray({
+      [1] = 196
+    })(Data_Semigroup_concatArray({ [1] = 197 })(Data_Semigroup_concatArray({
+      [1] = 198
+    })(Data_Semigroup_concatArray({ [1] = 199 })(Data_Semigroup_concatArray({
+      [1] = 200
+    })({})))))))))))))))))))))))))))))))))))))))
+    local _S_tmp1 = Data_Semigroup_concatArray({
       [1] = 122
-    }), function()
-      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-        [1] = 123
-      }), function()
-        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-          [1] = 124
-        }), function()
-          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-            [1] = 125
-          }), function()
-            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-              [1] = 126
-            }), function()
-              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                [1] = 127
-              }), function()
-                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                  [1] = 128
-                }), function()
-                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                    [1] = 129
-                  }), function()
-                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                      [1] = 130
-                    }), function()
-                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                        [1] = 131
-                      }), function()
-                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                          [1] = 132
-                        }), function()
-                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                            [1] = 133
-                          }), function()
-                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                              [1] = 134
-                            }), function()
-                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                [1] = 135
-                              }), function()
-                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                  [1] = 136
-                                }), function()
-                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                    [1] = 137
-                                  }), function()
-                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                      [1] = 138
-                                    }), function()
-                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                        [1] = 139
-                                      }), function()
-                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                          [1] = 140
-                                        }), function()
-                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                            [1] = 141
-                                          }), function()
-                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                              [1] = 142
-                                            }), function()
-                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                [1] = 143
-                                              }), function()
-                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                  [1] = 144
-                                                }), function()
-                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                    [1] = 145
-                                                  }), function()
-                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                      [1] = 146
-                                                    }), function()
-                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                        [1] = 147
-                                                      }), function()
-                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                          [1] = 148
-                                                        }), function()
-                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                            [1] = 149
-                                                          }), function()
-                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                              [1] = 150
-                                                            }), function()
-                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                [1] = 151
-                                                              }), function()
-                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                  [1] = 152
-                                                                }), function()
-                                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                    [1] = 153
-                                                                  }), function()
-                                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                      [1] = 154
-                                                                    }), function(  )
-                                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                        [1] = 155
-                                                                      }), function(  )
-                                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                          [1] = 156
-                                                                        }), function(  )
-                                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                            [1] = 157
-                                                                          }), function(  )
-                                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                              [1] = 158
-                                                                            }), function(  )
-                                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                [1] = 159
-                                                                              }), function(  )
-                                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                  [1] = 160
-                                                                                }), function(  )
-                                                                                  return _S_kont0
-                                                                                end)
-                                                                              end)
-                                                                            end)
-                                                                          end)
-                                                                        end)
-                                                                      end)
-                                                                    end)
-                                                                  end)
-                                                                end)
-                                                              end)
-                                                            end)
-                                                          end)
-                                                        end)
-                                                      end)
-                                                    end)
-                                                  end)
-                                                end)
-                                              end)
-                                            end)
-                                          end)
-                                        end)
-                                      end)
-                                    end)
-                                  end)
-                                end)
-                              end)
-                            end)
-                          end)
-                        end)
-                      end)
-                    end)
-                  end)
-                end)
-              end)
-            end)
-          end)
-        end)
-      end)
-    end)
-  end)
-  local _S_kont2 = Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-    [1] = 81
-  }), function()
-    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
+    })(Data_Semigroup_concatArray({ [1] = 123 })(Data_Semigroup_concatArray({
+      [1] = 124
+    })(Data_Semigroup_concatArray({ [1] = 125 })(Data_Semigroup_concatArray({
+      [1] = 126
+    })(Data_Semigroup_concatArray({ [1] = 127 })(Data_Semigroup_concatArray({
+      [1] = 128
+    })(Data_Semigroup_concatArray({ [1] = 129 })(Data_Semigroup_concatArray({
+      [1] = 130
+    })(Data_Semigroup_concatArray({ [1] = 131 })(Data_Semigroup_concatArray({
+      [1] = 132
+    })(Data_Semigroup_concatArray({ [1] = 133 })(Data_Semigroup_concatArray({
+      [1] = 134
+    })(Data_Semigroup_concatArray({ [1] = 135 })(Data_Semigroup_concatArray({
+      [1] = 136
+    })(Data_Semigroup_concatArray({ [1] = 137 })(Data_Semigroup_concatArray({
+      [1] = 138
+    })(Data_Semigroup_concatArray({ [1] = 139 })(Data_Semigroup_concatArray({
+      [1] = 140
+    })(Data_Semigroup_concatArray({ [1] = 141 })(Data_Semigroup_concatArray({
+      [1] = 142
+    })(Data_Semigroup_concatArray({ [1] = 143 })(Data_Semigroup_concatArray({
+      [1] = 144
+    })(Data_Semigroup_concatArray({ [1] = 145 })(Data_Semigroup_concatArray({
+      [1] = 146
+    })(Data_Semigroup_concatArray({ [1] = 147 })(Data_Semigroup_concatArray({
+      [1] = 148
+    })(Data_Semigroup_concatArray({ [1] = 149 })(Data_Semigroup_concatArray({
+      [1] = 150
+    })(Data_Semigroup_concatArray({ [1] = 151 })(Data_Semigroup_concatArray({
+      [1] = 152
+    })(Data_Semigroup_concatArray({ [1] = 153 })(Data_Semigroup_concatArray({
+      [1] = 154
+    })(Data_Semigroup_concatArray({ [1] = 155 })(Data_Semigroup_concatArray({
+      [1] = 156
+    })(Data_Semigroup_concatArray({ [1] = 157 })(Data_Semigroup_concatArray({
+      [1] = 158
+    })(Data_Semigroup_concatArray({ [1] = 159 })(Data_Semigroup_concatArray({
+      [1] = 160
+    })(Data_Semigroup_concatArray({
+      [1] = 161
+    })(_S_tmp0))))))))))))))))))))))))))))))))))))))))
+    local _S_tmp2 = Data_Semigroup_concatArray({
       [1] = 82
-    }), function()
-      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-        [1] = 83
-      }), function()
-        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-          [1] = 84
-        }), function()
-          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-            [1] = 85
-          }), function()
-            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-              [1] = 86
-            }), function()
-              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                [1] = 87
-              }), function()
-                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                  [1] = 88
-                }), function()
-                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                    [1] = 89
-                  }), function()
-                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                      [1] = 90
-                    }), function()
-                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                        [1] = 91
-                      }), function()
-                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                          [1] = 92
-                        }), function()
-                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                            [1] = 93
-                          }), function()
-                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                              [1] = 94
-                            }), function()
-                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                [1] = 95
-                              }), function()
-                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                  [1] = 96
-                                }), function()
-                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                    [1] = 97
-                                  }), function()
-                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                      [1] = 98
-                                    }), function()
-                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                        [1] = 99
-                                      }), function()
-                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                          [1] = 100
-                                        }), function()
-                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                            [1] = 101
-                                          }), function()
-                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                              [1] = 102
-                                            }), function()
-                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                [1] = 103
-                                              }), function()
-                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                  [1] = 104
-                                                }), function()
-                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                    [1] = 105
-                                                  }), function()
-                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                      [1] = 106
-                                                    }), function()
-                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                        [1] = 107
-                                                      }), function()
-                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                          [1] = 108
-                                                        }), function()
-                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                            [1] = 109
-                                                          }), function()
-                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                              [1] = 110
-                                                            }), function()
-                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                [1] = 111
-                                                              }), function()
-                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                  [1] = 112
-                                                                }), function()
-                                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                    [1] = 113
-                                                                  }), function()
-                                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                      [1] = 114
-                                                                    }), function(  )
-                                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                        [1] = 115
-                                                                      }), function(  )
-                                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                          [1] = 116
-                                                                        }), function(  )
-                                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                            [1] = 117
-                                                                          }), function(  )
-                                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                              [1] = 118
-                                                                            }), function(  )
-                                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                [1] = 119
-                                                                              }), function(  )
-                                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                  [1] = 120
-                                                                                }), function(  )
-                                                                                  return _S_kont1
-                                                                                end)
-                                                                              end)
-                                                                            end)
-                                                                          end)
-                                                                        end)
-                                                                      end)
-                                                                    end)
-                                                                  end)
-                                                                end)
-                                                              end)
-                                                            end)
-                                                          end)
-                                                        end)
-                                                      end)
-                                                    end)
-                                                  end)
-                                                end)
-                                              end)
-                                            end)
-                                          end)
-                                        end)
-                                      end)
-                                    end)
-                                  end)
-                                end)
-                              end)
-                            end)
-                          end)
-                        end)
-                      end)
-                    end)
-                  end)
-                end)
-              end)
-            end)
-          end)
-        end)
-      end)
-    end)
-  end)
-  local _S_kont3 = Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-    [1] = 41
-  }), function()
-    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
+    })(Data_Semigroup_concatArray({ [1] = 83 })(Data_Semigroup_concatArray({
+      [1] = 84
+    })(Data_Semigroup_concatArray({ [1] = 85 })(Data_Semigroup_concatArray({
+      [1] = 86
+    })(Data_Semigroup_concatArray({ [1] = 87 })(Data_Semigroup_concatArray({
+      [1] = 88
+    })(Data_Semigroup_concatArray({ [1] = 89 })(Data_Semigroup_concatArray({
+      [1] = 90
+    })(Data_Semigroup_concatArray({ [1] = 91 })(Data_Semigroup_concatArray({
+      [1] = 92
+    })(Data_Semigroup_concatArray({ [1] = 93 })(Data_Semigroup_concatArray({
+      [1] = 94
+    })(Data_Semigroup_concatArray({ [1] = 95 })(Data_Semigroup_concatArray({
+      [1] = 96
+    })(Data_Semigroup_concatArray({ [1] = 97 })(Data_Semigroup_concatArray({
+      [1] = 98
+    })(Data_Semigroup_concatArray({ [1] = 99 })(Data_Semigroup_concatArray({
+      [1] = 100
+    })(Data_Semigroup_concatArray({ [1] = 101 })(Data_Semigroup_concatArray({
+      [1] = 102
+    })(Data_Semigroup_concatArray({ [1] = 103 })(Data_Semigroup_concatArray({
+      [1] = 104
+    })(Data_Semigroup_concatArray({ [1] = 105 })(Data_Semigroup_concatArray({
+      [1] = 106
+    })(Data_Semigroup_concatArray({ [1] = 107 })(Data_Semigroup_concatArray({
+      [1] = 108
+    })(Data_Semigroup_concatArray({ [1] = 109 })(Data_Semigroup_concatArray({
+      [1] = 110
+    })(Data_Semigroup_concatArray({ [1] = 111 })(Data_Semigroup_concatArray({
+      [1] = 112
+    })(Data_Semigroup_concatArray({ [1] = 113 })(Data_Semigroup_concatArray({
+      [1] = 114
+    })(Data_Semigroup_concatArray({ [1] = 115 })(Data_Semigroup_concatArray({
+      [1] = 116
+    })(Data_Semigroup_concatArray({ [1] = 117 })(Data_Semigroup_concatArray({
+      [1] = 118
+    })(Data_Semigroup_concatArray({ [1] = 119 })(Data_Semigroup_concatArray({
+      [1] = 120
+    })(Data_Semigroup_concatArray({
+      [1] = 121
+    })(_S_tmp1))))))))))))))))))))))))))))))))))))))))
+    local _S_tmp3 = Data_Semigroup_concatArray({
       [1] = 42
-    }), function()
-      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-        [1] = 43
-      }), function()
-        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-          [1] = 44
-        }), function()
-          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-            [1] = 45
-          }), function()
-            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-              [1] = 46
-            }), function()
-              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                [1] = 47
-              }), function()
-                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                  [1] = 48
-                }), function()
-                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                    [1] = 49
-                  }), function()
-                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                      [1] = 50
-                    }), function()
-                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                        [1] = 51
-                      }), function()
-                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                          [1] = 52
-                        }), function()
-                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                            [1] = 53
-                          }), function()
-                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                              [1] = 54
-                            }), function()
-                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                [1] = 55
-                              }), function()
-                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                  [1] = 56
-                                }), function()
-                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                    [1] = 57
-                                  }), function()
-                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                      [1] = 58
-                                    }), function()
-                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                        [1] = 59
-                                      }), function()
-                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                          [1] = 60
-                                        }), function()
-                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                            [1] = 61
-                                          }), function()
-                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                              [1] = 62
-                                            }), function()
-                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                [1] = 63
-                                              }), function()
-                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                  [1] = 64
-                                                }), function()
-                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                    [1] = 65
-                                                  }), function()
-                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                      [1] = 66
-                                                    }), function()
-                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                        [1] = 67
-                                                      }), function()
-                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                          [1] = 68
-                                                        }), function()
-                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                            [1] = 69
-                                                          }), function()
-                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                              [1] = 70
-                                                            }), function()
-                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                [1] = 71
-                                                              }), function()
-                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                  [1] = 72
-                                                                }), function()
-                                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                    [1] = 73
-                                                                  }), function()
-                                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                      [1] = 74
-                                                                    }), function(  )
-                                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                        [1] = 75
-                                                                      }), function(  )
-                                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                          [1] = 76
-                                                                        }), function(  )
-                                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                            [1] = 77
-                                                                          }), function(  )
-                                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                              [1] = 78
-                                                                            }), function(  )
-                                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                [1] = 79
-                                                                              }), function(  )
-                                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                  [1] = 80
-                                                                                }), function(  )
-                                                                                  return _S_kont2
-                                                                                end)
-                                                                              end)
-                                                                            end)
-                                                                          end)
-                                                                        end)
-                                                                      end)
-                                                                    end)
-                                                                  end)
-                                                                end)
-                                                              end)
-                                                            end)
-                                                          end)
-                                                        end)
-                                                      end)
-                                                    end)
-                                                  end)
-                                                end)
-                                              end)
-                                            end)
-                                          end)
-                                        end)
-                                      end)
-                                    end)
-                                  end)
-                                end)
-                              end)
-                            end)
-                          end)
-                        end)
-                      end)
-                    end)
-                  end)
-                end)
-              end)
-            end)
-          end)
-        end)
-      end)
-    end)
-  end)
-  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-    [1] = 1
-  }), function()
-    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
+    })(Data_Semigroup_concatArray({ [1] = 43 })(Data_Semigroup_concatArray({
+      [1] = 44
+    })(Data_Semigroup_concatArray({ [1] = 45 })(Data_Semigroup_concatArray({
+      [1] = 46
+    })(Data_Semigroup_concatArray({ [1] = 47 })(Data_Semigroup_concatArray({
+      [1] = 48
+    })(Data_Semigroup_concatArray({ [1] = 49 })(Data_Semigroup_concatArray({
+      [1] = 50
+    })(Data_Semigroup_concatArray({ [1] = 51 })(Data_Semigroup_concatArray({
+      [1] = 52
+    })(Data_Semigroup_concatArray({ [1] = 53 })(Data_Semigroup_concatArray({
+      [1] = 54
+    })(Data_Semigroup_concatArray({ [1] = 55 })(Data_Semigroup_concatArray({
+      [1] = 56
+    })(Data_Semigroup_concatArray({ [1] = 57 })(Data_Semigroup_concatArray({
+      [1] = 58
+    })(Data_Semigroup_concatArray({ [1] = 59 })(Data_Semigroup_concatArray({
+      [1] = 60
+    })(Data_Semigroup_concatArray({ [1] = 61 })(Data_Semigroup_concatArray({
+      [1] = 62
+    })(Data_Semigroup_concatArray({ [1] = 63 })(Data_Semigroup_concatArray({
+      [1] = 64
+    })(Data_Semigroup_concatArray({ [1] = 65 })(Data_Semigroup_concatArray({
+      [1] = 66
+    })(Data_Semigroup_concatArray({ [1] = 67 })(Data_Semigroup_concatArray({
+      [1] = 68
+    })(Data_Semigroup_concatArray({ [1] = 69 })(Data_Semigroup_concatArray({
+      [1] = 70
+    })(Data_Semigroup_concatArray({ [1] = 71 })(Data_Semigroup_concatArray({
+      [1] = 72
+    })(Data_Semigroup_concatArray({ [1] = 73 })(Data_Semigroup_concatArray({
+      [1] = 74
+    })(Data_Semigroup_concatArray({ [1] = 75 })(Data_Semigroup_concatArray({
+      [1] = 76
+    })(Data_Semigroup_concatArray({ [1] = 77 })(Data_Semigroup_concatArray({
+      [1] = 78
+    })(Data_Semigroup_concatArray({ [1] = 79 })(Data_Semigroup_concatArray({
+      [1] = 80
+    })(Data_Semigroup_concatArray({
+      [1] = 81
+    })(_S_tmp2))))))))))))))))))))))))))))))))))))))))
+    local _S_tmp4 = Data_Semigroup_concatArray({
       [1] = 2
-    }), function()
-      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-        [1] = 3
-      }), function()
-        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-          [1] = 4
-        }), function()
-          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-            [1] = 5
-          }), function()
-            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-              [1] = 6
-            }), function()
-              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                [1] = 7
-              }), function()
-                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                  [1] = 8
-                }), function()
-                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                    [1] = 9
-                  }), function()
-                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                      [1] = 10
-                    }), function()
-                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                        [1] = 11
-                      }), function()
-                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                          [1] = 12
-                        }), function()
-                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                            [1] = 13
-                          }), function()
-                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                              [1] = 14
-                            }), function()
-                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                [1] = 15
-                              }), function()
-                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                  [1] = 16
-                                }), function()
-                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                    [1] = 17
-                                  }), function()
-                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                      [1] = 18
-                                    }), function()
-                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                        [1] = 19
-                                      }), function()
-                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                          [1] = 20
-                                        }), function()
-                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                            [1] = 21
-                                          }), function()
-                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                              [1] = 22
-                                            }), function()
-                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                [1] = 23
-                                              }), function()
-                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                  [1] = 24
-                                                }), function()
-                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                    [1] = 25
-                                                  }), function()
-                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                      [1] = 26
-                                                    }), function()
-                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                        [1] = 27
-                                                      }), function()
-                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                          [1] = 28
-                                                        }), function()
-                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                            [1] = 29
-                                                          }), function()
-                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                              [1] = 30
-                                                            }), function()
-                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                [1] = 31
-                                                              }), function()
-                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                  [1] = 32
-                                                                }), function()
-                                                                  return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                    [1] = 33
-                                                                  }), function()
-                                                                    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                      [1] = 34
-                                                                    }), function(  )
-                                                                      return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                        [1] = 35
-                                                                      }), function(  )
-                                                                        return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                          [1] = 36
-                                                                        }), function(  )
-                                                                          return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                            [1] = 37
-                                                                          }), function(  )
-                                                                            return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                              [1] = 38
-                                                                            }), function(  )
-                                                                              return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                [1] = 39
-                                                                              }), function(  )
-                                                                                return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
-                                                                                  [1] = 40
-                                                                                }), function(  )
-                                                                                  return _S_kont3
-                                                                                end)
-                                                                              end)
-                                                                            end)
-                                                                          end)
-                                                                        end)
-                                                                      end)
-                                                                    end)
-                                                                  end)
-                                                                end)
-                                                              end)
-                                                            end)
-                                                          end)
-                                                        end)
-                                                      end)
-                                                    end)
-                                                  end)
-                                                end)
-                                              end)
-                                            end)
-                                          end)
-                                        end)
-                                      end)
-                                    end)
-                                  end)
-                                end)
-                              end)
-                            end)
-                          end)
-                        end)
-                      end)
-                    end)
-                  end)
-                end)
-              end)
-            end)
-          end)
-        end)
-      end)
-    end)
-  end)
-end)()
+    })(Data_Semigroup_concatArray({ [1] = 3 })(Data_Semigroup_concatArray({
+      [1] = 4
+    })(Data_Semigroup_concatArray({ [1] = 5 })(Data_Semigroup_concatArray({
+      [1] = 6
+    })(Data_Semigroup_concatArray({ [1] = 7 })(Data_Semigroup_concatArray({
+      [1] = 8
+    })(Data_Semigroup_concatArray({ [1] = 9 })(Data_Semigroup_concatArray({
+      [1] = 10
+    })(Data_Semigroup_concatArray({ [1] = 11 })(Data_Semigroup_concatArray({
+      [1] = 12
+    })(Data_Semigroup_concatArray({ [1] = 13 })(Data_Semigroup_concatArray({
+      [1] = 14
+    })(Data_Semigroup_concatArray({ [1] = 15 })(Data_Semigroup_concatArray({
+      [1] = 16
+    })(Data_Semigroup_concatArray({ [1] = 17 })(Data_Semigroup_concatArray({
+      [1] = 18
+    })(Data_Semigroup_concatArray({ [1] = 19 })(Data_Semigroup_concatArray({
+      [1] = 20
+    })(Data_Semigroup_concatArray({ [1] = 21 })(Data_Semigroup_concatArray({
+      [1] = 22
+    })(Data_Semigroup_concatArray({ [1] = 23 })(Data_Semigroup_concatArray({
+      [1] = 24
+    })(Data_Semigroup_concatArray({ [1] = 25 })(Data_Semigroup_concatArray({
+      [1] = 26
+    })(Data_Semigroup_concatArray({ [1] = 27 })(Data_Semigroup_concatArray({
+      [1] = 28
+    })(Data_Semigroup_concatArray({ [1] = 29 })(Data_Semigroup_concatArray({
+      [1] = 30
+    })(Data_Semigroup_concatArray({ [1] = 31 })(Data_Semigroup_concatArray({
+      [1] = 32
+    })(Data_Semigroup_concatArray({ [1] = 33 })(Data_Semigroup_concatArray({
+      [1] = 34
+    })(Data_Semigroup_concatArray({ [1] = 35 })(Data_Semigroup_concatArray({
+      [1] = 36
+    })(Data_Semigroup_concatArray({ [1] = 37 })(Data_Semigroup_concatArray({
+      [1] = 38
+    })(Data_Semigroup_concatArray({ [1] = 39 })(Data_Semigroup_concatArray({
+      [1] = 40
+    })(Data_Semigroup_concatArray({
+      [1] = 41
+    })(_S_tmp3))))))))))))))))))))))))))))))))))))))))
+    return Data_Semigroup_concatArray({ [1] = 1 })(_S_tmp4)
+  end)())
+}
 local Golden_LongWriterBind_Test_compute = Golden_LongWriterBind_Test_go[1]
 return (function(s) return function() print(s) end end)((function(n)
   return tostring(n)


### PR DESCRIPTION
Closes #328.

## The problem

The IR optimizer runs several of its passes as *fixpoints*: a group of passes is applied to the whole linked module over and over until a round changes nothing. One of them, `specialize+dce`, is where a monadic bind chain collapses — call-site inlining pastes the `bind` method bodies in, and the case-of-known-constructor folds then reduce the resulting matches to straight-line code.

That fixpoint took **301 rounds** on `Golden.LongBindFlipped`, a ~300-deep chain of `=<<` over `Maybe`, and 3–4 rounds on everything else in the corpus. One round per layer, measured by tracing the round count of every fixpoint in the pipeline:

```
("ROUNDS","optimize+dce",4)
("ROUNDS","optimize+dce-post-merge",2)
("ROUNDS","optimize+dce-post-uncurry",2)
("ROUNDS","specialize+dce",301)          <-- ~300-deep chain, ~300 rounds
("ROUNDS","specialize+dce-post-cpr",1)
```

Each round is a sweep of the whole module, so compile time was O(depth × module size). #327 raised the fixpoint's iteration backstop (`maxFixpointIterations`, the cap that stops a genuinely looping pass from spinning forever) from 100 to 1000 to keep the invariant-checking test runner from reporting these legitimate rounds as divergence — which also meant a real loop bug had to burn 1000 whole-module sweeps before being reported.

## Why one layer per round

Not the growth veto and not the nested-rewrite bound — instrumenting both showed no sweep was ever vetoed, and the chain shrank by ~10 nodes per round, exactly one layer. Dumping the expression before and after one sweep of round 2 shows what actually blocks:

```
BEFORE (innermost layer)                    AFTER (same sweep)
  Let (a$4504 = Just 2)                       Let ($field4527 = 2)
    (if justTag == reflectCtor a$4504            (Just 3)
       then Just (arg0 a$4504 + 1)
       else Nothing)
```

The fold worked — the match collapsed, the payload was inlined, `2 + 1` folded to `3`. But it left `$field4527` behind: `propagateKnownCtorThroughLet`, the rule that pushes a known constructor into a let-bound scrutinee's reads, binds each read field to a fresh `$field` binder (so an argument read at several sites is evaluated once, not copied). When the reads then fold away, that binder is unreferenced — and nothing in the rewrite rule set dropped an unreferenced `Let` binding. Only the separate `dce` pass did, one pass later in the round. That matches the per-pass trace: `specialize` and `dce` each reported `Rewritten` on 300 consecutive rounds, then both went quiet.

While the residue stands, the enclosing layer's right-hand side is a `Let` rather than the `Just 3` it wraps, so `propagateKnownCtorThroughLet` declines there — it needs a saturated constructor. The chain advances one layer, `dce` clears the residue, and the next round advances one more.

## The change

Dropping an unread binding becomes a rewrite as well, so a cascade completes inside the sweep that starts it:

```haskell
removeUnusedLetBindings ∷ Applicative m ⇒ RewriteRuleM m Ann
removeUnusedLetBindings =
  pure . \case
    Let ann groupings body
      | let kept = snd (foldr keep (countFreeRefs body, []) groupings)
      , length kept < length groupings →
          Just case nonEmpty kept of
            Nothing → body
            Just keptNE → Let ann keptNE body
    _ → Nothing
```

The licence to discard an unread binding's right-hand side is the one `eliminateDeadCode` already takes: an effect run stays (dropping it would silently discard the effect), anything else is evaluated for a value nothing wants.

```haskell
  keep grouping (refs, kept) = case grouping of
    Standalone (_ann, name, rhs)
      | Local name `Map.notMember` refs
      , not (isEffectRun rhs) →
          (refs, kept)
    _ → (…refs plus this grouping's own references…, grouping : kept)
```

Bindings are decided right to left and only a *kept* grouping contributes its references, so a binding kept alive solely by a binding that is itself dropped goes with it. The direction matters because a `Let`'s bindings scope sequentially — a binder is in scope for the groupings after it and the body, never the ones before (`Note [Sequential scoping of Let bindings]`). Recursive groups are left to `dce`, which sees a dead group as a whole through module-level reachability.

`maxFixpointIterations` returns to **100**. With convergence no longer depth-scaled the bound can sit close to real work, so a pass that over-reports changes is caught in 100 sweeps instead of 1000.

## Verification

**Round count, measured the same way as above.** The three ~300-deep stress modules now converge in the same number of rounds as a three-deep chain, and the deepest fixpoint anywhere in the 348-example golden corpus takes 4:

| module | chain depth | `optimize+dce` | `specialize+dce` |
|---|---|---|---|
| `Golden.MaybeChain` | ~3 | 3 | 2 |
| `Golden.LongBindFlipped` | ~300 | 3 | 2 (was 301) |
| `Golden.LongApplyChain` | ~300 | 3 | 2 |
| `Golden.LongWriterBind` | ~200 | 4 | 3 |

The new cap is itself the regression guard: the stress goldens are ~300 layers deep, so any return to per-layer folding exceeds 100 rounds and the checked runner used by the test suite fails with `FixpointDivergence` rather than merely getting slower.

**Compile time**, best of three runs each, `spec --match <module>`:

| | before | after |
|---|---|---|
| `Golden.LongApplyChain` | 42.6s | 1.2s |
| `Golden.LongBindFlipped` | 8.2s | 1.2s |
| whole golden suite (348 examples) | 81.9s | 30.2s |

**Unit-level pin** (red before the fix, in its own commit). Eight layers nested one in another must fold to their final constant in a single `optimizedExpression` sweep. Verbatim failure without the fix — one layer folded, the other seven untouched:

```
expected: Ctor … (CtorName "Just") [LiteralInt Nothing 8]
 but got: Let (v1, Let (v2, … Let (v7,
            Let ($field0 = LiteralInt Nothing 0) (Just [LiteralInt Nothing 1]))
            (if justTag == reflectCtor v7 then Just [arg0 v7 + 1] else Nothing)) …)
```

**Goldens.** 346 of 348 byte-identical. `Golden.LongWriterBind` moves, in the direction the collapse intends: its 200-deep `Writer` chain used to compile to a nest of closures over `tell`/`discard` plus the `Data.Identity` dictionary tables, and now compiles to straight-line code — 847 lines of Lua down to 234:

```lua
-- before
local Data_Identity_applyIdentity = { apply = …, Functor0 = … }
local Data_Identity_applicativeIdentity = { pure = …, Apply0 = … }
local Golden_LongWriterBind_Test_tell = function(x_S_1) return { Data_Unit_unit, x_S_1 } end
local Golden_LongWriterBind_Test_go = (function()
  local _S_kont0 = Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
    [1] = 161
  }), function()
    return Golden_LongWriterBind_Test_discard_S_w(Golden_LongWriterBind_Test_tell({
    -- … 200 nested closures …

-- after
local Golden_LongWriterBind_Test_go = {
  42,
  ((function()
    local _S_tmp0 = Data_Semigroup_concatArray({ [1] = 162 })(…)
    -- … flat concatArray spine in A-normalised locals …
```

The accumulated result is now the literal `42`, computed at compile time. The module's `eval/golden.txt` oracle (`42`) is unchanged, so the collapse is semantics-preserving where execution checks it.

Four existing expectations in the optimizer spec moved with the rule. Each asserted the pre-`dce` residue — `let1 name inlinee inlinee` where the paste had just consumed the body's only reference — and now expects the bare `inlinee`. They still pin the paste: a result that kept the `Let` would mean the inlining never happened. One of them becomes identical to its beta-reduced sibling two tests down, which previously already expected the bare `literalInt 5`.

`cabal test all` is green (1247 examples). The optimizer's Hedgehog groups were re-run under 14 fresh seeds, all clean with no hangs. A forced full recompile of the library and test suite emits no warnings; `hlint` reports no hints.

## Sibling audit

The shape here is "a rewrite leaves residue only a later pass clears, so a cascade stalls at one layer per round". Searched the rest of the rule set for the same shape:

- **`LetValues`** (the multi-value binding CPR introduces) has the same asymmetry: `eliminateDeadCode` collapses one whose every binder is dead, and no rule in the sweep does. No instance shows up in the corpus — the `specialize+dce-post-cpr` fixpoint peaks at 2 rounds across all 348 goldens — and this PR's rule deliberately does not cover it, since the red would have to be a shape I invent rather than one the corpus produces. Recorded as a follow-up rather than fixed blind.
- **Dead parameter blanking** (`blankDeadSuffix`, also DCE-only) does not gate any fold: the rules match on node structure, not on binder names.
- **Top-level binding elimination** is per-round by construction, but `withBinding` folds all bindings in one pass, substituting into later ones, so a chain of top-level bindings does not need a round each. No depth scaling observed.
